### PR TITLE
sdk: use fee bumps

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,7 +2,7 @@ module github.com/stellar/experimental-payment-channels/sdk
 
 go 1.16
 
-replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20210514225055-eafef939d8d2
+replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20210521212547-6e7c3ba30f97
 
 require (
 	github.com/stellar/go v0.0.0-00010101000000-000000000000

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -50,6 +50,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-querystring v0.0.0-20160401233042-9235644dd9e5 h1:oERTZ1buOUYlpmKaqlO5fYmz8cZ1rYu5DieJzF4ZVmU=
 github.com/google/go-querystring v0.0.0-20160401233042-9235644dd9e5/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
@@ -87,8 +88,8 @@ github.com/kr/pretty v0.0.0-20150520163514-e6ac2fc51e89/go.mod h1:Bvhd+E3laJ0AVk
 github.com/kr/text v0.0.0-20150520163712-e373e137fafd h1:ohpc+F5FseC/PPrR1wz2WcZxOc4kplnJ39pGbFlj/eY=
 github.com/kr/text v0.0.0-20150520163712-e373e137fafd/go.mod h1:sjUstKUATFIcff4qlB53Kml0wQPtJVc/3fWrmuUmcfA=
 github.com/lann/builder v0.0.0-20140829050551-c603884a2c1f/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
-github.com/leighmcculloch/stellar--go v0.0.0-20210514225055-eafef939d8d2 h1:ro4YA+63FIZB7OYuyzSyd0n4jwX2gEGZtfKG0psjiXQ=
-github.com/leighmcculloch/stellar--go v0.0.0-20210514225055-eafef939d8d2/go.mod h1:m5Azd56FGZT/mnjlZE9i68+nxm/6b6YOg0kP99aBDi4=
+github.com/leighmcculloch/stellar--go v0.0.0-20210521212547-6e7c3ba30f97 h1:VFrUXbrayMXIaTWIlEWlevwzC+El6940SYZdhwoboas=
+github.com/leighmcculloch/stellar--go v0.0.0-20210521212547-6e7c3ba30f97/go.mod h1:1A0CTcMznKMFvMUikXykmoecbVX6YEJksvSm2JXFP4A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -113,6 +114,7 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/pelletier/go-toml v1.9.0/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/sdk/txbuild/close.go
+++ b/sdk/txbuild/close.go
@@ -27,7 +27,7 @@ func Close(p CloseParams) (*txnbuild.Transaction, error) {
 			AccountID: p.InitiatorEscrow.Address(),
 			Sequence:  startSequenceOfIteration(p.StartSequence, p.IterationNumber) + 1, // Close is the second transaction in an iteration's transaction set.
 		},
-		BaseFee:              txnbuild.MinBaseFee,
+		BaseFee:              0,
 		Timebounds:           txnbuild.NewTimeout(300),
 		MinSequenceAge:       int64(p.ObservationPeriodTime.Seconds()),
 		MinSequenceLedgerGap: p.ObservationPeriodLedgerGap,

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -20,7 +20,7 @@ func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
 				AccountID: p.Creator.Address(),
 				Sequence:  p.SequenceNumber,
 			},
-			BaseFee:              txnbuild.MinBaseFee,
+			BaseFee:              0,
 			Timebounds:           txnbuild.NewTimeout(300),
 			Operations: []txnbuild.Operation{
 				&txnbuild.BeginSponsoringFutureReserves{

--- a/sdk/txbuild/declaration.go
+++ b/sdk/txbuild/declaration.go
@@ -19,7 +19,7 @@ func Declaration(p DeclarationParams) (*txnbuild.Transaction, error) {
 			AccountID: p.InitiatorEscrow.Address(),
 			Sequence:  startSequenceOfIteration(p.StartSequence, p.IterationNumber) + 0, // Declaration is the first transaction in an iteration's transaction set.
 		},
-		BaseFee:           txnbuild.MinBaseFee,
+		BaseFee:           0,
 		Timebounds:        txnbuild.NewTimeout(300),
 		MinSequenceNumber: &minSequenceNumber,
 		Operations: []txnbuild.Operation{

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -19,7 +19,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 			AccountID: p.InitiatorEscrow.Address(),
 			Sequence:  p.StartSequence,
 		},
-		BaseFee:    txnbuild.MinBaseFee,
+		BaseFee:    0,
 		Timebounds: txnbuild.NewTimeout(300),
 	}
 	tp.Operations = append(tp.Operations, &txnbuild.BeginSponsoringFutureReserves{SourceAccount: p.InitiatorSigner.Address(), SponsoredID: p.InitiatorEscrow.Address()})


### PR DESCRIPTION
### What
Set the fee to zero in txbuild built transactions, and require the use of fee bumps by a participant when submitting a tx.

### Why
The SEP specifies that fee bumps should be used. The reason is to keep the balances of the escrow accounts unaffected be fees which makes accounting simpler.

Close #36