### PR TITLE
sdk/state: add fully signed param to confirm functions

### DIFF
--- a/sdk/state/state_open.go
+++ b/sdk/state/state_open.go
@@ -83,18 +83,21 @@ func (c *Channel) ProposeOpen() (Open, error) {
 //
 // If there are close, declaration, and formation signatures for all
 // participants, the channel will be considered open.
-func (c *Channel) ConfirmOpen(m Open) (Open, error) {
+//
+// If after confirming the open has all the signatures it needs to be fully and
+// completely signed, fully signed will be true, otherwise it will be false.
+func (c *Channel) ConfirmOpen(m Open) (open Open, fullySigned bool, err error) {
 	c.startingSequence = c.initiatorEscrowAccount().SequenceNumber + 1
 
 	txClose, txDecl, formation, err := c.OpenTxs()
 	if err != nil {
-		return m, err
+		return m, fullySigned, err
 	}
 
 	// If remote has not signed close, error as is invalid.
 	err = c.verifySigned(txClose, m.CloseSignatures, c.remoteSigner)
 	if err != nil {
-		return m, fmt.Errorf("open confirm: close invalid %w", err)
+		return m, fullySigned, fmt.Errorf("open confirm: close invalid %w", err)
 	}
 
 	// If local has not signed close, sign it.
@@ -102,11 +105,11 @@ func (c *Channel) ConfirmOpen(m Open) (Open, error) {
 	if errors.Is(err, ErrNotSigned{}) {
 		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return m, fmt.Errorf("open confirm: close incomplete: %w", err)
+			return m, fullySigned, fmt.Errorf("open confirm: close incomplete: %w", err)
 		}
 		m.CloseSignatures = append(m.CloseSignatures, txClose.Signatures()...)
 	} else if err != nil {
-		return m, fmt.Errorf("open confirm: close error: %w", err)
+		return m, fullySigned, fmt.Errorf("open confirm: close error: %w", err)
 	}
 
 	// If local has not signed declaration, sign it.
@@ -114,17 +117,17 @@ func (c *Channel) ConfirmOpen(m Open) (Open, error) {
 	if errors.Is(err, ErrNotSigned{}) {
 		txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return m, fmt.Errorf("open confirm: decl %w", err)
+			return m, fullySigned, fmt.Errorf("open confirm: decl %w", err)
 		}
 		m.DeclarationSignatures = append(m.DeclarationSignatures, txDecl.Signatures()...)
 	} else if err != nil {
-		return m, fmt.Errorf("open confirm: decl incomplete: %w", err)
+		return m, fullySigned, fmt.Errorf("open confirm: decl incomplete: %w", err)
 	}
 
-	// If remote has not signed declaration, error as is incomplete.
+	// If remote has not signed declaration, don't perform any others signing.
 	err = c.verifySigned(txDecl, m.DeclarationSignatures, c.remoteSigner)
 	if err != nil {
-		return m, fmt.Errorf("open confirm: decl incomplete: %w", err)
+		return m, fullySigned, nil
 	}
 
 	// If local has not signed formation, sign it.
@@ -132,20 +135,24 @@ func (c *Channel) ConfirmOpen(m Open) (Open, error) {
 	if errors.Is(err, ErrNotSigned{}) {
 		formation, err = formation.Sign(c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return m, fmt.Errorf("open confirm: formation local error %w", err)
+			return m, fullySigned, fmt.Errorf("open confirm: formation local error %w", err)
 		}
 		m.FormationSignatures = append(m.FormationSignatures, formation.Signatures()...)
 	} else if err != nil {
-		return m, fmt.Errorf("open confirm: formation local %w", err)
+		return m, fullySigned, fmt.Errorf("open confirm: formation local %w", err)
 	}
 
 	// If remote has not signed formation, error as is incomplete.
 	err = c.verifySigned(formation, m.FormationSignatures, c.remoteSigner)
-	if err != nil {
-		return m, fmt.Errorf("open confirm: formation remote %w", err)
+	if errors.Is(err, ErrNotSigned{}) {
+		return m, fullySigned, nil
+	} else if err != nil {
+		return m, fullySigned, fmt.Errorf("open confirm: formation remote %w", err)
 	}
 
-	// TODO: channel status = open
+	// All signatures are present that would be required to submit all
+	// transactions in the open.
+	fullySigned = true
 
-	return m, nil
+	return m, fullySigned, nil
 }

--- a/sdk/state/state_open.go
+++ b/sdk/state/state_open.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
@@ -95,59 +94,69 @@ func (c *Channel) ConfirmOpen(m Open) (open Open, fullySigned bool, err error) {
 	}
 
 	// If remote has not signed close, error as is invalid.
-	err = c.verifySigned(txClose, m.CloseSignatures, c.remoteSigner)
+	signed, err := c.verifySigned(txClose, m.CloseSignatures, c.remoteSigner)
 	if err != nil {
-		return m, fullySigned, fmt.Errorf("open confirm: close invalid %w", err)
+		return m, fullySigned, fmt.Errorf("verifying close signed by remote: %w", err)
+	}
+	if !signed {
+		return m, fullySigned, fmt.Errorf("verifying close signed by remote: not signed by remote")
 	}
 
 	// If local has not signed close, sign it.
-	err = c.verifySigned(txClose, m.CloseSignatures, c.localSigner)
-	if errors.Is(err, ErrNotSigned{}) {
+	signed, err = c.verifySigned(txClose, m.CloseSignatures, c.localSigner)
+	if err != nil {
+		return m, fullySigned, fmt.Errorf("verifying close signed by local: %w", err)
+	}
+	if !signed {
 		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return m, fullySigned, fmt.Errorf("open confirm: close incomplete: %w", err)
+			return m, fullySigned, fmt.Errorf("signing close with local: %w", err)
 		}
 		m.CloseSignatures = append(m.CloseSignatures, txClose.Signatures()...)
-	} else if err != nil {
-		return m, fullySigned, fmt.Errorf("open confirm: close error: %w", err)
 	}
 
 	// If local has not signed declaration, sign it.
-	err = c.verifySigned(txDecl, m.DeclarationSignatures, c.localSigner)
-	if errors.Is(err, ErrNotSigned{}) {
+	signed, err = c.verifySigned(txDecl, m.DeclarationSignatures, c.localSigner)
+	if err != nil {
+		return m, fullySigned, fmt.Errorf("verifying declaration with local: %w", err)
+	}
+	if !signed {
 		txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return m, fullySigned, fmt.Errorf("open confirm: decl %w", err)
+			return m, fullySigned, fmt.Errorf("signing declaration with local: decl %w", err)
 		}
 		m.DeclarationSignatures = append(m.DeclarationSignatures, txDecl.Signatures()...)
-	} else if err != nil {
-		return m, fullySigned, fmt.Errorf("open confirm: decl incomplete: %w", err)
 	}
 
 	// If remote has not signed declaration, don't perform any others signing.
-	err = c.verifySigned(txDecl, m.DeclarationSignatures, c.remoteSigner)
+	signed, err = c.verifySigned(txDecl, m.DeclarationSignatures, c.remoteSigner)
 	if err != nil {
+		return m, fullySigned, fmt.Errorf("verifying declaration with remote: decl: %w", err)
+	}
+	if !signed {
 		return m, fullySigned, nil
 	}
 
 	// If local has not signed formation, sign it.
-	err = c.verifySigned(formation, m.FormationSignatures, c.localSigner)
-	if errors.Is(err, ErrNotSigned{}) {
+	signed, err = c.verifySigned(formation, m.FormationSignatures, c.localSigner)
+	if err != nil {
+		return m, fullySigned, fmt.Errorf("verifying formation with local: %w", err)
+	}
+	if !signed {
 		formation, err = formation.Sign(c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return m, fullySigned, fmt.Errorf("open confirm: formation local error %w", err)
+			return m, fullySigned, fmt.Errorf("signing formation with local: %w", err)
 		}
 		m.FormationSignatures = append(m.FormationSignatures, formation.Signatures()...)
-	} else if err != nil {
-		return m, fullySigned, fmt.Errorf("open confirm: formation local %w", err)
 	}
 
-	// If remote has not signed formation, error as is incomplete.
-	err = c.verifySigned(formation, m.FormationSignatures, c.remoteSigner)
-	if errors.Is(err, ErrNotSigned{}) {
-		return m, fullySigned, nil
-	} else if err != nil {
+	// If remote has not signed formation, it is incomplete.
+	signed, err = c.verifySigned(formation, m.FormationSignatures, c.remoteSigner)
+	if err != nil {
 		return m, fullySigned, fmt.Errorf("open confirm: formation remote %w", err)
+	}
+	if !signed {
+		return m, fullySigned, nil
 	}
 
 	// All signatures are present that would be required to submit all

--- a/sdk/state/state_test.go
+++ b/sdk/state/state_test.go
@@ -3,7 +3,6 @@ package state_test
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -179,17 +178,17 @@ func Test(t *testing.T) {
 	open, err := initiatorChannel.ProposeOpen()
 	require.NoError(t, err)
 	for {
-		var errR error
-		open, errR = responderChannel.ConfirmOpen(open)
-		if errR != nil && !errors.Is(errR, state.ErrNotSigned{}) {
-			t.Fatal(errR)
+		var fullySignedR bool
+		open, fullySignedR, err = responderChannel.ConfirmOpen(open)
+		if err != nil {
+			t.Fatal(err)
 		}
-		var errI error
-		open, errI = initiatorChannel.ConfirmOpen(open)
-		if errI != nil && !errors.Is(errI, state.ErrNotSigned{}) {
-			t.Fatal(errI)
+		var fullySignedI bool
+		open, fullySignedI, err = initiatorChannel.ConfirmOpen(open)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if errR == nil && errI == nil {
+		if fullySignedI && fullySignedR {
 			break
 		}
 	}

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -131,7 +131,7 @@ func (c *Channel) ConfirmPayment(p *Payment) (payment *Payment, fullySigned bool
 		p.DeclarationSignatures = append(p.DeclarationSignatures, txDecl.Signatures()...)
 	}
 
-	// If remote has not signed close, error as is incomplete.
+	// If remote has not signed declaration, it is incomplete.
 	signed, err = c.verifySigned(txDecl, p.DeclarationSignatures, c.remoteSigner)
 	if err != nil {
 		return p, fullySigned, fmt.Errorf("verifying declaration signed by remote: %w", err)

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -90,36 +90,63 @@ func (c *Channel) PaymentTxs(p *Payment) (close, decl *txnbuild.Transaction, err
 	return
 }
 
-func (c *Channel) ConfirmPayment(p *Payment) (*Payment, error) {
+func (c *Channel) ConfirmPayment(p *Payment) (payment *Payment, fullySigned bool, err error) {
 	txClose, txDecl, err := c.PaymentTxs(p)
 	if err != nil {
-		return nil, err
-	}
-	// If remote has not signed close, error as is invalid.
-	if err := c.verifySigned(txClose, p.CloseSignatures, c.remoteSigner); err != nil {
-		return nil, fmt.Errorf("incorrect closing transaction, the one given may have different data: %w", err)
-	}
-	// If local has not signed close, sign.
-	if err := c.verifySigned(txClose, p.CloseSignatures, c.localSigner); err != nil {
-		// TODO - differentiate between wrong signature and missing one
-		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
-		if err != nil {
-			return nil, err
-		}
-	}
-	// Local should always sign declaration if have not yet.
-	if err := c.verifySigned(txDecl, p.DeclarationSignatures, c.localSigner); err != nil {
-		txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
-		if err != nil {
-			return nil, err
-		}
+		return p, fullySigned, err
 	}
 
-	p.CloseSignatures = append(p.CloseSignatures, txClose.Signatures()...)
-	p.DeclarationSignatures = append(p.DeclarationSignatures, txDecl.Signatures()...)
+	// If remote has not signed close, error as is invalid.
+	signed, err := c.verifySigned(txClose, p.CloseSignatures, c.remoteSigner)
+	if err != nil {
+		return p, fullySigned, fmt.Errorf("verifying close signed by remote: %w", err)
+	}
+	if !signed {
+		return p, fullySigned, fmt.Errorf("verifying close signed by remote: not signed by remote")
+	}
+
+	// If local has not signed close, sign.
+	signed, err = c.verifySigned(txClose, p.CloseSignatures, c.localSigner)
+	if err != nil {
+		return p, fullySigned, fmt.Errorf("verifying close signed by local: %w", err)
+	}
+	if !signed {
+		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
+		if err != nil {
+			return p, fullySigned, fmt.Errorf("signing close with local: %w", err)
+		}
+		p.CloseSignatures = append(p.CloseSignatures, txClose.Signatures()...)
+	}
+
+	// Local should always sign declaration if have not yet.
+	signed, err = c.verifySigned(txDecl, p.DeclarationSignatures, c.localSigner)
+	if err != nil {
+		return p, fullySigned, fmt.Errorf("verifying declaration signed by local: %w", err)
+	}
+	if !signed {
+		txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
+		if err != nil {
+			return p, fullySigned, err
+		}
+		p.DeclarationSignatures = append(p.DeclarationSignatures, txDecl.Signatures()...)
+	}
+
+	// If remote has not signed close, error as is incomplete.
+	signed, err = c.verifySigned(txDecl, p.DeclarationSignatures, c.remoteSigner)
+	if err != nil {
+		return p, fullySigned, fmt.Errorf("verifying declaration signed by remote: %w", err)
+	}
+	if !signed {
+		return p, fullySigned, nil
+	}
+
+	// All signatures are present that would be required to submit all
+	// transactions in the payment.
+	fullySigned = true
 	newBalance := c.newBalance(p)
 	c.latestCloseAgreement = &CloseAgreement{p.IterationNumber, newBalance, p.CloseSignatures, p.DeclarationSignatures}
-	return p, nil
+
+	return p, fullySigned, nil
 }
 
 func maxInt64(x int64, y int64) int64 {


### PR DESCRIPTION
### What
Add fully signed param to confirm functions that indicates if the value being returned is completely signed and valid for submission if the user wished to submit the transactions to the network. Also, the error value of the confirm functions no longer error when the value is not completely signed, and no other error occurred.

### Why
@acharb mentioned it was confusing that the functions returns values that would be usable when returning an errors. I also found it difficult to remember that the errors returned from these functions could be catastrophic, but then also just routine part of how the process works.

It's a bit more verbose but clearer if the function returns some solid signal that this is fully signed, or complete and submittable, separate to whether some other arbitrary error occurred.

This seemed like a good use case for error inspection, but in reality it was more confusing.
