### PR TITLE
SEP: Add security sections about auth required and clawback

### DIFF
--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -575,7 +575,8 @@ possible without the participants coordinating.
 
 The closing transaction, C_i, must never fail.  Under the conditions of the
 Stellar Consensus Protocol as it is defined today, and under correct use of this
-protocol, there is no known conditions that will cause it to fail.  It will be
+protocol, and assuming no changes in the authorized state of the channels
+trustlines, there is no known conditions that will cause it to fail.  It will be
 either invalid or valid and successful, but not valid and failed.  If C_i was to
 be valid and fail it would consume a sequence number and fair distribution of
 the assets within the escrow account would require the cooperation of all
@@ -593,7 +594,7 @@ account has on making a payment, due to liabilities, or would exceed limits on
 the receiving account, such as a trustline limit. Participants must ensure that
 the payments they sign for are receivable by the escrow accounts.
 
-### Auth Required
+### Trustline Authorization
 
 Any trustlines on the escrow accounts that have been auth revoked, or could be
 auth revoked, could compromise the payment channels ability to close
@@ -603,7 +604,7 @@ If the issuer of any auth revocable asset submits an allow trust operation
 freezing the amounts in either escrow account, the close transaction may fail to
 process if its payment operations are dependent on amounts frozen.
 
-There is nothing participants can do to prevent this, other than only using auth
+There is nothing participants can do to prevent this, other than using only auth
 immutable assets.
 
 ### Clawback

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -593,6 +593,36 @@ account has on making a payment, due to liabilities, or would exceed limits on
 the receiving account, such as a trustline limit. Participants must ensure that
 the payments they sign for are receivable by the escrow accounts.
 
+### Auth Required
+
+Any trustlines on the escrow accounts that have been auth revoked, or could be
+auth revoked, could compromise the payment channels ability to close
+successfully.
+
+If the issuer of any auth revocable asset submits an allow trust operation
+freezing the amounts in either escrow account, the close transaction may fail to
+process if its payment operations are dependent on amounts frozen.
+
+There is nothing participants can do to prevent this, other than only using auth
+immutable assets.
+
+### Clawback
+
+Any trustlines on the escrow accounts that have clawback enabled could
+compromise the payment channels ability to close successfully.
+
+If the issuer of any clawback enabled trustline submits a clawback operation for
+amounts in either escrow account, the close transaction may fail to process if
+its payment operations are dependent on amounts clawed back.
+
+Participants can inspect the state of trustlines before and after formation to
+check if either participant has clawback enabled. Checking the state after
+formation is critical because there is no way for participants to guarantee
+trustline state until after formation has completed because the state can change
+prior to formation. For this reason participants should perform their initial
+deposit after formation, unless they trust the asset issuer not to clawback from
+payment channel escrow accounts, or unless the asset is auth immutable. 
+
 ## Limitations
 
 This protocol defines the mechanisms of the Stellar network's core protocol that


### PR DESCRIPTION
### What
Add two sections about auth required and clawback and how they can be security concerns.

### Why
Both seems like relatively important topics to discuss. The choice of assets used in the payment channel can compromise the entire payment channel, not just the portion of the channel using that asset.

cc @stanford-scs 