### PR TITLE
Add SEP defining transactions required

### DIFF
--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -285,20 +285,39 @@ declaration transaction and closing the channel at the actual final state.
 4. Wait observation period O
 5. Submit C_i
 
-#### Mutating the Channel
+#### Changing the Channel Setup
 
 The payment channel setup can be altered with on-chain transactions after
-channel setup. The following operations can take place. Each operation is
-implemented in a two-step process where participants first agree on a new state
-at a future iteration that is not yet executable, then participants sign a
-transaction to make that new state possible.
+channel setup. Some of the operations used to alter the channel setup may fail
+even if the transactions are valid, while others will always succeed if the
+transactions are valid.
+
+Each operation is implemented in a two-step process. Participants agree on a new
+closing state at a future iteration by signing C_i and D_i transactions where i
+has skipped an iteration that is not yet executable because the D_i's
+`minSeqNum` is also set in the future. Participants then sign a transaction to
+make the change that only moves the sequence of escrow account E to satisfy the
+`minSeqNum` of the future D_i.
+
+Operations that can fail have the following requirements as well:
+
+- The transaction that can fail must have its source account set to an account
+that is not escrow account E.
+- The transaction that can fail must contain a `BUMP_SEQUENCE` operation that
+bumps escrow account E's sequence number to a sequence number that makes the D_i
+executable.
+
+Operations that cannot fail:
+
+- [Change the Observation Period](#Change-the-Observation-Period)
+
+Operations that can fail:
 
 - [Add Trustline](#Add-Trustline)
 - [Remove Trustline](#Remove-Trustline)
 - [Deposit by Initiator](#Deposit-by-Initiator)
 - [Deposit by Responder](#Deposit-by-Responder)
 - [Withdraw](#Withdraw)
-- [Change the Observation Period](#Change-the-Observation-Period)
 
 ##### Add Trustline
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -395,8 +395,7 @@ This step yields transactions D_i' and C_i' where i' = i+1.
 increment i, to build, sign, and exchange declaration and closing transactions
 that define how the assets held by the escrow account will be disbursed at close
 of the channel such that the deposited amount included in P_i will be disbursed
-   to participant R. This step yields transactions D_i'' and C_i'' where i'' =
-   i+2. **D_i''**'s maxSeqNo is additionally set to i.
+to participant R. This step yields transactions D_i'' and C_i'' where i'' = i+2.
 4. I and R sign and exchange signatures for deposit transaction P_i.
 5. I or R submit P_i.
 6. Wait for E's sequence number to be P_i's.

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -1,0 +1,66 @@
+## Preamble
+
+```
+SEP: ????
+Title: Payment Channel
+Author: Leigh McCulloch <@leighmcculloch>
+Track: Standard
+Status: Draft
+Discussion: https://github.com/stellar/experimental-payment-channels/issues
+Created: 2021-04-21
+Updated: 2021-04-21
+Version: 0.0.1
+```
+
+## Summary
+
+This protocol defines the transactions that two participants use to open,
+mutate, and close a payment channel.
+
+## Dependencies
+
+This protocol is dependent on [CAP-21] and is built on the example two-way
+payment channel protocol defined in that CAP's rationale.
+
+This protocol is also dependent on [CAP-23] providing claimable balances and
+[CAP-33] providing sponsorship.
+
+## Motivation
+
+Stellar account holders who frequently interact with a set of partners must
+choose between performing every transaction on-chain, or trusting each other
+to some degree and performing net-settlement. Transactions on-chain are fast
+and affordable but it would be beneficial to some operators if speed and cost
+were not bounded and only limited by the partners own capability to agree.
+
+## Abstract
+
+This protocol defines...
+
+## Use Cases
+
+
+## Specification
+
+TODO
+
+## Security Concerns
+
+TODO
+
+## Limitations
+
+This protocol defines the mechanisms of the Stellar network's core protocol
+that are used to enforce agreements made by two participants. This protocol
+does not define the transport through which the agreements are coordinated,
+or the methods through which more than two participants can coordinate and
+exchange dependent agreements. These issues are likely to be discussed in a
+separate proposal.
+
+## Implementations
+
+TODO
+
+[CAP-21]: https://stellar.org/protocol/cap-21
+[CAP-23]: https://stellar.org/protocol/cap-23
+[CAP-33]: https://stellar.org/protocol/cap-33

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -8,8 +8,8 @@ Track: Standard
 Status: Draft
 Discussion: https://github.com/stellar/experimental-payment-channels/issues
 Created: 2021-04-21
-Updated: 2021-04-21
-Version: 0.0.1
+Updated: 2021-05-05
+Version: 0.1.0
 ```
 
 ## Summary

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -243,26 +243,47 @@ then submitting the closing transaction.
 #### Contesting an Uncooperative Close
 
 Either participant can attempt to close the channel at an earlier state that
-benefits them using the uncooperative close process.  The other participant
-can identify that the close process has started at an earlier state by
-monitoring changes in the accounts sequence.  If the other participant sees
-the sequence number of escrow account E change to a value that is not the
-most recent consumed s_i, they can use the following process to contest the
-close.  A participant contests a close by submitting a more recent
-declaration transaction.
+benefits them, by using the uncooperative close process.  The other
+participant can identify that the close process has started at an earlier
+state by monitoring changes in the accounts sequence.  If the other
+participant sees the sequence number of escrow account E change to a value
+that is not the most recently used s_i, they can use the following process to
+contest the close.  A participant contests a close by submitting a more
+recent declaration transaction and closing the channel.
 
 1. Monitor if E's sequence number changes to a value that is not s_i
 2. Submit most recent D_i
 3. Wait observation period O
 4. Submit C_i
 
-#### Top-up by Initiator
+#### Add or Remove Trustlines
 
-TODO: 
+TODO:
 
-#### Top-up by Responder
+1. Set s to 
 
-TODO: 
+#### Deposit by Initiator
+
+Participant I may deposit into the channel without coordination with
+participant R, as long as escrow account E already has a trustline for the
+asset being deposited.
+
+If participant I wishes to deposit an asset that escrow account E does not
+hold a trustline for, the [Add or Remove
+Trustlines](#Add-or-Remove-Trustlines) process must be used first.
+
+#### Deposit by Responder
+
+Participant R may deposit into the channel without coordination with
+participant R, as long as escrow account E already has a trustline for the
+asset being deposited, and as long as participants R's intent is to make a
+payment of the same value to participant I.  Any amounts deposited to the
+payment channel without coordination will be disbursable to participant I.
+
+Participant R must coordinate with participant I to deposit any amount that
+it does not intend to pay participant I. The participants use the following process:
+
+1. TODO: 
 
 #### Withdraw Without Close
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -313,6 +313,20 @@ Participant R provides reserves for:
 - Signers added to V for R
 - Claimable balances created at close
 
+The total reserves required for each participant are:
+
+- Participant I
+
+  - 1 (Escrow Account E)
+  - \+ Number of Assets (for Trustlines)
+  - \+ 2 x Number of I's Signers
+
+- Participant R
+
+  - 1 (Reserve Account V)
+  - \+ Number of Assets (for Claimable Balances)
+  - \+ 2 x Number of R's Signers
+
 In the rare event that a network upgrade results in base reserve increasing,
 but participant R does not increase the funds in reserve account V to
 sufficiently cover the reserve cost, participant I may choose to deposit the

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -556,6 +556,14 @@ sequence number s_i.
   transactions, it contains a `BUMP_SEQUENCE` operation with sequence value 0 as
   a no-op.
 
+#### Reusing a Channel
+
+After close, escrow account E and reserve account V can be reused for another
+channel with the same or different participants. The relevant account creation
+steps during [Setup](#Setup) are skipped. All variable values from the closed
+channel are discarded and set anew with iteration number i and executed
+iteration number e being set to zero.
+
 ### Network Transaction Fees
 
 All transaction fees are paid by the participant submitting the transaction to

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -659,6 +659,11 @@ lock sufficient funds up-front to provide the reserve, and that both
 participants monitor base reserve changes in the network and respond by adding
 additional native asset if required.
 
+Another condition that can result in the closing transaction failing is if the
+use of claimable balances is replaced with payment operations. Payment
+operations may fail and as such a closing transaction containing a payment can
+fail.
+
 ## Limitations
 
 This protocol defines the mechanisms of the Stellar network's core protocol that

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -156,19 +156,20 @@ To setup the payment channel:
    - i to 0.
 5. Increment i.
 4. I and R build the formation transaction F.
-6. I and R follow the [Update Process](#Update-Process), including the step
-to increment i, to build, sign, and exchange declaration and closing
-transactions that allow the payment channel to be closed with disbursements
-matching the initial contributions.
+6. I and R follow the [Update Process](#Update-Process), including the step to
+increment i, to build, sign, and exchange declaration and closing transactions
+that allow the payment channel to be closed with disbursements matching the
+initial contributions. This step yields transactions D_i' and C_i' where i' =
+i+1.
 7. I and R sign and exchange signatures for formation transaction F.
 8. I or R submit F.
 9. Set e to F's iteration number.
 
 The transactions are constructed as follows:
 
-- C_i, see [Update Process](#Update-Process).
+- C_i', see [Update Process](#Update-Process).
 
-- D_i, see [Update Process](#Update-Process).
+- D_i', see [Update Process](#Update-Process).
 
 - F, the _formation transaction_, deposits I and R's contributions to escrow
 account E, R's reserves to reserve account V, and changes escrow account E
@@ -296,7 +297,8 @@ Participants can add additional trustlines if they plan to make deposits of new 
 2. I and R build the trustline transaction TA_i.
 3. I and R follow the [Update Process](#Update-Process), including the step to
 increment i, to build, sign, and exchange declaration and closing transactions
-that close the channel in the same state as the most recently asgreed state.
+that close the channel in the same state as the most recently agreed state.
+This step yields transactions D_i' and C_i' where i' = i+1.
 4. I and R sign and exchange signatures for trustline transaction TA_i.
 5. I or R submit TA_i.
 6. Wait for E's sequence number to be TA_i's.
@@ -304,9 +306,9 @@ that close the channel in the same state as the most recently asgreed state.
 
 The transactions are constructed as follows:
 
-- C_i, see [Update Process](#Update-Process).
+- C_i', see [Update Process](#Update-Process).
 
-- D_i, see [Update Process](#Update-Process).
+- D_i', see [Update Process](#Update-Process).
 
 - TA_i, the _add trustline transaction_, adds one or more trustlines on escrow
 account E, and deposits R's reserves to reserve account V. TA_i has source
@@ -332,7 +334,8 @@ Participants can remove empty trustlines.
 2. I and R build the trustline transaction TR_i.
 3. I and R follow the [Update Process](#Update-Process), including the step to
 increment i, to build, sign, and exchange declaration and closing transactions
-that close the channel in the same state as the most recently asgreed state.
+that close the channel in the same state as the most recently agreed state.
+This step yields transactions D_i' and C_i' where i' = i+1.
 4. I and R sign and exchange signatures for trustline transaction TR_i.
 5. I or R submit TR_i.
 6. Wait for E's sequence number to be TR_i's.
@@ -340,9 +343,9 @@ that close the channel in the same state as the most recently asgreed state.
 
 The transactions are constructed as follows:
 
-- C_i, see [Update Process](#Update-Process).
+- C_i', see [Update Process](#Update-Process).
 
-- D_i, see [Update Process](#Update-Process).
+- D_i', see [Update Process](#Update-Process).
 
 - TR_i, the _add trustline transaction_, removes one or more trustline on escrow
 account E, and withdraws R's reserves from reserve account V. TR_i has source
@@ -378,12 +381,52 @@ deposited, and as long as participants R's intent is to make a payment of the
 same value to participant I. Any amounts deposited to the payment channel
 without coordination will be disbursable to participant I at close.
 
-Participant R must coordinate with participant I to deposit any amount that
-it does not intend to pay participant I. The participants use the following process:
+Participant R must coordinate with participant I to deposit any amount that it
+does not intend to immediately pay participant I. The participants use the
+following process:
 
-1. TODO: 
+1. Increment i.
+2. I and R build the deposit transaction P_i.
+3. I and R follow the [Update Process](#Update-Process), including the step to
+increment i, to build, sign, and exchange declaration and closing transactions
+that close the channel in the same state as the most recently agreed state.
+This step yields transactions D_i' and C_i' where i' = i+1.
+4. I and R follow the [Update Process](#Update-Process), including the step to
+increment i, to build, sign, and exchange declaration and closing transactions
+that define how the assets held by the escrow account will be disbursed at close
+of the channel such that the deposited amount included in P_i will be disbursed
+to participant R. This step yields transactions D_i'' and C_i'' where i'' = i+2.
+4. I and R sign and exchange signatures for deposit transaction P_i.
+5. I or R submit P_i.
+6. Wait for E's sequence number to be P_i's.
+6. Set e to P_i's iteration number.
 
-#### Withdraw Without Close
+The transactions are constructed as follows:
+
+- C_i', see [Update Process](#Update-Process).
+
+- D_i', see [Update Process](#Update-Process).
+
+- C_i'', see [Update Process](#Update-Process).
+
+- D_i'', see [Update Process](#Update-Process).
+
+- P_i, the _deposit transaction_, makes one or more payments from any Stellar
+accounts to escrow account E. P_i has source account E, and sequence number set
+to s_i.
+
+  P_i contains operations:
+
+  - One or more `PAYMENT` operations depositing assets into escrow account E.
+  - One `BUMP_SEQUENCE` operation bumping the sequence number of escrow account
+  E to s_i''.
+
+TODO: This deposit operation is not safe. If it succeeds the appropriate final
+state closure is possible with D_i'' and C_i''. If it fails the existing state
+is preserved in D_i' and C_i', however there is now nothing preventing D_i'' and
+C_i'' being submitted.
+
+#### Withdraw
 
 TODO: Flesh out with more steps and list operations explicitly.
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -436,7 +436,7 @@ following process:
 
 1. Increment i.
 2. I and R build the deposit transaction P_i.
-3. Set e' to e.
+3. Set e' to the value of e.
 4. Set e to i.
 5. Increment i.
 6. Sign and exchange a closing transaction C_i, that closes the channel with
@@ -451,7 +451,7 @@ not executable because escrow account E's sequence number was not bumped to s_i.
 The participants should take the following steps since the deposit did not
 succeed:
 
-10. Set e to e'.
+10. Set e to the value of e'.
 
 The transactions are constructed as follows:
 
@@ -477,7 +477,7 @@ withdrawing:
 
 1. Increment i.
 2. I and R build the withdrawal transaction W_i.
-3. Set e' to e.
+3. Set e' to the value of e.
 4. Set e to i.
 5. Increment i.
 6. Sign and exchange a closing transaction C_i, that closes the channel with
@@ -492,7 +492,7 @@ are not executable because escrow account E's sequence number was not bumped to
 s_i.  The participants should take the following steps since the withdrawal did
 not succeed:
 
-10. Set e to e'.
+10. Set e to the value of e'.
 
 The transactions are constructed as follows:
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -421,10 +421,9 @@ to s_i.
   - One `BUMP_SEQUENCE` operation bumping the sequence number of escrow account
   E to s_i''.
 
-TODO: This deposit process is dependent on a maxSeqNo being added to CAP-21 that
-is not currently part of the proposal. is not safe. If it succeeds the appropriate final
-state closure is possible with D_i'' and C_i''. If it fails the existing state
-is preserved in D_i' and C_i', however there is now nothing preventing D_i'' and
+TODO: This deposit is not safe. If it succeeds the appropriate final state
+closure is possible with D_i'' and C_i''. If it fails the existing state is
+preserved in D_i' and C_i', however there is now nothing preventing D_i'' and
 C_i'' being submitted.
 
 #### Withdraw

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -247,7 +247,7 @@ execute.
   transactions, it contains a `BUMP_SEQUENCE` operation with sequence value 0
   as a no-op.
 
-#### Cooperative Close
+#### Coordinated Close
 
 Participants can agree to close the channel immediately by modifying and
 resigning the most recently signed confirmation transaction. The participants
@@ -258,7 +258,7 @@ change `minSeqAge` and `minSeqLedgerGap` to zero.
 3. Submit D_i
 4. Submit modified C_i
 
-#### Uncooperative Close
+#### Uncordinated Close
 
 Participants can close the channel at the latest state by submitting the most
 recently signed declaration transaction, waiting the observation period O, then

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -260,9 +260,10 @@ change `minSeqAge` and `minSeqLedgerGap` to zero.
 
 #### Uncordinated Close
 
-Participants can close the channel at the latest state by submitting the most
-recently signed declaration transaction, waiting the observation period O, then
-submitting the closing transaction.
+Participants can close the channel after the observation period O without
+coordinating. They do this by submitting the most recently signed declaration
+transaction, waiting the observation period O, then submitting the closing
+transaction.
 
 1. Submit most recent D_i
 2. Wait observation period O

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -269,7 +269,7 @@ transaction.
 2. Wait observation period O
 3. Submit C_i
 
-#### Contesting an Uncooperative Close
+#### Contesting an Uncoordinated Close
 
 Participants can attempt to close the channel at a state that is earlier in the
 history of the channel than the most recently agreed to state. A participant who

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -302,14 +302,15 @@ channel setup. Some of the operations used to alter the channel setup may fail
 even if the transactions are valid, while others will always succeed if the
 transactions are valid.
 
-Each operation is implemented in a two-step process. Participants agree on a new
-closing state at a future iteration by signing C_i and D_i transactions where i
-has skipped an iteration that is not yet executable because the D_i's
+Some operations are implemented in a two-step process. Participants agree on a
+new closing state at a future iteration by signing C_i and D_i transactions
+where i has skipped an iteration that is not yet executable because the D_i's
 `minSeqNum` is also set in the future. Participants then sign a transaction to
 make the change that only moves the sequence of escrow account E to satisfy the
 `minSeqNum` of the future D_i.
 
-Operations that can fail have the following requirements as well:
+Operations that can fail and change the balances of the channel have the
+following requirements as well:
 
 - The transaction that can fail must have its source account set to an account
 that is not escrow account E.
@@ -317,14 +318,13 @@ that is not escrow account E.
 bumps escrow account E's sequence number to a sequence number that makes the D_i
 executable.
 
-Operations that cannot fail:
+Operations where failure cannot occur or is of no consequence:
 
 - [Change the Observation Period](#Change-the-Observation-Period)
-
-Operations that can fail:
-
 - [Add Trustline](#Add-Trustline)
 - [Remove Trustline](#Remove-Trustline)
+
+Operations that can fail:
 - [Deposit by Initiator](#Deposit-by-Initiator)
 - [Deposit by Responder](#Deposit-by-Responder)
 - [Withdraw](#Withdraw)
@@ -333,23 +333,11 @@ Operations that can fail:
 
 Participants can add additional trustlines if they plan to make deposits of new balances.
 
-1. Increment i.
-2. I and R build the trustline transaction TA_i.
-3. Set e' to e.
-4. Set e to i.
-5. Increment i.
-6. Sign and exchange a closing transaction C_i, that closes the channel with
-disbursements matching the most recent agreed state.
-7. Sign and exchange a declaration transaction D_i.
-8. I and R sign and exchange signatures for trustline transaction TA_i.
-9. I or R submit TA_i.
+1. I and R sign and exchange signatures for trustline transaction TA_i.
+2. I or R submit TA_i.
 
-If the remove trustline transaction TA_i fails or is never submitted, the C_i
-and D_i are not executable because escrow account E's sequence number was not
-bumped to s_i.  The participants should take the following steps since the
-transaction did not succeed:
-
-10. Set e to e'.
+If the remove trustline transaction TA_i fails or is never submitted, there is
+no consequence to the channel.
 
 The transactions are constructed as follows:
 
@@ -368,34 +356,16 @@ account that is not E or V, typically the participant proposing the change.
   - One or more `PAYMENT` operations depositing R's reserves to V, for each new
   trustline on E that will be used to sponsor claimable balances at
   disbursement.
-  - One `BUMP_SEQUENCE` operation bumping the sequence number of escrow account
-  E to s_i.
-  
-- C_i, see [Update](#Update) process.
-
-- D_i, see [Update](#Update) process.
 
 ##### Remove Trustline
 
 Participants can remove empty trustlines.
 
-1. Increment i.
-2. I and R build the trustline transaction TR_i.
-3. Set e' to e.
-4. Set e to i.
-5. Increment i.
-6. Sign and exchange a closing transaction C_i, that closes the channel with
-disbursements matching the most recent agreed state.
-7. Sign and exchange a declaration transaction D_i.
-8. I and R sign and exchange signatures for trustline transaction TR_i.
-9. I or R submit TR_i.
+1. I and R sign and exchange signatures for trustline transaction TR_i.
+2. I or R submit TR_i.
 
-If the remove trustline transaction TR_i fails or is never submitted, the C_i
-and D_i are not executable because escrow account E's sequence number was not
-bumped to s_i.  The participants should take the following steps since the
-deposit did not succeed:
-
-10. Set e to e'.
+If the remove trustline transaction TR_i fails or is never submitted, there is
+no consequence to the channel.
 
 The transactions are constructed as follows:
 
@@ -415,12 +385,6 @@ change.
   - One or more `PAYMENT` operations withdrawing R's reserves from V, for each
   trustline being removed from E that would have been used to sponsor claimable
   balances at disbursement and are no longer required.
-  - One `BUMP_SEQUENCE` operation bumping the sequence number of escrow account
-  E to s_i.
-  
-- C_i, see [Update](#Update) process.
-
-- D_i, see [Update](#Update) process.
 
 ##### Deposit by Initiator
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -14,35 +14,96 @@ Version: 0.0.1
 
 ## Summary
 
-This protocol defines the transactions that two participants use to open,
-mutate, and close a payment channel.
+This protocol defines the Stellar transactions that two participants use to
+open and close a payment channel.
 
 ## Dependencies
 
-This protocol is dependent on [CAP-21] and is built on the example two-way
-payment channel protocol defined in that CAP's rationale.
+This protocol is dependent on [CAP-21] and is based on the two-way payment
+channel protocol defined in that CAP's rationale.
 
-This protocol is also dependent on [CAP-23] providing claimable balances and
-[CAP-33] providing sponsorship.
+This protocol is also dependent on [CAP-23] that added claimable balances
+ledger entries and [CAP-33] that added sponsorship to accounts.
 
 ## Motivation
 
-Stellar account holders who frequently interact with a set of partners must
-choose between performing every transaction on-chain, or trusting each other
-to some degree and performing net-settlement. Transactions on-chain are fast
-and affordable but it would be beneficial to some operators if speed and cost
-were not bounded and only limited by the partners own capability to agree.
+Stellar account holders who frequently transact with each other, but do not
+trust each other, perform all their transactions on-chain to get the benefits
+of the network enforcing transaction finality. The network is fast, but not
+as fast as two parties forming an agreement directly with each other. For
+high-frequency transactors it would be beneficial if there was a simple
+method on Stellar to use the concepts found in payment channels to allow two
+parties to escrow funds into an account that is controlled by both parties,
+where agreements can be formed and guaranteed to be executable and contested
+on-chain. [CAP-21] introduces new fields that make it easier to do this.
 
 ## Abstract
 
-This protocol defines...
-
-## Use Cases
-
+TODO
 
 ## Specification
 
-TODO
+A payment channel has two participants, an initiator I and a responder R.
+
+The protocol assumes some _synchrony period_, S, such that both parties are
+guaranteed to be able to observe the blockchain state and submit transactions
+within any period of length S.
+
+The payment channel consists of a 2-of-2 multisig escrow account E, initially
+created and configured by I, and a series of transaction sets that contain
+_declaration_ and _closing_ transactions on E signed by both parties. The
+closing transaction defines the final state of the escrow account and the
+assets it holds.
+
+The two parties maintain the following two variables during the lifetime of
+the channel:
+
+* s - the _starting sequence number_, is initialized to one greater
+than the sequence number of the escrow account E after E has been created and
+configured. It is increased only when withdrawing from or topping up the
+escrow account E.
+
+* i - the _iteration number_ of the payment channel, is initialized to
+(s/2)+1. It is incremented with every off-chain update of the payment channel
+state.
+
+To update the payment channel state, the parties:
+
+1. Increment i.
+2. Sign and exchange two closing transactions IC_i and RC_i.
+3. Sign and exchange a declaration transaction D_i.
+
+The transactions are constructed as follows:
+
+* D_i, the _declaration transaction_, declares an intent to execute
+the corresponding closing transaction C_i. D_i has source account E, sequence
+number 2i, and `minSeqNum` set to s. Hence, D_i can execute at any time, so
+long as E's sequence number n satisfies s <= n < 2i. D_i always leaves E's
+sequence number at 2i after executing. Because C_i has source account E and
+sequence number 2i+1, D_i leaves E in a state where C_i can execute. Note
+that D_i does not require any operations, but since Stellar disallows empty
+transactions, it contains a `BUMP_SEQUENCE` operation as a no-op.
+
+* C_i, the _closing transaction_, disburses funds to R and changes the
+signing weights on E such that I unilaterally controls E. C_i has source
+account E, sequence number 2i+1, and a `minSeqAge` of S (the synchrony
+period). The `minSeqAge` prevents a misbehaving party from executing C_i when
+the channel state has already progressed to a later iteration number, as the
+other party can always invalidate C_i by submitting D_i' for some i' > i. C_i
+contains one or more `CREATE_CLAIMABLE_BALANCE` operations disbursing funds
+to R, plus a `SET_OPTIONS` operation adjusting signing weights to give I full
+control of E.
+
+For R to top-up or withdraw excess funds from the escrow account E, the
+participants skip a generation. They set s = 2(i+1), and i = i+2. They then
+exchange C_i and D_i (which unlike the update case, can be exchanged in a
+single phase of communication because D_i is not yet executable while E's
+sequence number is below the new s). Finally, they create a top-up
+transaction that atomically adjusts E's balance and uses `BUMP_SEQUENCE` to
+increase E's sequence number to s.
+
+To close the channel cooperatively, the parties re-sign C_i with a
+`minSeqNum` of s and a `minSeqAge` of 0, then submit this transaction.
 
 ## Security Concerns
 
@@ -54,8 +115,8 @@ This protocol defines the mechanisms of the Stellar network's core protocol
 that are used to enforce agreements made by two participants. This protocol
 does not define the transport through which the agreements are coordinated,
 or the methods through which more than two participants can coordinate and
-exchange dependent agreements. These issues are likely to be discussed in a
-separate proposal.
+exchange dependent agreements. These issues are likely to be discussed in
+separate proposals.
 
 ## Implementations
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -87,35 +87,6 @@ The participants agree on the period O at channel open.
 The participants may agree at anytime by following the [Change the
 Observation Period](#Change-the-Observation-Period) process.
 
-#### Change the Observation Period
-
-The participants may agree at anytime to decrease period O by simply using a
-smaller value for O in future transaction sets.  The change will only apply
-to future transaction sets.  The change does not require submitting a
-transaction to the network.
-
-The participants may agree at anytime to increase period O by using a larger
-value for O in the next and future transaction sets, or regenerating the most
-recent transaction set, then signing and submitting a transaction that bumps
-the sequence number of the escrow account to the sequence before the most
-recent D_i.  The sequence bump ensures only the most recent transaction with
-the new period O is valid.
-
-The participants:
-
-1. Follow the [Update](#Update) process with the new period O.
-2. Sign and exchange a bump transaction B.
-3. TODO: Set new values for s and i.
-
-The transactions are constructed as follows:
-
-- B, the _bump transaction_, bumps the sequence number of escrow account E
-such that only the most recent transaction set is valid.  B has source
-account E, sequence number s.
-
-  B contains operations:
-  - One `BUMP_SEQUENCE` operation with sequence set to 2(i-1)+1.
-
 ### Accounts
 
 The payment channel utilizes two Stellar accounts that are both 2-of-2
@@ -269,6 +240,35 @@ increase E's sequence number to s.
 
 To close the channel cooperatively, the parties re-sign C_i with a
 `minSeqNum` of s and a `minSeqAge` of 0, then submit this transaction.
+
+#### Change the Observation Period
+
+The participants may agree at anytime to decrease period O by simply using a
+smaller value for O in future transaction sets.  The change will only apply
+to future transaction sets.  The change does not require submitting a
+transaction to the network.
+
+The participants may agree at anytime to increase period O by using a larger
+value for O in the next and future transaction sets, or regenerating the most
+recent transaction set, then signing and submitting a transaction that bumps
+the sequence number of the escrow account to the sequence before the most
+recent D_i.  The sequence bump ensures only the most recent transaction with
+the new period O is valid.
+
+The participants:
+
+1. Follow the [Update](#Update) process with the new period O.
+2. Sign and exchange a bump transaction B.
+3. TODO: Set new values for s and i.
+
+The transactions are constructed as follows:
+
+- B, the _bump transaction_, bumps the sequence number of escrow account E
+such that only the most recent transaction set is valid.  B has source
+account E, sequence number s.
+
+  B contains operations:
+  - One `BUMP_SEQUENCE` operation with sequence set to 2(i-1)+1.
 
 ### Network Transaction Fees
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -59,6 +59,16 @@ and returns control of E to I.  Each generation of declaration and closing
 transaction sets in the series are an agreement on a new final state for the
 channel.
 
+Participants use each iteration of declaration and closing transaction sets to
+agree, and continuously re-agree, on a new final states for the channel. They
+may choose to modify their agreement based on individual payments to one
+another, or on some other basis such as to perform net settlement.
+
+For example, if the channel initial state is $30 of which $10 belongs to I and
+$20 belongs to R, the first closing transaction will disburse $10 to I and $20
+to R. If I makes a payment of $2 to R, then I and R agree on a new closing
+transaction that will disburse $8 to I and $22 to R.
+
 The payment channel also uses a second 2-of-2 multisig reserve account V, to
 sponsor the claimable balances ledger entries that are created at channel
 close, and that disburse funds to R.
@@ -205,6 +215,17 @@ sequence number set to s_i.
 - D_i, see [Update](#Update) process.
 
 #### Update
+
+Participants use the update process to agree, and re-agree, on a new final state
+for the channel. Participants will agree on a new final state when making
+payments to one another within the channel.
+
+For example, if the channel initial state is $30 of which $10 belongs to I and
+$20 belongs to R, the first closing transaction will disburse $10 to I and $20
+to R. If I makes a payment of $2 to R, this update process will involve I and R
+agreeing on a new declaration and aclosing transaction that supersedes all
+previous declaration and closing transaction and that will disburse $8 to I and
+$22 to R.
 
 To update the payment channel state, the participants:
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -253,12 +253,12 @@ Participants can agree to close the channel immediately by modifying and
 resigning the most recently signed confirmation transaction. The participants
 change `minSeqAge` and `minSeqLedgerGap` to zero.
 
-1. Modify the most recent C_i `minSeqAge` and `minSeqLedgerGap` to zero.
-2. Resign and exchange the modified confirmation transaction C_i.
-3. Submit D_i
+1. Submit most recent D_i
+2. Modify the most recent C_i `minSeqAge` and `minSeqLedgerGap` to zero
+3. Resign and exchange the modified confirmation transaction C_i
 4. Submit modified C_i
 
-#### Uncordinated Close
+#### Uncoordinated Close
 
 Participants can close the channel after the observation period O without
 coordinating. They do this by submitting the most recently signed declaration
@@ -269,14 +269,17 @@ transaction.
 2. Wait observation period O
 3. Submit C_i
 
-#### Contesting an Uncoordinated Close
+#### Contesting a Close
+
+Participants can contest a close if the close is not the most recent agreed
+closing state of the payment channel.
 
 Participants can attempt to close the channel at a state that is earlier in the
 history of the channel than the most recently agreed to state. A participant who
 is a malicious actor might attempt to do this if an earlier state benefits them.
 
-The malicious participant can do this by performing the [Uncooperative
-Close](#Uncooperative-Close) process with a declaration transaction that is not
+The malicious participant can do this by performing the [Uncoordinated
+Close](#Uncoordinated-Close) process with a declaration transaction that is not
 the most recently signed declaration transaction.
 
 The other participant can identify that the close process has started at an
@@ -287,7 +290,7 @@ the close. A participant contests a close by submitting a more recent
 declaration transaction and closing the channel at the actual final state.
 
 1. Get E's sequence number n
-2. If s_e > n < s_i, go to 3, otherwise go to 1
+2. If s_{e+1} >= n < s_i, go to step 3, else go to step 1
 3. Submit most recent D_i
 4. Wait observation period O
 5. Submit C_i

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -176,6 +176,11 @@ disbursements matching the initial contributions.
 9. I and R sign and exchange signatures for formation transaction F.
 10. I or R submit F.
 
+It is important that F is signed after C_i and D_i because F will make the
+accounts E and V 2-of-2 multisig. Without C_i and D_i, I and R would not be able
+to close the channel, or regain control of the accounts, and the assets within
+without coordinating with each other.
+
 The transactions are constructed as follows:
 
 - F, the _formation transaction_, deposits I and R's contributions to escrow
@@ -232,6 +237,13 @@ To update the payment channel state, the participants:
 1. Increment i.
 2. Sign and exchange a closing transaction C_i.
 3. Sign and exchange a declaration transaction D_i.
+
+It is important that D_i is signed after C_i because D_i will invalidate any
+previously signed C_i. If I and R signed and exchanged D_i first either party
+could prevent the channel from closing without coordination by submitting D_i
+and refusing to sign C_i.  The participants would not be able to close the
+channel, or regain control of the accounts, and the assets within without
+coordinating with each other.
 
 The transactions are constructed as follows:
 
@@ -618,6 +630,14 @@ asset necessary into reserve account V themselves, at some written-off cost to
 themselves.
 
 ## Security Concerns
+
+### Transaction Signing Order
+
+In many of the processes outlined in the protocol an order is provided to when
+transactions should be signed and exchanged. This order is critical to the
+protocol. If a participant signs transactions out-of-order they will allow the
+other participant to place the channel into a state where disbursement is not
+possible without the participants coordinating.
 
 ### Closing Transaction Failure
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -3,7 +3,7 @@
 ```
 SEP: ????
 Title: Payment Channel
-Author: Leigh McCulloch <@leighmcculloch>
+Author: David Mazeries <@standford-scs>, Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Discussion: https://github.com/stellar/experimental-payment-channels/issues
@@ -19,8 +19,8 @@ open and close a payment channel.
 
 ## Dependencies
 
-This protocol is dependent on [CAP-21] and is based on the two-way payment
-channel protocol defined in that CAP's rationale.
+This protocol is dependent on the not impemented [CAP-21] and is based on the
+two-way payment channel protocol defined in that CAP's rationale.
 
 This protocol is also dependent on [CAP-23] that added claimable balances
 ledger entries and [CAP-33] that added sponsorship to accounts.
@@ -29,13 +29,14 @@ ledger entries and [CAP-33] that added sponsorship to accounts.
 
 Stellar account holders who frequently transact with each other, but do not
 trust each other, perform all their transactions on-chain to get the benefits
-of the network enforcing transaction finality. The network is fast, but not
-as fast as two parties forming an agreement directly with each other. For
+of the network enforcing transaction finality.  The network is fast, but not
+as fast as two parties forming an agreement directly with each other.  For
 high-frequency transactors it would be beneficial if there was a simple
-method on Stellar to use the concepts found in payment channels to allow two
-parties to escrow funds into an account that is controlled by both parties,
-where agreements can be formed and guaranteed to be executable and contested
-on-chain. [CAP-21] introduces new fields that make it easier to do this.
+method on Stellar to allow two parties to escrow funds into an account that
+is controlled by both parties, where agreements can be formed and guaranteed
+to be executable and contested on-chain.  [CAP-21], [CAP-23], and [CAP-33]
+introduce new functionality to the Stellar protocol that make it easier to do
+this.
 
 ## Abstract
 
@@ -52,47 +53,65 @@ within any period of length S.
 The payment channel consists of a 2-of-2 multisig escrow account E, initially
 created and configured by I, and a series of transaction sets that contain
 _declaration_ and _closing_ transactions on E signed by both parties. The
-closing transaction defines the final state of the escrow account and the
-assets it holds.
+closing transaction defines the final state of E and the assets it holds.
+
+### Variables
 
 The two parties maintain the following two variables during the lifetime of
 the channel:
 
 * s - the _starting sequence number_, is initialized to one greater
 than the sequence number of the escrow account E after E has been created and
-configured. It is increased only when withdrawing from or topping up the
+configured. It is changed only when withdrawing from or topping up the
 escrow account E.
 
 * i - the _iteration number_ of the payment channel, is initialized to
 (s/2)+1. It is incremented with every off-chain update of the payment channel
 state.
 
+### Update Process
+
 To update the payment channel state, the parties:
 
 1. Increment i.
-2. Sign and exchange two closing transactions IC_i and RC_i.
+2. Sign and exchange each other's closing transactions IC_i and RC_i.
 3. Sign and exchange a declaration transaction D_i.
 
 The transactions are constructed as follows:
 
 * D_i, the _declaration transaction_, declares an intent to execute
-the corresponding closing transaction C_i. D_i has source account E, sequence
-number 2i, and `minSeqNum` set to s. Hence, D_i can execute at any time, so
-long as E's sequence number n satisfies s <= n < 2i. D_i always leaves E's
-sequence number at 2i after executing. Because C_i has source account E and
-sequence number 2i+1, D_i leaves E in a state where C_i can execute. Note
-that D_i does not require any operations, but since Stellar disallows empty
-transactions, it contains a `BUMP_SEQUENCE` operation as a no-op.
+the corresponding closing transactions IC_i/RC_i.  D_i has source account E,
+sequence number 2i, and `minSeqNum` set to s.  Hence, D_i can execute at any
+time, so long as E's sequence number n satisfies s <= n < 2i.  Because C_i
+has source account E and sequence number 2i+1, D_i leaves E in a state where
+C_i can execute.
 
-* C_i, the _closing transaction_, disburses funds to R and changes the
-signing weights on E such that I unilaterally controls E. C_i has source
-account E, sequence number 2i+1, and a `minSeqAge` of S (the synchrony
-period). The `minSeqAge` prevents a misbehaving party from executing C_i when
-the channel state has already progressed to a later iteration number, as the
-other party can always invalidate C_i by submitting D_i' for some i' > i. C_i
-contains one or more `CREATE_CLAIMABLE_BALANCE` operations disbursing funds
-to R, plus a `SET_OPTIONS` operation adjusting signing weights to give I full
-control of E.
+  Note that D_i does not require any operations, but since Stellar disallows
+  empty transactions, it contains a `BUMP_SEQUENCE` operation as a no-op.
+
+* IC_i and RC_i, the _closing transactions_, disburse funds to R and change the
+signing weights on E such that I unilaterally controls E.  IC_i and RC_i have
+source account E, sequence number 2i+1, and a `minSeqAge` of S (the synchrony
+period).
+
+  The `minSeqAge` prevents a misbehaving party from executing IC_i/RC_i when
+  the channel state has already progressed to a later iteration number, as
+  the other party can invalidate IC_i/RC_i by submitting D_i' for some i' >
+  i.
+  
+  IC_i and RC_i contain one or more `CREATE_CLAIMABLE_BALANCE` operations
+  disbursing funds to R, plus a `SET_OPTIONS` operation adjusting signing
+  weights to give I full control of E.
+
+  IC_i and RC_i are identical, except that the sponsor for new ledger entries
+  in each will be I or R respectively.  IC_i wraps its operations with a
+  `BEGIN_SPONSORING_FUTURE_RESERVES` and `END_SPONSORING_FUTURE_RESERVES`
+  with the source account for sponsorship set to I.  RC_I does same with the
+  source account for sponsorship set to R.
+
+### Top-Up and Withdraw-Without-Close Processes
+
+TODO:
 
 For R to top-up or withdraw excess funds from the escrow account E, the
 participants skip a generation. They set s = 2(i+1), and i = i+2. They then
@@ -104,6 +123,17 @@ increase E's sequence number to s.
 
 To close the channel cooperatively, the parties re-sign C_i with a
 `minSeqNum` of s and a `minSeqAge` of 0, then submit this transaction.
+
+### Fees and Reserves
+
+All fees and reserves are paid or sponsored by the participant submitting the
+transaction to the Stellar network.
+
+All transactions that are presigned have their fees set to zero.  The
+submitter of a transaction wraps the transactions in a fee bump transaction
+envelope and provides an appropriate fee, paying for the fee themselves.
+
+Credits and debits to escrow account E only ever represent payments between I and R, or top-ups or withdrawals, since all transaction fees and reserves are paid or sponsored by the participants.
 
 ## Security Concerns
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -362,7 +362,7 @@ Participants can add additional trustlines if they plan to make deposits of new 
 1. I and R sign and exchange signatures for trustline transaction TA_i.
 2. I or R submit TA_i.
 
-If the remove trustline transaction TA_i fails or is never submitted, there is
+If the add trustline transaction TA_i fails or is never submitted, there is
 no consequence to the channel.
 
 The transactions are constructed as follows:

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -141,8 +141,9 @@ available sequence number for iterations to consume.
 every off-chain update of the payment channel state, or on-chain setup, deposit,
 withdrawal, etc.
 
-- e, the _executed iteration number_, is initialized to zero. It is incremented
-with every iteration submitted on-chain.
+- e, the _executed iteration number_, is initialized to zero. It is updated to
+the most recent iteration number i that the participants agree to execute
+on-chain, such as a setup, deposit, or withdrawal.
 
 ### Computed Values
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -308,7 +308,12 @@ earlier state by monitoring changes in escrow account E's sequence. If the other
 participant sees the sequence number of escrow account E change to a value that
 is not the most recently used s_i, they can use the following process to contest
 the close. A participant contests a close by submitting a more recent
-declaration transaction and closing the channel at the actual final state.
+declaration transaction and closing the channel at the actual final state. A
+more recent declaration transaction may be submitted because it has a higher
+sequence number than the declaration transaction that the malicious actor
+submitted. The more recent declaration transaction prevents the malicious actor
+from submitting the older closing transaction because it has a lower sequence
+number making that transaction invalid.
 
 1. Get E's sequence number n
 2. If s_{e+1} >= n < s_i, go to step 3, else go to step 1

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -3,7 +3,7 @@
 ```
 SEP: ????
 Title: Payment Channel
-Author: David Mazeries <@standford-scs>, Leigh McCulloch <@leighmcculloch>
+Author: David Mazières <@standford-scs>, Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Discussion: https://github.com/stellar/experimental-payment-channels/issues

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -114,7 +114,7 @@ until all claimable balances created at close for R are claimed by R.
 
 The two participants agree on the following constants:
 
-- m, the _maximum transaction account of an iteration's transaction set_, is
+- m, the _maximum transaction count for an iteration's transaction set_, is
 defined as 2, the maximum number of transactions that can be signed in any
 process between the increments of iteration number i.
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -51,7 +51,7 @@ The protocol assumes some _observation period_, O, such that both parties are
 guaranteed to be able to observe the blockchain state and submit transactions
 within any period of length O.
 
-The payment channel consists of two 2-of-2 multisig escrow account E, and a
+The payment channel consists of a 2-of-2 multisig escrow account E, and a
 series of transaction sets that contain _declaration_ and _closing_
 transactions on E signed by both participants.  The closing transaction
 defines the final state of the channel that creates claimable balances for R
@@ -84,6 +84,11 @@ participants are guaranteed to be able to observe the blockchain state and
 submit transactions in response to changing state.
 
 The participants agree on the period O at channel open.
+
+The observation period is defined both as a duration in time, and a count of
+ledgers. The observation period has passed if both the duration and ledger count
+have been exceeded. These two properties together are referred to as O
+throughout the protocol.
 
 The participants may agree to change the period O at anytime by following the
 [Change the Observation Period](#Change-the-Observation-Period) process.
@@ -122,9 +127,9 @@ the channel:
 sequence number of escrow account E after E has been created. It is the first
 available sequence number for iterations to consume.
 
-- i, the _iteration number_ of the payment channel, is initialized to zero.
-It is incremented with every off-chain update of the payment channel state,
-or on-chain setup, deposit, withdrawal, etc.
+- i, the _iteration number_, is initialized to zero.  It is incremented with
+every off-chain update of the payment channel state, or on-chain setup, deposit,
+withdrawal, etc.
 
 - e, the _executed iteration number_, is initialized to zero. It is incremented
 with every iteration submitted on-chain.
@@ -209,14 +214,15 @@ To update the payment channel state, the participants:
 
 The transactions are constructed as follows:
 
-- C_i, the _closing transaction_, disburses funds to R and changes the
-signing weights on E such that I unilaterally controls E.  C_i has source
-account E, sequence number s_i+1, and a `minSeqAge` of O (the observation
-period).
+- C_i, the _closing transaction_, disburses funds to R and changes the signing
+weights on E such that I unilaterally controls E.  C_i has source account E,
+sequence number s_i+1, a `minSeqAge` of O (the observation period time
+duration), and a `minSeqLedgerGap` of O (the observation period ledger count).
 
-  The `minSeqAge` prevents a misbehaving party from executing C_i when the
-  channel state has already progressed to a later iteration number, as the
-  other party can invalidate C_i by submitting D_i' for some i' > i.
+  The `minSeqAge` and `minSeqLedgerGap` prevents a misbehaving party from
+  executing C_i when the channel state has already progressed to a later
+  iteration number, as the other party has the period O to invalidate C_i by
+  submitting D_i' for some i' > i.
   
   C_i contains operations:
   - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies reserve
@@ -245,9 +251,9 @@ execute.
 
 Participants can agree to close the channel immediately by modifying and
 resigning the most recently signed confirmation transaction. The participants
-change the `minSeqAge` to zero.
+change `minSeqAge` and `minSeqLedgerGap` to zero.
 
-1. Modify the most recent C_i `minSeqAge` to zero.
+1. Modify the most recent C_i `minSeqAge` and `minSeqLedgerGap` to zero.
 2. Resign and exchange the modified confirmation transaction C_i.
 3. Submit D_i
 4. Submit modified C_i

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -363,7 +363,7 @@ Operations where failure cannot occur or is of no consequence:
 - [Add Trustline](#Add-Trustline)
 - [Remove Trustline](#Remove-Trustline)
 
-Operations that can fail:
+Operations that can fail and where the additional requirements apply:
 - [Deposit by Initiator](#Deposit-by-Initiator)
 - [Deposit by Responder](#Deposit-by-Responder)
 - [Withdraw](#Withdraw)

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -84,8 +84,8 @@ submit transactions in response to changing state.
 
 The participants agree on the period O at channel open.
 
-The participants may agree at anytime by following the [Change the
-Observation Period](#Change-the-Observation-Period) process.
+The participants may agree to change the period O at anytime by following the
+[Change the Observation Period](#Change-the-Observation-Period) process.
 
 ### Accounts
 


### PR DESCRIPTION
### What
Add a SEP that defines the transactions required to form a payment channel, using the new preconditions in CAP-21, and based on the two-way payment channel in CAP-21's rationale section.

### Why
CAP-21 contains a brief description of how to use CAP-21's new preconditions to support a two-way payment channel protocol, but there are more things that participants need to agree on in regards to the transactions and blockchain state. We should document all these things in a new SEP.

We can work on and iterate on the SEP in this repo for the moment until we have prototyped it and have some confidence we want to propose it as a SEP in the stellar-protocol repository.

This SEP contains no discussion of a transport protocol because it is out-of-scope. We aren't at a point where it is really important to document that concretely as any prototypes we develop now will use whatever simple transport mechanism they can to make the prototype work. We'll document that separately in some future milestone as a separate SEP.

Close #5