### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The forks may not be exactly the same as the CAP as shortcuts may have been take
 
 - xdr: https://github.com/leighmcculloch/stellar--stellar-core/tree/cap21/src/xdr
 - stellar-core: https://github.com/leighmcculloch/stellar--stellar-core/pull/1
-- horizon: https://github.com/stellar/go/pull/35
+- horizon: https://github.com/stellar/go/pull/3546
 - quickstart: https://github.com/leighmcculloch/stellar--docker-stellar-core-horizon/pull/1
 - stc: https://github.com/leighmcculloch/xdrpp--stc/pull/1
 


### PR DESCRIPTION
### What
Update the link in the README to the Horizon fork.

### Why
It is pointing to the wrong PR on the repo due to a typo.