### PR TITLE
specifications/sequence-diagrams: add withdraw seq diagram

### DIFF
--- a/specifications/sequence-diagrams/README.md
+++ b/specifications/sequence-diagrams/README.md
@@ -6,3 +6,6 @@ These sequence diagrams were created using the [mermaid diagram live editor](htt
 ## Diagrams
 [setup-update-close.txt](./setup-update-close.txt)
 - walks through the steps of the basic case for setting up a channel, updating it, and closing it either cooperatively or non-cooperatively
+
+[withdraw.txt](./withdraw.txt)
+- a withdrawal by I after setup and a single update

--- a/specifications/sequence-diagrams/withdraw.txt
+++ b/specifications/sequence-diagrams/withdraw.txt
@@ -28,4 +28,5 @@ sequenceDiagram
         I->>I: set e = e'
         R->>R: set e = e'
         Note right of R: e = 0
+        Note right of R: note: D_4.minSeq = s_3, with an unsuccessful W_3, <br> D_4 is impossible to submit successfully
     end

--- a/specifications/sequence-diagrams/withdraw.txt
+++ b/specifications/sequence-diagrams/withdraw.txt
@@ -1,0 +1,31 @@
+sequenceDiagram
+    participant I as Initiator
+    participant R as Responder
+    
+    Note over I,R: 1. Setup and a single update
+    Note right of R: i = 2, e = 0
+    Note left of I: EI.seqNum = 1000
+    
+    Note over I,R: 2. Withdrawal by I
+    I->>I: increment i
+    R->>R: increment i
+    Note right of R: i = 3
+    I->>R: create W_3, which has a payment op from EI to I, and bumps EI.seqNum to s_3
+    I->>I: increment i, set e' = e, set e = i
+    R->>R: increment i, set e' = e, set e = i
+    Note right of R: i = 4, e' = 0, e = 3
+    I->>R: create and sign C_4, which has the last agreed upon payouts minus I's payout from W_3
+    R-->>I: sign C_4, send back
+    I->>R: create and sign D_4
+    R-->>I: sign D_4, send back
+    R->>I: sign W_4
+    I->>I: submit W_4
+
+    alt W_4 successful
+        Note right of R: withdrawal complete
+        Note left of I: EI.seqNum = 1007
+    else W_4 unsuccessful
+        I->>I: set e = e'
+        R->>R: set e = e'
+        Note right of R: e = 0
+    end

--- a/specifications/sequence-diagrams/withdraw.txt
+++ b/specifications/sequence-diagrams/withdraw.txt
@@ -1,19 +1,19 @@
 sequenceDiagram
     participant I as Initiator
     participant R as Responder
-    
+
     Note over I,R: 1. Setup and a single update
     Note right of R: i = 2, e = 0
     Note left of I: EI.seqNum = 1000
-    
+
     Note over I,R: 2. Withdrawal by I
     I->>I: increment i
     R->>R: increment i
     Note right of R: i = 3
     I->>R: create W_3, which has a payment op from EI to I, and bumps EI.seqNum to s_3
-    I->>I: increment i, set e' = e, set e = i
-    R->>R: increment i, set e' = e, set e = i
-    Note right of R: i = 4, e' = 0, e = 3
+    I->>I: set e' = e, set e = i, then increment i
+    R->>R: set e' = e, set e = i, then increment i
+    Note right of R: e' = 0, e = 3, i = 4
     I->>R: create and sign C_4, which has the last agreed upon payouts minus I's payout from W_3
     R-->>I: sign C_4, send back
     I->>R: create and sign D_4


### PR DESCRIPTION
adds a sequence diagram going through the [withdrawal steps](https://github.com/stellar/experimental-payment-channels/blob/main/specifications/sep-payment-channel-mechanism.md#withdraw) of the payment channel SEP