### PR TITLE
sdk: store lastPayment on channel  and evaluate balance from there 

### DIFF
--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -81,9 +81,9 @@ func (c *Channel) SetIterationNumber(i int64) {
 	c.iterationNumber = i
 }
 
-// Amount returns the amount owing from the initiator to the responder, if positive, or
+// Balance returns the amount owing from the initiator to the responder, if positive, or
 // the amount owing from the responder to the initiator, if negative.
-func (c *Channel) Amount() Amount {
+func (c *Channel) Balance() Amount {
 	if c.lastConfirmedPayment == nil {
 		return Amount{NativeAsset{}, 0}
 	}

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -36,17 +36,16 @@ type Channel struct {
 	// TODO - leave execution out for now
 	// iterationNumberExecuted int64
 
-	// The balance owing from the initiator to the responder, if positive, or
-	// the balance owing from the responder to the initiator, if negative.
-	// TODO - use Balance struct
-	amount Amount
-
 	initiator           bool
 	localEscrowAccount  *EscrowAccount
 	remoteEscrowAccount *EscrowAccount
 
 	localSigner  *keypair.Full
 	remoteSigner *keypair.FromAddress
+
+	lastConfirmedPayment *Payment
+	// TODO - need to store this too?
+	// lastUnConfirmedPayment *Payment
 }
 
 type Config struct {
@@ -82,9 +81,13 @@ func (c *Channel) SetIterationNumber(i int64) {
 	c.iterationNumber = i
 }
 
-// TODO: Remove
+// Amount returns the amount owing from the initiator to the responder, if positive, or
+// the amount owing from the responder to the initiator, if negative.
 func (c *Channel) Amount() Amount {
-	return c.amount
+	if c.lastConfirmedPayment == nil {
+		return Amount{NativeAsset{}, 0}
+	}
+	return c.lastConfirmedPayment.NewBalance
 }
 
 func (c *Channel) initiatorEscrowAccount() *EscrowAccount {

--- a/sdk/state/state_test.go
+++ b/sdk/state/state_test.go
@@ -3,7 +3,6 @@ package state_test
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -255,9 +254,7 @@ func Test(t *testing.T) {
 
 		//// Sender: creates new Payment, sends to other party
 		sendingChannel.SetIterationNumber(i)
-		payment, err := sendingChannel.ProposePayment(amount)
-		require.NoError(t, err)
-		j, err := json.Marshal(payment)
+		payment, err := sendingChannel.ProposePayment(state.Amount{Asset: state.NativeAsset{}, Amount: amount})
 		require.NoError(t, err)
 
 		ci, di, err := sendingChannel.PaymentTxs(payment)
@@ -265,19 +262,10 @@ func Test(t *testing.T) {
 
 		//// Receiver: receives new payment proposal, validates, then confirms by signing both
 		receivingChannel.SetIterationNumber(i)
-		payment = &state.Payment{}
-		err = json.Unmarshal(j, payment)
-		require.NoError(t, err)
-
 		payment, err = receivingChannel.ConfirmPayment(payment)
-		require.NoError(t, err)
-		j, err = json.Marshal(payment)
 		require.NoError(t, err)
 
 		//// Sender: re-confirms P_i by signing D_i and sending back
-		payment = &state.Payment{}
-		err = json.Unmarshal(j, payment)
-		require.NoError(t, err)
 		payment, err = sendingChannel.ConfirmPayment(payment)
 		require.NoError(t, err)
 

--- a/sdk/state/state_test.go
+++ b/sdk/state/state_test.go
@@ -249,7 +249,7 @@ func Test(t *testing.T) {
 			rBalanceCheck -= amount
 			iBalanceCheck += amount
 		}
-		t.Log("Current channel balances: I: ", initiatorChannel.Amount().Amount/1_000_0000, "R: ", responderChannel.Amount().Amount/1_000_0000)
+		t.Log("Current channel balances: I: ", initiatorChannel.Balance().Amount/1_000_0000, "R: ", responderChannel.Balance().Amount/1_000_0000)
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		//// Sender: creates new Payment, sends to other party

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -119,8 +119,8 @@ func (c *Channel) ConfirmPayment(p *Payment) (*Payment, error) {
 		}
 	}
 
-	p.CloseSignatures = append(p.CloseSignatures, txC.Signatures()...)
-	p.DeclarationSignatures = append(p.DeclarationSignatures, txD.Signatures()...)
+	p.CloseSignatures = append(p.CloseSignatures, txClose.Signatures()...)
+	p.DeclarationSignatures = append(p.DeclarationSignatures, txDecl.Signatures()...)
 	c.lastConfirmedPayment = p
 	return p, nil
 }

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -24,9 +24,9 @@ func (c *Channel) ProposePayment(amount Amount) (*Payment, error) {
 	}
 	newBalance := int64(0)
 	if c.initiator {
-		newBalance = c.Amount().Amount + amount.Amount
+		newBalance = c.Balance().Amount + amount.Amount
 	} else {
-		newBalance = c.Amount().Amount - amount.Amount
+		newBalance = c.Balance().Amount - amount.Amount
 	}
 	txClose, err := txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      c.observationPeriodTime,
@@ -66,7 +66,7 @@ func (c *Channel) PaymentTxs(p *Payment) (close, decl *txnbuild.Transaction, err
 	} else {
 		amountFromResponder = p.Amount.Amount
 	}
-	newBalance := c.Amount().Amount + amountFromInitiator - amountFromResponder
+	newBalance := c.Balance().Amount + amountFromInitiator - amountFromResponder
 	close, err = txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      c.observationPeriodTime,
 		ObservationPeriodLedgerGap: c.observationPeriodLedgerGap,

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -11,21 +11,22 @@ import (
 
 type Payment struct {
 	IterationNumber       int64
-	Amount                int64
+	Amount                Amount
 	CloseSignatures       []xdr.DecoratedSignature
 	DeclarationSignatures []xdr.DecoratedSignature
 	FromInitiator         bool
+	NewBalance            Amount
 }
 
-func (c *Channel) ProposePayment(amount int64) (*Payment, error) {
-	if amount <= 0 {
+func (c *Channel) ProposePayment(amount Amount) (*Payment, error) {
+	if amount.Amount <= 0 {
 		return nil, errors.New("payment amount must be greater than 0")
 	}
 	newBalance := int64(0)
 	if c.initiator {
-		newBalance = c.amount.Amount + amount
+		newBalance = c.Amount().Amount + amount.Amount
 	} else {
-		newBalance = c.amount.Amount - amount
+		newBalance = c.Amount().Amount - amount.Amount
 	}
 	txC, err := txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      c.observationPeriodTime,
@@ -46,21 +47,26 @@ func (c *Channel) ProposePayment(amount int64) (*Payment, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Payment{
+	p := &Payment{
 		Amount:          amount,
 		CloseSignatures: txC.Signatures(),
 		FromInitiator:   c.initiator,
-	}, nil
+		NewBalance: Amount{
+			Asset:  amount.Asset,
+			Amount: newBalance,
+		},
+	}
+	return p, nil
 }
 
 func (c *Channel) PaymentTxs(p *Payment) (close, decl *txnbuild.Transaction, err error) {
 	var amountFromInitiator, amountFromResponder int64
 	if p.FromInitiator {
-		amountFromInitiator = p.Amount
+		amountFromInitiator = p.Amount.Amount
 	} else {
-		amountFromResponder = p.Amount
+		amountFromResponder = p.Amount.Amount
 	}
-	newBalance := c.amount.Amount + amountFromInitiator - amountFromResponder
+	newBalance := c.Amount().Amount + amountFromInitiator - amountFromResponder
 	close, err = txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      c.observationPeriodTime,
 		ObservationPeriodLedgerGap: c.observationPeriodLedgerGap,
@@ -89,24 +95,14 @@ func (c *Channel) PaymentTxs(p *Payment) (close, decl *txnbuild.Transaction, err
 }
 
 func (c *Channel) ConfirmPayment(p *Payment) (*Payment, error) {
-	var amountFromInitiator, amountFromResponder int64
-	if p.FromInitiator {
-		amountFromInitiator = p.Amount
-	} else {
-		amountFromResponder = p.Amount
-	}
-	newBalance := c.amount.Amount + amountFromInitiator - amountFromResponder
-
 	txC, txD, err := c.PaymentTxs(p)
 	if err != nil {
 		return nil, err
 	}
-
 	// If remote has not signed close, error as is invalid.
 	if err := c.verifySigned(txC, p.CloseSignatures, c.remoteSigner); err != nil {
 		return nil, fmt.Errorf("incorrect closing transaction, the one given may have different data: %w", err)
 	}
-
 	// If local has not signed close, sign.
 	if err := c.verifySigned(txC, p.CloseSignatures, c.localSigner); err != nil {
 		// TODO - differentiate between wrong signature and missing one
@@ -115,7 +111,6 @@ func (c *Channel) ConfirmPayment(p *Payment) (*Payment, error) {
 			return nil, err
 		}
 	}
-
 	// Local should always sign declaration if have not yet.
 	if err := c.verifySigned(txD, p.DeclarationSignatures, c.localSigner); err != nil {
 		txD, err = txD.Sign(c.networkPassphrase, c.localSigner)
@@ -123,10 +118,9 @@ func (c *Channel) ConfirmPayment(p *Payment) (*Payment, error) {
 			return nil, err
 		}
 	}
-
 	p.CloseSignatures = append(p.CloseSignatures, txC.Signatures()...)
 	p.DeclarationSignatures = append(p.DeclarationSignatures, txD.Signatures()...)
-	c.amount.Amount = newBalance
+	c.lastConfirmedPayment = p
 	return p, nil
 }
 


### PR DESCRIPTION
store the lastConfirmedPayment on the channel, and evaluate balances based off of that payment

also, removes the json marshalling/unmarshalling from the test to simulate the handoff. More trouble than it's worth



fulfills part of https://github.com/stellar/experimental-payment-channels/issues/63, but not the iteration part. Going to do that in separate PR