### PR TITLE
sdk/state: merge new signatures into stored signature slice instead of overwriting

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -91,7 +91,7 @@ func (c *Channel) ConfirmCoordinatedClose(cc CoordinatedClose) (coordinatedClose
 	}
 	fullySigned = true
 
-	c.coordinatedClose.CloseSignatures = appendNewSignatures(c.coordinatedClose.CloseSignatures, cc.CloseSignatures)
+	c.coordinatedClose = CoordinatedClose{CloseSignatures: appendNewSignatures(c.coordinatedClose.CloseSignatures, cc.CloseSignatures)}
 	return c.coordinatedClose, fullySigned, nil
 }
 

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -26,6 +26,16 @@ func (cc CoordinatedClose) CloseSignatures() []xdr.DecoratedSignature {
 	return cc.closeSignatures
 }
 
+// mergeCoordinatedCloseData merges the data from a new coordinated close into an existing one. The signatures of the existing
+// coordinated close are appended to so that existing signatures are not lost.
+func mergeCoordinatedCloseData(cc CoordinatedClose, newCoordinatedClose CoordinatedClose) CoordinatedClose {
+	return CoordinatedClose{
+		observationPeriodTime:      newCoordinatedClose.observationPeriodTime,
+		observationPeriodLedgerGap: newCoordinatedClose.observationPeriodLedgerGap,
+		closeSignatures:            appendNewSignatures(cc.closeSignatures, newCoordinatedClose.closeSignatures),
+	}
+}
+
 func (c *Channel) CloseTxs() (txDecl *txnbuild.Transaction, txClose *txnbuild.Transaction, err error) {
 	txDecl, err = txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
@@ -98,8 +108,7 @@ func (c *Channel) ConfirmCoordinatedClose(cc CoordinatedClose) (CoordinatedClose
 		cc.closeSignatures = append(cc.closeSignatures, txCoordinatedClose.Signatures()...)
 	}
 
-	// TODO - merge instead of overwrite, similar to ConfirmProposal
-	c.coordinatedClose = cc
+	c.coordinatedClose = mergeCoordinatedCloseData(c.coordinatedClose, cc)
 	return cc, nil
 }
 

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -174,6 +174,20 @@ func (c *Channel) verifySigned(tx *txnbuild.Transaction, sigs []xdr.DecoratedSig
 	return false, nil
 }
 
+func appendNewSignatures(oldSignatures []xdr.DecoratedSignature, newSignatures []xdr.DecoratedSignature) []xdr.DecoratedSignature {
+	m := make(map[string]bool)
+	for _, os := range oldSignatures {
+		m[string(os.Signature)] = true
+	}
+
+	for _, ns := range newSignatures {
+		if _, found := m[string(ns.Signature)]; !found {
+			oldSignatures = append(oldSignatures, ns)
+		}
+	}
+	return oldSignatures
+}
+
 type TxInfo struct {
 	ID        string
 	Iteration int

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -180,7 +180,7 @@ func appendNewSignatures(oldSignatures []xdr.DecoratedSignature, newSignatures [
 	}
 
 	for _, ns := range newSignatures {
-		if _, found := m[string(ns.Signature)]; !found {
+		if !m[string(ns.Signature)] {
 			oldSignatures = append(oldSignatures, ns)
 		}
 	}

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -35,6 +35,11 @@ func (p Payment) isEmpty() bool {
 	return p.IterationNumber == 0 && p.Amount == (Amount{}) && p.FromInitiator == false && len(p.CloseSignatures) == 0 && len(p.DeclarationSignatures) == 0
 }
 
+// addSignatures adds new signatures to the payment. If the signature already exists, it is skipped.
+func (p Payment) addNewSignatures(closeSignatures []xdr.DecoratedSignature declarationSignatures []xdr.DecoratedSignature) {
+
+}
+
 type CloseAgreement struct {
 	IterationNumber       int64
 	Balance               Amount

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -1,7 +1,7 @@
 package state
 
 import (
-	"crypto/rand"
+	"math/rand"
 	"testing"
 
 	"github.com/stellar/go/keypair"

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -84,7 +84,6 @@ func TestLastConfirmedPayment(t *testing.T) {
 }
 
 func TestAppendNewSignature(t *testing.T) {
-	// TODO - put this code somewhere for re-use (use the integration function code?)
 	localSigner := keypair.MustRandom()
 	remoteSigner := keypair.MustRandom()
 	localEscrowAccount := &EscrowAccount{
@@ -135,7 +134,6 @@ func TestAppendNewSignature(t *testing.T) {
 	}
 }
 
-// TODO - move to another folder for helper methods?
 func randomByteArray(length int) ([]byte, error) {
 	arr := make([]byte, length)
 	_, err := rand.Read(arr)


### PR DESCRIPTION
adds functionality for merging new signatures into stored signatures instead of overwriting. This process is done in the close and update steps, when a user receives signatures from the other party and needs to store them locally

closes https://github.com/stellar/experimental-payment-channels/issues/82