### PR TITLE
sdk: add helper sign and verify funcs and use local/remote terms

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,7 +2,7 @@ module github.com/stellar/experimental-payment-channels/sdk
 
 go 1.16
 
-replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20210521212547-6e7c3ba30f97
+replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20210527221449-1306fe7becec
 
 require (
 	github.com/stellar/go v0.0.0-00010101000000-000000000000

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -88,8 +88,8 @@ github.com/kr/pretty v0.0.0-20150520163514-e6ac2fc51e89/go.mod h1:Bvhd+E3laJ0AVk
 github.com/kr/text v0.0.0-20150520163712-e373e137fafd h1:ohpc+F5FseC/PPrR1wz2WcZxOc4kplnJ39pGbFlj/eY=
 github.com/kr/text v0.0.0-20150520163712-e373e137fafd/go.mod h1:sjUstKUATFIcff4qlB53Kml0wQPtJVc/3fWrmuUmcfA=
 github.com/lann/builder v0.0.0-20140829050551-c603884a2c1f/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
-github.com/leighmcculloch/stellar--go v0.0.0-20210521212547-6e7c3ba30f97 h1:VFrUXbrayMXIaTWIlEWlevwzC+El6940SYZdhwoboas=
-github.com/leighmcculloch/stellar--go v0.0.0-20210521212547-6e7c3ba30f97/go.mod h1:1A0CTcMznKMFvMUikXykmoecbVX6YEJksvSm2JXFP4A=
+github.com/leighmcculloch/stellar--go v0.0.0-20210527221449-1306fe7becec h1:ibW/YR6Tt951urvgS6SMjmDiVjLNFWxySrizTczSdhA=
+github.com/leighmcculloch/stellar--go v0.0.0-20210527221449-1306fe7becec/go.mod h1:1A0CTcMznKMFvMUikXykmoecbVX6YEJksvSm2JXFP4A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -1,48 +1,144 @@
 package state
 
 import (
+	"encoding/hex"
+	"time"
+
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
 )
 
-type Asset = txnbuild.Asset
-
-type ChannelStatus string
-
-const (
-	ChannelStatusInitialized = ChannelStatus("initialized")
-	ChannelStatusOpen        = ChannelStatus("open")
-	ChannelStatusOpenWaiting = ChannelStatus("open_waiting")
-	ChannelStatusOpenClosing = ChannelStatus("closing")
-	ChannelStatusClosed      = ChannelStatus("closed")
+type (
+	Asset       = txnbuild.Asset
+	NativeAsset = txnbuild.NativeAsset
+	CreditAsset = txnbuild.CreditAsset
 )
+
+type Amount struct {
+	Asset  Asset
+	Amount int64
+}
+
+type EscrowAccount struct {
+	Address        *keypair.FromAddress
+	SequenceNumber int64
+	Balances       []Amount
+}
 
 type Channel struct {
-	Status ChannelStatus
+	networkPassphrase          string
+	observationPeriodTime      time.Duration
+	observationPeriodLedgerGap int64
 
-	Initiator              bool
-	InitiatorEscrowAccount *keypair.FromAddress
-	ResponderEscrowAccount *keypair.FromAddress
+	startingSequence int64
+	// TODO: balances         []Amount
 
-	// The balance owing from the initiator to the responder, if positive, or
-	// the balance owing from the responder to the initiator, if negative.
-	Balance int64
-	Asset   Asset
+	initiator           bool
+	localEscrowAccount  *EscrowAccount
+	remoteEscrowAccount *EscrowAccount
+
+	localSigner  *keypair.Full
+	remoteSigner *keypair.FromAddress
 }
 
-type Config struct{}
+type Config struct {
+	NetworkPassphrase          string
+	ObservationPeriodTime      time.Duration
+	ObservationPeriodLedgerGap int64
+
+	Initiator bool
+
+	LocalEscrowAccount  *EscrowAccount
+	RemoteEscrowAccount *EscrowAccount
+
+	LocalSigner  *keypair.Full
+	RemoteSigner *keypair.FromAddress
+}
 
 func NewChannel(c Config) *Channel {
-	return nil
+	channel := &Channel{
+		networkPassphrase:          c.NetworkPassphrase,
+		observationPeriodTime:      c.ObservationPeriodTime,
+		observationPeriodLedgerGap: c.ObservationPeriodLedgerGap,
+		initiator:                  c.Initiator,
+		localEscrowAccount:         c.LocalEscrowAccount,
+		remoteEscrowAccount:        c.RemoteEscrowAccount,
+		localSigner:                c.LocalSigner,
+		remoteSigner:               c.RemoteSigner,
+	}
+	return channel
 }
 
-// Open handles the logic for opening a channel. This includes the Formation Transaction, C_1, and D_1.
-func (c *Channel) Open() error {
-	return nil
+func (c *Channel) initiatorEscrowAccount() *EscrowAccount {
+	if c.initiator {
+		return c.localEscrowAccount
+	} else {
+		return c.remoteEscrowAccount
+	}
 }
 
-func (c *Channel) CheckNetwork() error {
-	return nil
+func (c *Channel) responderEscrowAccount() *EscrowAccount {
+	if c.initiator {
+		return c.remoteEscrowAccount
+	} else {
+		return c.localEscrowAccount
+	}
+}
+
+func (c *Channel) initiatorSigner() *keypair.FromAddress {
+	if c.initiator {
+		return c.localSigner.FromAddress()
+	} else {
+		return c.remoteSigner
+	}
+}
+
+func (c *Channel) responderSigner() *keypair.FromAddress {
+	if c.initiator {
+		return c.remoteSigner
+	} else {
+		return c.localSigner.FromAddress()
+	}
+}
+
+func (c *Channel) sign(tx *txnbuild.Transaction) (xdr.DecoratedSignature, error) {
+	hash, err := tx.Hash(c.networkPassphrase)
+	if err != nil {
+		return xdr.DecoratedSignature{}, err
+	}
+	sig, err := c.localSigner.SignDecorated(hash[:])
+	if err != nil {
+		return xdr.DecoratedSignature{}, err
+	}
+	return sig, nil
+}
+
+type errNotSigned struct {
+	hash   string
+	signer string
+}
+
+func (e errNotSigned) Error() string { return "tx " + e.hash + " not signed by signer " + e.signer }
+
+func (c *Channel) verifySigned(tx *txnbuild.Transaction, sigs []xdr.DecoratedSignature, signer keypair.KP) error {
+	hash, err := tx.Hash(c.networkPassphrase)
+	if err != nil {
+		return err
+	}
+	for _, sig := range sigs {
+		if sig.Hint != signer.Hint() {
+			continue
+		}
+		err := signer.Verify(hash[:], sig.Signature)
+		if err == nil {
+			return nil
+		}
+	}
+	return errNotSigned{
+		hash:   hex.EncodeToString(hash[:]),
+		signer: signer.Address(),
+	}
 }
 
 func (c *Channel) Payment(sendAmount int) error {
@@ -97,5 +193,3 @@ type ChannelCheckResponse struct {
 	TriggeredTxInfo TxInfo
 	LatestTxInfo    TxInfo
 }
-
-type EscrowAccount struct{}


### PR DESCRIPTION
### What
Add helpers for signing and verification, and switches to storing internals of the channel state in the form of local/remote, and adds helper functions for getting at that data from the initiator/responder viewpoint.

### Why
This is a break out of some functionality in #52 that @acharb will probably be able to use while working on #46.

The reason to change the internals to be local/remote focused instead of initiator/responder is because signing keys will be different types for local vs remote, since the local will be a full key and remote will be only an address. So, this keeps all the internals in local/remote perspective.