### PR TITLE
sdk/state: move iteration to be pulled from latestCloseAgreement

### DIFF
--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -32,7 +32,6 @@ type Channel struct {
 	observationPeriodLedgerGap int64
 
 	startingSequence int64
-	iterationNumber  int64
 	// TODO - leave execution out for now
 	// iterationNumberExecuted int64
 
@@ -44,8 +43,8 @@ type Channel struct {
 	remoteSigner *keypair.FromAddress
 
 	latestCloseAgreement *CloseAgreement
-	// TODO - need to store this too?
-	// lastUnConfirmedPayment *Payment
+	// TODO - set this, probably use different name
+	lastUnConfirmedPayment *Payment
 }
 
 type Config struct {
@@ -76,9 +75,16 @@ func NewChannel(c Config) *Channel {
 	return channel
 }
 
-// TODO: Remove
-func (c *Channel) SetIterationNumber(i int64) {
-	c.iterationNumber = i
+func (c *Channel) IterationNumber() int64 {
+	var latestI int64
+	if c.lastUnConfirmedPayment != nil {
+		latestI = c.lastUnConfirmedPayment.IterationNumber
+	} else if c.latestCloseAgreement != nil {
+		latestI = c.latestCloseAgreement.IterationNumber
+	} else {
+		latestI = 0
+	}
+	return latestI + 1
 }
 
 // Balance returns the amount owing from the initiator to the responder, if positive, or

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -74,7 +74,7 @@ func NewChannel(c Config) *Channel {
 	return channel
 }
 
-func (c *Channel) IterationNumber() int64 {
+func (c *Channel) NextIterationNumber() int64 {
 	var latestI int64
 	if c.latestUnconfirmedPayment != nil {
 		latestI = c.latestUnconfirmedPayment.IterationNumber

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -43,7 +43,7 @@ type Channel struct {
 
 	latestCloseAgreement *CloseAgreement
 	// TODO - set this, probably use different name
-	lastUnConfirmedPayment *Payment
+	latestUnconfirmedPayment *Payment
 }
 
 type Config struct {
@@ -76,8 +76,8 @@ func NewChannel(c Config) *Channel {
 
 func (c *Channel) IterationNumber() int64 {
 	var latestI int64
-	if c.lastUnConfirmedPayment != nil {
-		latestI = c.lastUnConfirmedPayment.IterationNumber
+	if c.latestUnconfirmedPayment != nil {
+		latestI = c.latestUnconfirmedPayment.IterationNumber
 	} else if c.latestCloseAgreement != nil {
 		latestI = c.latestCloseAgreement.IterationNumber
 	} else {

--- a/sdk/state/state_open.go
+++ b/sdk/state/state_open.go
@@ -146,6 +146,11 @@ func (c *Channel) ConfirmOpen(m Open) (Open, error) {
 	}
 
 	// TODO: channel status = open
-
+	c.latestCloseAgreement = &CloseAgreement{
+		IterationNumber:       1,
+		Balance:               Amount{},
+		CloseSignatures:       m.CloseSignatures,
+		DeclarationSignatures: m.DeclarationSignatures,
+	}
 	return m, nil
 }

--- a/sdk/state/state_test.go
+++ b/sdk/state/state_test.go
@@ -230,8 +230,8 @@ func Test(t *testing.T) {
 	iBalanceCheck := initiator.Contribution
 	for i < 20 {
 		i++
-		require.Equal(t, i, initiatorChannel.IterationNumber())
-		require.Equal(t, i, responderChannel.IterationNumber())
+		require.Equal(t, i, initiatorChannel.NextIterationNumber())
+		require.Equal(t, i, responderChannel.NextIterationNumber())
 		amount := randomPositiveInt64(t, 100_0000000)
 
 		var sendingChannel *state.Channel
@@ -251,7 +251,7 @@ func Test(t *testing.T) {
 			iBalanceCheck += amount
 		}
 		t.Log("Current channel balances: I: ", sendingChannel.Balance().Amount/1_000_0000, "R: ", receivingChannel.Balance().Amount/1_000_0000)
-		t.Log("Current channel iteration numbers: I: ", sendingChannel.IterationNumber(), "R: ", receivingChannel.IterationNumber())
+		t.Log("Current channel iteration numbers: I: ", sendingChannel.NextIterationNumber(), "R: ", receivingChannel.NextIterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, sends to other party

--- a/sdk/state/state_test.go
+++ b/sdk/state/state_test.go
@@ -264,7 +264,6 @@ func Test(t *testing.T) {
 		var fullySigned bool
 
 		// Receiver: receives new payment, validates, then confirms by signing both
-		receivingChannel.SetIterationNumber(i)
 		payment, fullySigned, err = receivingChannel.ConfirmPayment(payment)
 		require.NoError(t, err)
 		require.False(t, fullySigned)

--- a/sdk/state/state_test.go
+++ b/sdk/state/state_test.go
@@ -231,6 +231,8 @@ func Test(t *testing.T) {
 	iBalanceCheck := initiator.Contribution
 	for i < 20 {
 		i++
+		require.Equal(t, i, initiatorChannel.IterationNumber())
+		require.Equal(t, i, responderChannel.IterationNumber())
 		amount := randomPositiveInt64(t, 100_0000000)
 
 		var sendingChannel *state.Channel
@@ -249,11 +251,11 @@ func Test(t *testing.T) {
 			rBalanceCheck -= amount
 			iBalanceCheck += amount
 		}
-		t.Log("Current channel balances: I: ", initiatorChannel.Balance().Amount/1_000_0000, "R: ", responderChannel.Balance().Amount/1_000_0000)
+		t.Log("Current channel balances: I: ", sendingChannel.Balance().Amount/1_000_0000, "R: ", receivingChannel.Balance().Amount/1_000_0000)
+		t.Log("Current channel iteration numbers: I: ", sendingChannel.IterationNumber(), "R: ", receivingChannel.IterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		//// Sender: creates new Payment, sends to other party
-		sendingChannel.SetIterationNumber(i)
 		payment, err := sendingChannel.ProposePayment(state.Amount{Asset: state.NativeAsset{}, Amount: amount})
 		require.NoError(t, err)
 
@@ -261,7 +263,6 @@ func Test(t *testing.T) {
 		require.NoError(t, err)
 
 		//// Receiver: receives new payment proposal, validates, then confirms by signing both
-		receivingChannel.SetIterationNumber(i)
 		payment, err = receivingChannel.ConfirmPayment(payment)
 		require.NoError(t, err)
 

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -93,7 +93,7 @@ func (c *Channel) PaymentTxs(p *Payment) (close, decl *txnbuild.Transaction, err
 
 func (c *Channel) ConfirmPayment(p *Payment) (payment *Payment, fullySigned bool, err error) {
 	if p.IterationNumber != c.IterationNumber() {
-		return nil, errors.New("invalid payment iteration number")
+		return nil, fullySigned, errors.New("invalid payment iteration number")
 	}
 	txClose, txDecl, err := c.PaymentTxs(p)
 	if err != nil {

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -3,6 +3,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
 	"github.com/stellar/go/txnbuild"
@@ -93,7 +94,8 @@ func (c *Channel) PaymentTxs(p *Payment) (close, decl *txnbuild.Transaction, err
 
 func (c *Channel) ConfirmPayment(p *Payment) (payment *Payment, fullySigned bool, err error) {
 	if p.IterationNumber != c.NextIterationNumber() {
-		return nil, fullySigned, errors.New("invalid payment iteration number")
+		return nil, fullySigned, errors.New(fmt.Sprintf("invalid payment iteration number, got: %s want: %s",
+			strconv.FormatInt(p.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10)))
 	}
 	txClose, txDecl, err := c.PaymentTxs(p)
 	if err != nil {

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -42,7 +42,7 @@ func (c *Channel) ProposePayment(amount Amount) (*Payment, error) {
 		InitiatorEscrow:            c.initiatorEscrowAccount().Address,
 		ResponderEscrow:            c.responderEscrowAccount().Address,
 		StartSequence:              c.startingSequence,
-		IterationNumber:            c.IterationNumber(),
+		IterationNumber:            c.NextIterationNumber(),
 		AmountToInitiator:          maxInt64(0, newBalance*-1),
 		AmountToResponder:          maxInt64(0, newBalance),
 	})
@@ -54,7 +54,7 @@ func (c *Channel) ProposePayment(amount Amount) (*Payment, error) {
 		return nil, err
 	}
 	p := &Payment{
-		IterationNumber: c.IterationNumber(),
+		IterationNumber: c.NextIterationNumber(),
 		Amount:          amount,
 		CloseSignatures: txClose.Signatures(),
 		FromInitiator:   c.initiator,
@@ -72,7 +72,7 @@ func (c *Channel) PaymentTxs(p *Payment) (close, decl *txnbuild.Transaction, err
 		InitiatorEscrow:            c.initiatorEscrowAccount().Address,
 		ResponderEscrow:            c.responderEscrowAccount().Address,
 		StartSequence:              c.startingSequence,
-		IterationNumber:            c.IterationNumber(),
+		IterationNumber:            c.NextIterationNumber(),
 		AmountToInitiator:          maxInt64(0, newBalance.Amount*-1),
 		AmountToResponder:          maxInt64(0, newBalance.Amount),
 	})
@@ -82,7 +82,7 @@ func (c *Channel) PaymentTxs(p *Payment) (close, decl *txnbuild.Transaction, err
 	decl, err = txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
 		StartSequence:           c.startingSequence,
-		IterationNumber:         c.IterationNumber(),
+		IterationNumber:         c.NextIterationNumber(),
 		IterationNumberExecuted: 0,
 	})
 	if err != nil {
@@ -92,7 +92,7 @@ func (c *Channel) PaymentTxs(p *Payment) (close, decl *txnbuild.Transaction, err
 }
 
 func (c *Channel) ConfirmPayment(p *Payment) (payment *Payment, fullySigned bool, err error) {
-	if p.IterationNumber != c.IterationNumber() {
+	if p.IterationNumber != c.NextIterationNumber() {
 		return nil, fullySigned, errors.New("invalid payment iteration number")
 	}
 	txClose, txDecl, err := c.PaymentTxs(p)


### PR DESCRIPTION
removes `c.SetIterationNumber`. The channel's current iteration number = lastCloseAgreement.IterationNumber + 1

note:
- not updating `lastUnconfirmedPayment` yet. So adding the field as a dummy field for when it's added

closes https://github.com/stellar/experimental-payment-channels/issues/64 and https://github.com/stellar/experimental-payment-channels/issues/61