### PR TITLE
in formation transaction ensure other party is signer and weight of 1

### DIFF
--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -31,6 +31,10 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		HighThreshold:   txnbuild.NewThreshold(2),
 		Signer:          &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
 	})
+	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
+		SourceAccount: p.InitiatorEscrow.Address(),
+		Signer:        &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
+	})
 	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.InitiatorEscrow.Address()})
 	tp.Operations = append(tp.Operations, &txnbuild.BeginSponsoringFutureReserves{SourceAccount: p.ResponderSigner.Address(), SponsoredID: p.ResponderEscrow.Address()})
 	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
@@ -40,6 +44,10 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		MediumThreshold: txnbuild.NewThreshold(2),
 		HighThreshold:   txnbuild.NewThreshold(2),
 		Signer:          &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
+	})
+	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
+		SourceAccount: p.ResponderEscrow.Address(),
+		Signer:        &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
 	})
 	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.ResponderEscrow.Address()})
 	tx, err := txnbuild.NewTransaction(tp)

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -194,7 +194,7 @@ multisig accounts. F has source account E, and sequence number set to s.
     - One or more `CHANGE_TRUST` operations configuring trustlines on EI.
     - One `SET_OPTIONS` operation adjusting escrow account EI's thresholds such
     that I and R's signers must both sign.
-    - One or more `SET_OPTIONS` operations adding I and R's signers to ER with equal weight.
+    - One or more `SET_OPTIONS` operations adding I and R's signers to ER.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops I sponsoring
     future reserves of subsequent operations.
   - Operations sponsored by R:
@@ -203,7 +203,7 @@ multisig accounts. F has source account E, and sequence number set to s.
     - One or more `CHANGE_TRUST` operations configuring trustlines on ER.
     - One `SET_OPTIONS` operations adjusting escrow account ER's thresholds such
     that R and I's signers must both sign.
-    - One or more `SET_OPTIONS` operations adding I and R's signers to EI with equal weight.
+    - One or more `SET_OPTIONS` operations adding I and R's signers to EI.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops R sponsoring
     future reserves of subsequent operations.
   

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -194,7 +194,7 @@ multisig accounts. F has source account E, and sequence number set to s.
     - One or more `CHANGE_TRUST` operations configuring trustlines on EI.
     - One `SET_OPTIONS` operation adjusting escrow account EI's thresholds such
     that I and R's signers must both sign.
-    - One or more `SET_OPTIONS` operations adding I's signers to ER.
+    - One or more `SET_OPTIONS` operations adding I and R as equal signers to ER.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops I sponsoring
     future reserves of subsequent operations.
   - Operations sponsored by R:
@@ -203,7 +203,7 @@ multisig accounts. F has source account E, and sequence number set to s.
     - One or more `CHANGE_TRUST` operations configuring trustlines on ER.
     - One `SET_OPTIONS` operations adjusting escrow account ER's thresholds such
     that R and I's signers must both sign.
-    - One or more `SET_OPTIONS` operations adding R's signers to EI.
+    - One or more `SET_OPTIONS` operations adding I and R as equal signers to EI.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops R sponsoring
     future reserves of subsequent operations.
   

--- a/specifications/sep-payment-channel-mechanism.md
+++ b/specifications/sep-payment-channel-mechanism.md
@@ -194,7 +194,7 @@ multisig accounts. F has source account E, and sequence number set to s.
     - One or more `CHANGE_TRUST` operations configuring trustlines on EI.
     - One `SET_OPTIONS` operation adjusting escrow account EI's thresholds such
     that I and R's signers must both sign.
-    - One or more `SET_OPTIONS` operations adding I and R as equal signers to ER.
+    - One or more `SET_OPTIONS` operations adding I and R's signers to ER with equal weight.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops I sponsoring
     future reserves of subsequent operations.
   - Operations sponsored by R:
@@ -203,7 +203,7 @@ multisig accounts. F has source account E, and sequence number set to s.
     - One or more `CHANGE_TRUST` operations configuring trustlines on ER.
     - One `SET_OPTIONS` operations adjusting escrow account ER's thresholds such
     that R and I's signers must both sign.
-    - One or more `SET_OPTIONS` operations adding I and R as equal signers to EI.
+    - One or more `SET_OPTIONS` operations adding I and R's signers to EI with equal weight.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops R sponsoring
     future reserves of subsequent operations.
   


### PR DESCRIPTION
ensure the other party is a signer and has an equal weight for each escrow account. This ensures the Escrow account is in the right state for the channel, w/o relying on the other party to do it correctly themselves