### PR TITLE
Change the SEP to use two escrow accounts

### DIFF
--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -257,8 +257,8 @@ ledger count).
 - D_i, the _declaration transaction_, declares an intent to execute the
 corresponding closing transaction C_i.  D_i has source account EI, sequence
 number s_i, and `minSeqNum` set to s_e.  Hence, D_i can execute at any time, so
-long as E's sequence number n satisfies s_e <= n < s_i.  Because C_i has source
-account E and sequence number s_i+1, D_i leaves EI in a state where C_i can
+long as EI's sequence number n satisfies s_e <= n < s_i.  Because C_i has source
+account EI and sequence number s_i+1, D_i leaves EI in a state where C_i can
 execute.
 
   D_i does not require any operations, but since Stellar disallows empty
@@ -329,7 +329,7 @@ Some operations are implemented in a two-step process. Participants agree on a
 new closing state at a future iteration by signing C_i and D_i transactions
 where i has skipped an iteration that is not yet executable because the D_i's
 `minSeqNum` is also set in the future. Participants then sign a transaction to
-make the change that only moves the sequence of escrow account E to satisfy the
+make the change that only moves the sequence of escrow account EI to satisfy the
 `minSeqNum` of the future D_i.
 
 Operations that can fail and change the balances of the channel have the
@@ -510,12 +510,12 @@ being set to zero.
 All transaction fees are paid by the participant submitting the transaction to
 the Stellar network.
 
-All transactions defined in the protocol with escrow account E as the source
+All transactions defined in the protocol with escrow account EI as the source
 account have their fees set to zero.  The submitter of a transaction wraps the
 transaction in a fee bump transaction envelope and provides an appropriate fee,
 paying the fee themselves.
 
-Credits and debits to escrow account E only ever represent deposits or
+Credits and debits to escrow accounts EI and ER only ever represent deposits or
 withdrawals by I or R, and the sum of all disbursements at close equal the sum
 of all deposits minus the sum of all withdrawals.  Network transaction fees do
 not change the balance of the channel.

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -591,7 +591,7 @@ Another condition that can result in the closing transaction failing is if the
 payment operations between the escrow accounts would exceed any limits either
 account has on making a payment, due to liabilities, or would exceed limits on
 the receiving account, such as a trustline limit. Participants must ensure that
-the payments they sign for a receivable by the escrow accounts.
+the payments they sign for are receivable by the escrow accounts.
 
 ## Limitations
 

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -22,8 +22,7 @@ open and close a payment channel.
 This protocol is dependent on the not-yet-impemented [CAP-21], and is based
 on the two-way payment channel protocol defined in that CAP's rationale.
 
-This protocol is also dependent on [CAP-23], that added claimable balances
-ledger entries, and [CAP-33], that added sponsorship to accounts.
+This protocol is also dependent on [CAP-33], that added sponsorship to accounts.
 
 ## Motivation
 
@@ -41,9 +40,7 @@ that make it easier to do this.
 ## Abstract
 
 This protocol defines the Stellar transactions that two participants use to
-open and close a payment channel by using an escrow account to holds funds, a
-reserve account to hold native asset to pay for new ledger entries, and
-claimable balances as an uninterruptable method for final disbursement.
+open and close a payment channel by using escrow accounts to holds funds.
 
 A payment channel has two participants, an initiator I and a responder R.
 
@@ -51,13 +48,15 @@ The protocol assumes some _observation period_, O, such that both parties are
 guaranteed to be able to observe the blockchain state and submit transactions
 within any period of length O.
 
-The payment channel consists of a 2-of-2 multisig escrow account E, and a
-series of transaction sets that contain _declaration_ and _closing_
-transactions on E signed by both participants.  The closing transaction
-defines the final state of the channel that creates claimable balances for R
-and returns control of E to I.  Each generation of declaration and closing
-transaction sets in the series are an agreement on a new final state for the
-channel.
+The payment channel consists of two 2-of-2 multisig escrow accounts EI and ER,
+and a series of transaction sets that contain _declaration_ and _closing_
+transactions with EI as their source account, signed by both participants.  The
+closing transaction defines the final state of the channel that disburses assets
+from EI to ER and/or from ER to EI such that the final balances of EI and ER
+match the amounts belonging to I and R. The closing transaction also returns
+control of EI to I and control of ER to R.  Each generation of declaration and
+closing transaction sets in the series are an agreement on a new final state for
+the channel.
 
 Participants use each iteration of declaration and closing transaction sets to
 agree, and continuously re-agree, on a new final states for the channel. They
@@ -69,23 +68,19 @@ $20 belongs to R, the first closing transaction will disburse $10 to I and $20
 to R. If I makes a payment of $2 to R, then I and R agree on a new closing
 transaction that will disburse $8 to I and $22 to R.
 
-The payment channel also uses a second 2-of-2 multisig reserve account V, to
-sponsor the claimable balances ledger entries that are created at channel
-close, and that disburse funds to R.
-
 ## Specification
 
 ### Participants
 
 A payment channel has two participants:
 
-- I, the _initiator_, who proposes the payment channel, performs the first
-setup step, and will be able to make deposits to the payment channel without
-coordination.  I creates escrow account E and receives disbursement through
-regaining control of E at channel close.
+- I, the _initiator_, who proposes the payment channel, and creates the escrow
+account that will be used for sequence numbers.  I creates escrow account EI and
+receives disbursement through regaining control of EI at channel close.
 
-- R, the _responder_, who joins the payment channel, and receives disbursement
-through claimable balances at channel close.
+- R, the _responder_, who joins the payment channel, and creates the other
+escrow account. R creates escrow account ER and receives disbursement through
+regaining control of ER at channel close.
 
 ### Observation Period
 
@@ -103,22 +98,23 @@ throughout the protocol.
 The participants may agree to change the period O at anytime by following the
 [Change the Observation Period](#Change-the-Observation-Period) process.
 
-### Accounts
+### Escrow Accounts
 
 The payment channel utilizes two Stellar accounts that are both 2-of-2
 multisig accounts while the channel is open:
 
-- E, the _escrow account_, that holds the assets that both participants have
-contributed to the channel and that will be distributed to the participants
-at channel close according to the final close transactions submitted.
-Created by I.  Jointly controlled by I and R while the channel is open.
-Control is returned to I at close.
+- EI, the _escrow account belonging to I_, that holds the assets that I has
+contributed to the channel and that will be distributed to the participants at
+channel close according to the final close transactions submitted.  Created by
+I.  Jointly controlled by I and R while the channel is open.  Control is
+returned to I at close.  Provides sequence numbers for the channel while the
+channel is open.
 
-- V, the _reserve account_, that holds an amount of native asset contributed
-by R that will be used to sponsor the claimable balance ledger entries
-created at disbursement.  Created by R.  Jointly controlled by I and R while
-the channel is open.  Control is returned to R at close.  Cannot be merged
-until all claimable balances created at close for R are claimed by R.
+- ER, the _escrow account belonging to R_, that holds the assets that R has
+contributed to the channel and that will be distributed to the participants at
+channel close according to the final close transactions submitted.  Created by
+R.  Jointly controlled by I and R while the channel is open.  Control is
+returned to R at close.  Does not provide sequence numbers for the channel in anyway.
 
 ### Constants
 
@@ -134,16 +130,16 @@ The two participants maintain the following variables during the lifetime of
 the channel:
 
 - s, the _starting sequence number_, is initialized to one greater than the
-sequence number of escrow account E after E has been created. It is the first
+sequence number of escrow account EI after EI has been created. It is the first
 available sequence number for iterations to consume.
 
 - i, the _iteration number_, is initialized to zero.  It is incremented with
-every off-chain update of the payment channel state, or on-chain setup, deposit,
+every off-chain update of the payment channel state, or on-chain setup,
 withdrawal, etc.
 
 - e, the _executed iteration number_, is initialized to zero. It is updated to
 the most recent iteration number i that the participants agree to execute
-on-chain, such as a setup, deposit, or withdrawal.
+on-chain, such as a setup, or withdrawal.
 
 ### Computed Values
 
@@ -163,10 +159,10 @@ payment channel has a single value for m it is computable as, s+(m*e).
 
 To setup the payment channel:
 
-1. I creates the escrow account E.
-2. R creates the reserve account V.
+1. I creates and deposits initial contribution to escrow account EI.
+2. R creates and deposits initial contribution to escrow account ER.
 3. Set variable initial states:
-   - s to E's sequence number + 1.
+   - s to EI's sequence number + 1.
    - i to 0.
    - e to 0.
 5. I and R build the formation transaction F.
@@ -178,43 +174,33 @@ disbursements matching the initial contributions.
 10. I or R submit F.
 
 It is important that F is signed after C_i and D_i because F will make the
-accounts E and V 2-of-2 multisig. Without C_i and D_i, I and R would not be able
-to close the channel, or regain control of the accounts, and the assets within
-without coordinating with each other.
+accounts EI and ER 2-of-2 multisig. Without C_i and D_i, I and R would not be
+able to close the channel, or regain control of the accounts, and the assets
+within without coordinating with each other.
 
 The transactions are constructed as follows:
 
-- F, the _formation transaction_, deposits I and R's contributions to escrow
-account E, R's reserves to reserve account V, and changes escrow account E and
-reserve account V to be 2-of-2 multisig accounts. F has source account E, and
-sequence number set to s_i.
+- F, the _formation transaction_, changes escrow accounts EI and ER to be 2-of-2
+multisig accounts. F has source account E, and sequence number set to s_i.
 
   F contains operations:
 
   - Operations sponsored by I:
-    - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies participant
-    I as a sponsor of future reserves.
-    - One or more `SET_OPTIONS` operations adjusting escrow account E's
-    thresholds such that I and R's signers must both sign, and adding I's
-    signers to E.
-    - One or more `SET_OPTIONS` operations adding I's signers to V.
-    - One or more `CHANGE_TRUST` operations adding trustlines to E.
+    - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies
+    participant I as a sponsor of future reserves.
+    - One `SET_OPTIONS` operation adjusting escrow account EI's thresholds such
+    that I and R's signers must both sign.
+    - One or more `SET_OPTIONS` operations adding I's signers to ER.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops I sponsoring
     future reserves of subsequent operations.
   - Operations sponsored by R:
     - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies reserve
     account R as a sponsor of future reserves.
-    - One or more `SET_OPTIONS` operations adjusting escrow account V's
-    thresholds such that R and I's signers must both sign, and adding R's
-    signers to V.
-    - One or more `SET_OPTIONS` operations adding R's signers to E.
+    - One `SET_OPTIONS` operations adjusting escrow account ER's thresholds such
+    that R and I's signers must both sign.
+    - One or more `SET_OPTIONS` operations adding R's signers to EI.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops R sponsoring
     future reserves of subsequent operations.
-  - One or more `PAYMENT` operations depositing I's contribution to E.
-  - One or more `PAYMENT` operations depositing R's contribution to E.
-  - One or more `PAYMENT` operations depositing R's reserves to V, for each
-  trustline on E that will be used to sponsor claimable balances at
-  disbursement.
   
 - C_i, see [Update](#Update) process.
 
@@ -248,10 +234,12 @@ coordinating with each other.
 
 The transactions are constructed as follows:
 
-- C_i, the _closing transaction_, disburses funds to R and changes the signing
-weights on E such that I unilaterally controls E.  C_i has source account E,
-sequence number s_i+1, a `minSeqAge` of O (the observation period time
-duration), and a `minSeqLedgerGap` of O (the observation period ledger count).
+- C_i, the _closing transaction_, disburses funds from EI to ER and/or from ER
+to EI, and changes the signing weights on EI such that I unilaterally controls
+EI, and the signing weights on ER such that R unilaterally controls ER.  C_i has
+source account EI, sequence number s_i+1, a `minSeqAge` of O (the observation
+period time duration), and a `minSeqLedgerGap` of O (the observation period
+ledger count).
 
   The `minSeqAge` and `minSeqLedgerGap` prevents a misbehaving party from
   executing C_i when the channel state has already progressed to a later
@@ -259,22 +247,18 @@ duration), and a `minSeqLedgerGap` of O (the observation period ledger count).
   submitting D_i' for some i' > i.
   
   C_i contains operations:
-  - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies reserve
-  account V as a sponsor of future reserves.
-  - One `CREATE_CLAIMABLE_BALANCE` operation for each trustline that is
-  disbursing funds to R.
-  - One `END_SPONSORING_FUTURE_RESERVES` operation that confirms reserve
-  account V's sponsorship.
-  - One or more `SET_OPTIONS` operation adjusting escrow account E's
-  thresholds to give I full control of E, and removing R's signers.
-  - One or more `SET_OPTIONS` operation adjusting reserve account E's
-  thresholds to give R full control of V, and removing I's signers.
+  - One `PAYMENT` operation for each trustline that is disbursing funds from EI
+  to ER, or from ER to EI.
+  - One or more `SET_OPTIONS` operation adjusting escrow account EI's thresholds
+  to give I full control of EI, and removing R's signers.
+  - One or more `SET_OPTIONS` operation adjusting reserve account ER's
+  thresholds to give R full control of ER, and removing I's signers.
 
 - D_i, the _declaration transaction_, declares an intent to execute the
-corresponding closing transaction C_i.  D_i has source account E, sequence
+corresponding closing transaction C_i.  D_i has source account EI, sequence
 number s_i, and `minSeqNum` set to s_e.  Hence, D_i can execute at any time, so
 long as E's sequence number n satisfies s_e <= n < s_i.  Because C_i has source
-account E and sequence number s_i+1, D_i leaves E in a state where C_i can
+account E and sequence number s_i+1, D_i leaves EI in a state where C_i can
 execute.
 
   D_i does not require any operations, but since Stellar disallows empty
@@ -317,10 +301,10 @@ Close](#Uncoordinated-Close) process with a declaration transaction that is not
 the most recently signed declaration transaction.
 
 The other participant can identify that the close process has started at an
-earlier state by monitoring changes in escrow account E's sequence. If the other
-participant sees the sequence number of escrow account E change to a value that
-is not the most recently used s_i, they can use the following process to contest
-the close. A participant contests a close by submitting a more recent
+earlier state by monitoring changes in escrow account EI's sequence. If the
+other participant sees the sequence number of escrow account EI change to a
+value that is not the most recently used s_i, they can use the following process
+to contest the close. A participant contests a close by submitting a more recent
 declaration transaction and closing the channel at the actual final state. A
 more recent declaration transaction may be submitted because it has a higher
 sequence number than the declaration transaction that the malicious actor
@@ -328,7 +312,7 @@ submitted. The more recent declaration transaction prevents the malicious actor
 from submitting the older closing transaction because it has a lower sequence
 number making that transaction invalid.
 
-1. Get E's sequence number n
+1. Get EI's sequence number n
 2. If s_{e+1} >= n < s_i, go to step 3, else go to step 1
 3. Submit most recent D_i
 4. Wait observation period O
@@ -352,20 +336,19 @@ Operations that can fail and change the balances of the channel have the
 following requirements as well:
 
 - The transaction that can fail must have its source account set to an account
-that is not escrow account E.
+that is not escrow account EI.
 - The transaction that can fail must contain a `BUMP_SEQUENCE` operation that
-bumps escrow account E's sequence number to a sequence number that makes the D_i
-executable.
+bumps escrow account EI's sequence number to a sequence number that makes the
+D_i executable.
 
 Operations where failure cannot occur or is of no consequence:
 
 - [Change the Observation Period](#Change-the-Observation-Period)
 - [Add Trustline](#Add-Trustline)
 - [Remove Trustline](#Remove-Trustline)
+- [Deposit / Top-up](#Deposit--Top-up)
 
 Operations that can fail and where the additional requirements apply:
-- [Deposit by Initiator](#Deposit-by-Initiator)
-- [Deposit by Responder](#Deposit-by-Responder)
 - [Withdraw](#Withdraw)
 
 ##### Add Trustline
@@ -381,20 +364,23 @@ no consequence to the channel.
 The transactions are constructed as follows:
 
 - TA_i, the _add trustline transaction_, adds one or more trustlines on escrow
-account E, and deposits R's reserves to reserve account V. TA_i has any source
-account that is not E or V, typically the participant proposing the change.
+accounts EI and ER. TA_i has any source account that is not EI, typically the
+participant proposing the change.
 
   TA_i contains operations:
 
   - Operations sponsored by I:
     - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies
     participant I as a sponsor of future reserves.
-    - One or more `CHANGE_TRUST` operations adding trustlines to E.
+    - One or more `CHANGE_TRUST` operations adding trustlines to EI.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops I sponsoring
     future reserves of subsequent operations.
-  - One or more `PAYMENT` operations depositing R's reserves to V, for each new
-  trustline on E that will be used to sponsor claimable balances at
-  disbursement.
+  - Operations sponsored by R:
+    - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies
+    participant R as a sponsor of future reserves.
+    - One or more `CHANGE_TRUST` operations adding trustlines to ER.
+    - One `END_SPONSORING_FUTURE_RESERVES` operation that stops R sponsoring
+    future reserves of subsequent operations.
 
 ##### Remove Trustline
 
@@ -409,78 +395,29 @@ no consequence to the channel.
 The transactions are constructed as follows:
 
 - TR_i, the _remove trustline transaction_, removes one or more trustline on
-escrow account E, and withdraws R's reserves from reserve account V. TR_i has
-any source account that is not E or V, typically the participant proposing the
-change.
+escrow accounts EI and ER. TR_i has any source account that is not EI, typically
+the participant proposing the change.
 
   TR_i contains operations:
 
-  - Operations sponsored by I:
-    - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies
-    participant I as a sponsor of future reserves.
-    - One or more `CHANGE_TRUST` operations removing trustlines from E.
-    - One `END_SPONSORING_FUTURE_RESERVES` operation that stops I sponsoring
-    future reserves of subsequent operations.
-  - One or more `PAYMENT` operations withdrawing R's reserves from V, for each
-  trustline being removed from E that would have been used to sponsor claimable
-  balances at disbursement and are no longer required.
+  - One or more `CHANGE_TRUST` operations removing trustlines from EI.
+  - One or more `CHANGE_TRUST` operations removing trustlines from ER.
 
-##### Deposit by Initiator
+##### Deposit / Top-up
 
-Participant I may deposit into the channel without coordination with
-participant R, as long as escrow account E already has a trustline for the
-asset being deposited.
+Participants may deposit into the channel without coordination, as long as both
+escrow accounts EI and ER already have a trustline for the asset being
+deposited.
 
-If participant I wishes to deposit an asset that escrow account E does not hold
-a trustline for, the [Add Trustlines](#Add-Trustline) process must be used
+Participant I deposits or tops-up their balance by using a standard payment
+operation to EI.
+
+Participant R deposits or tops-up their balance by using a standard payment
+operation to ER.
+
+If participants wish to deposit an asset that escrow accounts EI or ER do not
+hold a trustline for, the [Add Trustlines](#Add-Trustline) process must be used
 first.
-
-##### Deposit by Responder
-
-Participant R may deposit into the channel without coordination with participant
-I, as long as escrow account E already has a trustline for the asset being
-deposited, and as long as participants R's intent is to make a payment of the
-same value to participant I. Any amounts deposited to the payment channel
-without coordination will be disbursable to participant I at close.
-
-Participant R must coordinate with participant I to deposit any amount that it
-does not intend to immediately pay participant I. The participants use the
-following process:
-
-1. Increment i.
-2. I and R build the deposit transaction P_i.
-3. Set e' to the value of e.
-4. Set e to i.
-5. Increment i.
-6. Sign and exchange a closing transaction C_i, that closes the channel with
-disbursements matching the most recent agreed state, but increasing R's
-disbursed amount by R's deposit amount.
-7. Sign and exchange a declaration transaction D_i.
-8. I and R sign and exchange signatures for deposit transaction P_i.
-9. I or R submit P.
-
-If the deposit transaction P fails or is never submitted, the C_i and D_i are
-not executable because escrow account E's sequence number was not bumped to s_i.
-The participants should take the following steps since the deposit did not
-succeed:
-
-10. Set e to the value of e'.
-
-The transactions are constructed as follows:
-
-- P_i, the _deposit transaction_, makes one or more payments from any Stellar
-accounts to escrow account E. P_i has any source account that is not E or V,
-typically the participant proposing the change.
-
-  P_i contains operations:
-
-  - One or more `PAYMENT` operations depositing assets into escrow account E.
-  - One `BUMP_SEQUENCE` operation bumping the sequence number of escrow account
-  E to s_i.
-  
-- C_i, see [Update](#Update) process.
-
-- D_i, see [Update](#Update) process.
 
 ##### Withdraw
 
@@ -501,7 +438,7 @@ amount by W's withdrawal amount.
 9. I or R submit W.
 
 If the withdrawal transaction W_i fails or is never submitted, the C_i and D_i
-are not executable because escrow account E's sequence number was not bumped to
+are not executable because escrow account EI's sequence number was not bumped to
 s_i.  The participants should take the following steps since the withdrawal did
 not succeed:
 
@@ -510,14 +447,15 @@ not succeed:
 The transactions are constructed as follows:
 
 - W_i, the _withdrawal transaction_, makes one or more payments from the escrow
-account E to any Stellar account. W_i has any source account that is not E or V,
-typically the participant proposing the change.
+account EI and/or ER to any Stellar account. W_i has any source account that is
+not EI, typically the participant proposing the change.
 
   W_i contains operations:
 
-  - One or more `PAYMENT` operations withdrawing assets from escrow account E.
+  - One or more `PAYMENT` operations withdrawing assets from escrow accounts EI
+  and/or ER.
   - One `BUMP_SEQUENCE` operation bumping the sequence number of escrow account
-  E to s_i.
+  EI to s_i.
   
 - C_i, see [Update](#Update) process.
 
@@ -552,8 +490,8 @@ disbursements matching the most recent agreed state.
 The transactions are constructed as follows:
 
 - B_i, the _bump transaction_, bumps the sequence number of escrow account E
-such that only the most recent transaction set is valid. B has source account E,
-sequence number s_i.
+such that only the most recent transaction set is valid. B has source account
+EI, sequence number s_i.
 
   B_i does not require any operations, but since Stellar disallows empty
   transactions, it contains a `BUMP_SEQUENCE` operation with sequence value 0 as
@@ -561,11 +499,11 @@ sequence number s_i.
 
 #### Reusing a Channel
 
-After close, escrow account E and reserve account V can be reused for another
-channel with the same or different participants. The relevant account creation
-steps during [Setup](#Setup) are skipped. All variable values from the closed
-channel are discarded and set anew with iteration number i and executed
-iteration number e being set to zero.
+After close, escrow accounts EI and ER can be reused for another channel with
+the same or different participants. The relevant account creation steps during
+[Setup](#Setup) are skipped. All variable values from the closed channel are
+discarded and set anew with iteration number i and executed iteration number e
+being set to zero.
 
 ### Network Transaction Fees
 
@@ -589,46 +527,39 @@ supplied by the participant who will be in control of the ledger entry at
 channel close.  Participants should have no impact or dependence on each other
 after channel close, and so they must not sponsor ledger entries that only the
 other party controls after channel close, either directly or indirectly through
-the escrow or reserve accounts.  For example, if the escrow account was to
-sponsor the creation of claimable balances at channel close, participant I would
-be unable to merge escrow account E until participant R claimed their claimable
-balances.
+the escrow or reserve accounts.
 
 Ledger entries that do not survive channel close, such as signers, are sponsored
 by their beneficiary.  Participants pay for their own key and signing
 requirements.
 
 Participant I provides reserves for:
-- Escrow account E
-- Trustlines added to E
-- Signers added to E for I
-- Signers added to V for I
+- Escrow account EI
+- Trustlines added to EI
+- Signers added to EI for I
+- Signers added to ER for I
 
 Participant R provides reserves for:
-- Signers added to E for R
-- Reserve account V
-- Signers added to V for R
-- Claimable balances created at close
+- Escrow account ER
+- Trustlines added to ER
+- Signers added to ER for R
+- Signers added to EI for R
 
 The total reserves required for each participant are:
 
 - Participant I
 
-  - 1 (Escrow Account E)
-  - \+ Number of Assets (for Trustlines)
+  - 1 (Escrow Account EI)
+  - \+ Number of Assets (for Trustlines on EI)
   - \+ 2 x Number of I's Signers
 
 - Participant R
 
-  - 1 (Reserve Account V)
-  - \+ Number of Assets (for Claimable Balances)
+  - 1 (Escrow Account ER)
+  - \+ Number of Assets (for Trustlines on ER)
   - \+ 2 x Number of R's Signers
 
-In the rare event that a network upgrade results in base reserve increasing, but
-participant R does not increase the funds in reserve account V to sufficiently
-cover the reserve cost, participant I may choose to deposit the amount of native
-asset necessary into reserve account V themselves, at some written-off cost to
-themselves.
+Changes in the networks base reserve do not impact the channel.
 
 ## Security Concerns
 
@@ -650,20 +581,17 @@ be valid and fail it would consume a sequence number and fair distribution of
 the assets within the escrow account would require the cooperation of all
 participants.
 
-If this protocol is not implemented correctly one condition that can result in
-the closing transaction failing is if there is not sufficient native asset to
-sponsor the ledger entries created by the transaction.  The closing transaction
-creates one or more new claimable balance ledger entries that each require
-sponsoring.  If the sponsor has insufficient native asset the closing
-transaction will fail.  To avoid this situation it is critical that participants
-lock sufficient funds up-front to provide the reserve, and that both
-participants monitor base reserve changes in the network and respond by adding
-additional native asset if required.
+A condition that can result in the closing transaction failing is if the payment
+operations between the escrow accounts are changed to pay out to some other
+accounts. If those other accounts do not exist, or some attribute of the
+accounts do not allow a payment to be received, then the payment operations may
+fail and as such a closing transaction containing a payment can fail.
 
 Another condition that can result in the closing transaction failing is if the
-use of claimable balances is replaced with payment operations. Payment
-operations may fail and as such a closing transaction containing a payment can
-fail.
+payment operations between the escrow accounts would exceed any limits either
+account has on making a payment, due to liabilities, or would exceed limits on
+the receiving account, such as a trustline limit. Participants must ensure that
+the payments they sign for a receivable by the escrow accounts.
 
 ## Limitations
 


### PR DESCRIPTION
### What
Make changes to the SEP so that it uses two escrow accounts and no claimable balances.

### Why
See stellar/stellar-protocol#938 for why.