### PR TITLE
sep: rename sep to scope to transactions

### DIFF
--- a/specifications/sep-payment-channel-transactions.md
+++ b/specifications/sep-payment-channel-transactions.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: ????
-Title: Payment Channel
+Title: Payment Channel Transactions
 Author: David Mazières <@standford-scs>, Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft


### PR DESCRIPTION
### What
Rename the SEP title so as to scope the SEP to specifying the transactions and how they are used.

### Why
We will no doubt write other SEPs that discuss coordination, networking, messaging, or refer to other external specifications for those things. It is helpful to scope this SEP from the get-go so it is clear what its current scope is.