### PR TITLE
Add note about Go SDK fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The forks may not be exactly the same as the CAP as shortcuts may have been take
 
 - xdr: https://github.com/leighmcculloch/stellar--stellar-core/tree/cap21/src/xdr
 - stellar-core: https://github.com/leighmcculloch/stellar--stellar-core/pull/1
-- horizon: https://github.com/stellar/go/pull/3546
+- horizon & Go SDK: https://github.com/stellar/go/pull/3546
 - quickstart: https://github.com/leighmcculloch/stellar--docker-stellar-core-horizon/pull/1
 - stc: https://github.com/leighmcculloch/xdrpp--stc/pull/1
 


### PR DESCRIPTION
### What
Add note to README indicating that the Go SDK fork is in the same place as the Horizon fork.

### Why
It isn't clear to others where it lived.