### PR TITLE
sdk/state: store latestUnconfirmedPayment, add unit test

### DIFF
--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -41,8 +41,8 @@ type Channel struct {
 	localSigner  *keypair.Full
 	remoteSigner *keypair.FromAddress
 
-	latestCloseAgreement     *CloseAgreement
-	latestUnconfirmedPayment *Payment
+	latestCloseAgreement     CloseAgreement
+	latestUnconfirmedPayment Payment
 }
 
 type Config struct {
@@ -74,26 +74,21 @@ func NewChannel(c Config) *Channel {
 }
 
 func (c *Channel) NextIterationNumber() int64 {
-	if c.latestUnconfirmedPayment != nil {
+	if !c.latestUnconfirmedPayment.isEmpty() {
 		return c.latestUnconfirmedPayment.IterationNumber
-	} else if c.latestCloseAgreement != nil {
-		return c.latestCloseAgreement.IterationNumber + 1
 	}
-	return 1
+	return c.latestCloseAgreement.IterationNumber + 1
 }
 
 // Balance returns the amount owing from the initiator to the responder, if positive, or
 // the amount owing from the responder to the initiator, if negative.
 func (c *Channel) Balance() Amount {
-	if c.latestCloseAgreement == nil {
-		return Amount{NativeAsset{}, 0}
-	}
 	return c.latestCloseAgreement.Balance
 }
 
 // newBalance is a hlper method for computing what the new channel balance will be if
 // the input payment is submitted successfully.
-func (c *Channel) newBalance(p *Payment) Amount {
+func (c *Channel) newBalance(p Payment) Amount {
 	var amountFromInitiator, amountFromResponder int64
 	if p.FromInitiator {
 		amountFromInitiator = p.Amount.Amount

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -41,8 +41,7 @@ type Channel struct {
 	localSigner  *keypair.Full
 	remoteSigner *keypair.FromAddress
 
-	latestCloseAgreement *CloseAgreement
-	// TODO - set this, probably use different name
+	latestCloseAgreement     *CloseAgreement
 	latestUnconfirmedPayment *Payment
 }
 
@@ -75,15 +74,12 @@ func NewChannel(c Config) *Channel {
 }
 
 func (c *Channel) NextIterationNumber() int64 {
-	var latestI int64
 	if c.latestUnconfirmedPayment != nil {
-		latestI = c.latestUnconfirmedPayment.IterationNumber
+		return c.latestUnconfirmedPayment.IterationNumber
 	} else if c.latestCloseAgreement != nil {
-		latestI = c.latestCloseAgreement.IterationNumber
-	} else {
-		latestI = 0
+		return c.latestCloseAgreement.IterationNumber + 1
 	}
-	return latestI + 1
+	return 1
 }
 
 // Balance returns the amount owing from the initiator to the responder, if positive, or

--- a/sdk/state/state_open.go
+++ b/sdk/state/state_open.go
@@ -162,7 +162,7 @@ func (c *Channel) ConfirmOpen(m Open) (open Open, fullySigned bool, err error) {
 	// All signatures are present that would be required to submit all
 	// transactions in the open.
 	fullySigned = true
-	c.latestCloseAgreement = &CloseAgreement{
+	c.latestCloseAgreement = CloseAgreement{
 		IterationNumber:       1,
 		Balance:               Amount{},
 		CloseSignatures:       m.CloseSignatures,

--- a/sdk/state/state_test.go
+++ b/sdk/state/state_test.go
@@ -80,7 +80,7 @@ func Test(t *testing.T) {
 
 	// Setup responder.
 	responder := Participant{
-		Name:         "Initiator",
+		Name:         "Responder",
 		KP:           keypair.MustRandom(),
 		Escrow:       keypair.MustRandom(),
 		Contribution: 1_000_0000000,

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -10,6 +10,13 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+// The high level steps for creating a channel update should be as follows, where the returned payments
+// flow to the next step:
+// 1. Sender calls ProposePayment()
+// 2. Receiver calls ConfirmPayment
+// 3. Sender calls ConfirmPayment
+// 4. Receiver calls ConfirmPayment
+
 type Payment struct {
 	IterationNumber       int64
 	Amount                Amount
@@ -103,6 +110,9 @@ func (c *Channel) PaymentTxs(p Payment) (close, decl *txnbuild.Transaction, err 
 	return
 }
 
+// ConfirmPayment confirms a payment. The original proposer should only have to call this once, and the
+// receiver should call twice. First to sign the payments and store signatures, second to just store the new signatures
+// from the other party's confirmation.
 func (c *Channel) ConfirmPayment(p Payment) (payment Payment, fullySigned bool, err error) {
 	// at the end of this method if a fully signed payment, create a close agreement and clear latest latestUnconfirmedPayment to
 	// prepare for the next update. If not fully signed, save latestUnconfirmedPayment, as we are still in the process of confirming.

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -104,6 +104,9 @@ func (c *Channel) PaymentTxs(p Payment) (close, decl *txnbuild.Transaction, err 
 }
 
 func (c *Channel) ConfirmPayment(p Payment) (payment Payment, fullySigned bool, err error) {
+	// at the end of this method if a fully signed payment, create a close agreement and clear latest latestUnconfirmedPayment to
+	// prepare for the next update. If not fully signed, save latestUnconfirmedPayment, as we are still in the process of confirming.
+	// If an error occurred during this process don't save any new state, as something went wrong.
 	defer func() {
 		if err != nil {
 			return

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -18,7 +18,9 @@ type Payment struct {
 	FromInitiator         bool
 }
 
-func (p Payment) isEqual(p2 Payment) bool {
+// isEquivalent returns true if all fields for the Payments are equal not including signatures, else false.
+// Two payments that are equal may have different signatures depending on who and when this method is called.
+func (p Payment) isEquivalent(p2 Payment) bool {
 	return p.IterationNumber == p2.IterationNumber && p.Amount == p2.Amount && p.FromInitiator == p2.FromInitiator
 }
 
@@ -119,7 +121,7 @@ func (c *Channel) ConfirmPayment(p Payment) (payment Payment, fullySigned bool, 
 		return p, fullySigned, errors.New(fmt.Sprintf("invalid payment iteration number, got: %s want: %s",
 			strconv.FormatInt(p.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10)))
 	}
-	if !c.latestUnconfirmedPayment.isEmpty() && !c.latestUnconfirmedPayment.isEqual(p) {
+	if !c.latestUnconfirmedPayment.isEmpty() && !c.latestUnconfirmedPayment.isEquivalent(p) {
 		return p, fullySigned, errors.New("a different unconfirmed payment exists")
 	}
 

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -1,0 +1,75 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLastConfirmedPayment(t *testing.T) {
+	localSigner := keypair.MustRandom()
+	remoteSigner := keypair.MustRandom()
+	localEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(101),
+	}
+	remoteEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(202),
+	}
+	sendingChannel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           true,
+		LocalSigner:         localSigner,
+		RemoteSigner:        remoteSigner.FromAddress(),
+		LocalEscrowAccount:  localEscrowAccount,
+		RemoteEscrowAccount: remoteEscrowAccount,
+	})
+	receiverChannel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           false,
+		LocalSigner:         remoteSigner,
+		RemoteSigner:        localSigner.FromAddress(),
+		LocalEscrowAccount:  remoteEscrowAccount,
+		RemoteEscrowAccount: localEscrowAccount,
+	})
+
+	p, err := sendingChannel.ProposePayment(Amount{
+		Asset:  NativeAsset{},
+		Amount: 200,
+	})
+	require.NoError(t, err)
+
+	p, fullySigned, err := receiverChannel.ConfirmPayment(p)
+	assert.False(t, fullySigned)
+	require.NoError(t, err)
+	assert.Equal(t, p, receiverChannel.latestUnconfirmedPayment)
+
+	// Confirming a payment with same sequence number but different Amount should error
+	pDifferent := &Payment{
+		IterationNumber: 1,
+		Amount: Amount{
+			Asset:  NativeAsset{},
+			Amount: 400,
+		},
+		CloseSignatures: p.CloseSignatures,
+	}
+	_, fullySigned, err = receiverChannel.ConfirmPayment(pDifferent)
+	assert.False(t, fullySigned)
+	require.Error(t, err)
+	require.Equal(t, "a different unconfirmed payment exists", err.Error())
+
+	// Confirming a payment with same sequence number and same amount should pass
+	p, fullySigned, err = sendingChannel.ConfirmPayment(p)
+	assert.True(t, fullySigned)
+	require.NoError(t, err)
+	assert.Nil(t, sendingChannel.latestUnconfirmedPayment)
+
+	p, fullySigned, err = receiverChannel.ConfirmPayment(p)
+	assert.True(t, fullySigned)
+	require.NoError(t, err)
+	assert.Nil(t, receiverChannel.latestUnconfirmedPayment)
+}

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -62,6 +62,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, "a different unconfirmed payment exists", err.Error())
 	assert.Equal(t, p, receiverChannel.latestUnconfirmedPayment)
+	assert.Equal(t, CloseAgreement{}, receiverChannel.latestCloseAgreement)
 
 	// Confirming a payment with same sequence number and same amount should pass
 	p, fullySigned, err = sendingChannel.ConfirmPayment(p)

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -49,7 +49,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	assert.Equal(t, p, receiverChannel.latestUnconfirmedPayment)
 
 	// Confirming a payment with same sequence number but different Amount should error
-	pDifferent := &Payment{
+	pDifferent := Payment{
 		IterationNumber: 1,
 		Amount: Amount{
 			Asset:  NativeAsset{},
@@ -66,10 +66,10 @@ func TestLastConfirmedPayment(t *testing.T) {
 	p, fullySigned, err = sendingChannel.ConfirmPayment(p)
 	assert.True(t, fullySigned)
 	require.NoError(t, err)
-	assert.Nil(t, sendingChannel.latestUnconfirmedPayment)
+	assert.Equal(t, Payment{}, sendingChannel.latestUnconfirmedPayment)
 
 	p, fullySigned, err = receiverChannel.ConfirmPayment(p)
 	assert.True(t, fullySigned)
 	require.NoError(t, err)
-	assert.Nil(t, receiverChannel.latestUnconfirmedPayment)
+	assert.Equal(t, Payment{}, receiverChannel.latestUnconfirmedPayment)
 }

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -61,6 +61,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	assert.False(t, fullySigned)
 	require.Error(t, err)
 	require.Equal(t, "a different unconfirmed payment exists", err.Error())
+	assert.Equal(t, p, receiverChannel.latestUnconfirmedPayment)
 
 	// Confirming a payment with same sequence number and same amount should pass
 	p, fullySigned, err = sendingChannel.ConfirmPayment(p)


### PR DESCRIPTION
this stores the latestUnconfirmedPayment on the channel, and uses it for validation in `ConfirmPayment`

This is to prevent the case of a receiver receiving two payments with different data but using the same next iteration number.

Also adds a unit test to test this

closes https://github.com/stellar/experimental-payment-channels/issues/69