### PR TITLE
readme: add extraSigners to list of CAP-21 preconditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The forks may not be exactly the same as the CAP as shortcuts may have been take
 - [x] `minSeqNum`
 - [x] `minSeqAge`
 - [x] `minSeqLedgerGap`
+- [ ] `extraSigners`
 
 - xdr: https://github.com/leighmcculloch/stellar--stellar-core/tree/cap21/src/xdr
 - stellar-core: https://github.com/leighmcculloch/stellar--stellar-core/pull/1


### PR DESCRIPTION
### What
Add the `extraSigners` precondition to the list of CAP-21 preconditions in the README that are not implemented in the forks.

### Why
The `extraSigners` precondition was added to CAP-21, and wasn't included in the list here. Adding to the list in the README so it is clear whether that precondition is currently implemented in the forks and in the channels implemented in this repo at this moment.