### PR TITLE
sdk/state: form channel and close channel with non-native currency

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -116,5 +116,6 @@ func (c *Channel) makeCloseTx(observationPeriodTime time.Duration, observationPe
 		IterationNumber:            c.latestCloseAgreement.IterationNumber,
 		AmountToInitiator:          c.initiatorClaimAmount(),
 		AmountToResponder:          c.responderClaimAmount(),
+		Asset:                      c.latestCloseAgreement.Balance.Asset,
 	})
 }

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -26,6 +26,8 @@ func (c *Channel) OpenTxs() (txClose, txDecl, formation *txnbuild.Transaction, e
 		IterationNumber:            1,
 		AmountToInitiator:          0,
 		AmountToResponder:          0,
+		// TODO - change to non native
+		Asset: NativeAsset{},
 	})
 	if err != nil {
 		return
@@ -45,6 +47,8 @@ func (c *Channel) OpenTxs() (txClose, txDecl, formation *txnbuild.Transaction, e
 		InitiatorEscrow: c.initiatorEscrowAccount().Address,
 		ResponderEscrow: c.responderEscrowAccount().Address,
 		StartSequence:   c.startingSequence,
+		// TODO - change to non native
+		Asset: NativeAsset{},
 	})
 	return
 }

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -63,6 +63,7 @@ func (c *Channel) ProposePayment(amount Amount) (Payment, error) {
 		IterationNumber:            c.NextIterationNumber(),
 		AmountToInitiator:          maxInt64(0, newBalance*-1),
 		AmountToResponder:          maxInt64(0, newBalance),
+		Asset:                      amount.Asset,
 	})
 	if err != nil {
 		return Payment{}, err
@@ -94,6 +95,7 @@ func (c *Channel) PaymentTxs(p Payment) (close, decl *txnbuild.Transaction, err 
 		IterationNumber:            c.NextIterationNumber(),
 		AmountToInitiator:          maxInt64(0, newBalance.Amount*-1),
 		AmountToResponder:          maxInt64(0, newBalance.Amount),
+		Asset:                      p.Amount.Asset,
 	})
 	if err != nil {
 		return

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +39,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	})
 
 	p, err := sendingChannel.ProposePayment(Amount{
-		Asset:  NativeAsset{},
+		Asset:  txnbuild.NativeAsset{},
 		Amount: 200,
 	})
 	require.NoError(t, err)
@@ -52,7 +53,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	pDifferent := Payment{
 		IterationNumber: 1,
 		Amount: Amount{
-			Asset:  NativeAsset{},
+			Asset:  txnbuild.NativeAsset{},
 			Amount: 400,
 		},
 		CloseSignatures: p.CloseSignatures,

--- a/sdk/txbuild/close.go
+++ b/sdk/txbuild/close.go
@@ -19,6 +19,7 @@ type CloseParams struct {
 	IterationNumber            int64
 	AmountToInitiator          int64
 	AmountToResponder          int64
+	Asset                      txnbuild.Asset
 }
 
 func Close(p CloseParams) (*txnbuild.Transaction, error) {
@@ -55,7 +56,7 @@ func Close(p CloseParams) (*txnbuild.Transaction, error) {
 		tp.Operations = append(tp.Operations, &txnbuild.Payment{
 			SourceAccount: p.ResponderEscrow.Address(),
 			Destination:   p.InitiatorEscrow.Address(),
-			Asset:         txnbuild.NativeAsset{},
+			Asset:         p.Asset,
 			Amount:        amount.StringFromInt64(p.AmountToInitiator),
 		})
 	}
@@ -63,7 +64,7 @@ func Close(p CloseParams) (*txnbuild.Transaction, error) {
 		tp.Operations = append(tp.Operations, &txnbuild.Payment{
 			SourceAccount: p.InitiatorEscrow.Address(),
 			Destination:   p.ResponderEscrow.Address(),
-			Asset:         txnbuild.NativeAsset{},
+			Asset:         p.Asset,
 			Amount:        amount.StringFromInt64(p.AmountToResponder),
 		})
 	}

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -11,6 +11,8 @@ type FormationParams struct {
 	InitiatorEscrow *keypair.FromAddress
 	ResponderEscrow *keypair.FromAddress
 	StartSequence   int64
+	Asset           txnbuild.Asset
+	AssetLimit      string
 }
 
 func Formation(p FormationParams) (*txnbuild.Transaction, error) {
@@ -35,6 +37,13 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		SourceAccount: p.InitiatorEscrow.Address(),
 		Signer:        &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
 	})
+	if !p.Asset.IsNative() {
+		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
+			Line:          p.Asset,
+			Limit:         p.AssetLimit,
+			SourceAccount: p.InitiatorEscrow.Address(),
+		})
+	}
 	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.InitiatorEscrow.Address()})
 	tp.Operations = append(tp.Operations, &txnbuild.BeginSponsoringFutureReserves{SourceAccount: p.ResponderSigner.Address(), SponsoredID: p.ResponderEscrow.Address()})
 	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
@@ -49,6 +58,13 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		SourceAccount: p.ResponderEscrow.Address(),
 		Signer:        &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
 	})
+	if !p.Asset.IsNative() {
+		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
+			Line:          p.Asset,
+			Limit:         p.AssetLimit,
+			SourceAccount: p.ResponderEscrow.Address(),
+		})
+	}
 	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.ResponderEscrow.Address()})
 	tx, err := txnbuild.NewTransaction(tp)
 	if err != nil {

--- a/sdk/txbuild/test_test.go
+++ b/sdk/txbuild/test_test.go
@@ -141,6 +141,7 @@ func Test(t *testing.T) {
 			IterationNumber:            i,
 			AmountToInitiator:          0,
 			AmountToResponder:          0,
+			Asset:                      txnbuild.NativeAsset{},
 		})
 		require.NoError(t, err)
 		ci, err = ci.Sign(networkPassphrase, initiator.KP, responder.KP)
@@ -170,6 +171,7 @@ func Test(t *testing.T) {
 			InitiatorEscrow: initiator.Escrow.FromAddress(),
 			ResponderEscrow: responder.Escrow.FromAddress(),
 			StartSequence:   s,
+			Asset:           txnbuild.NativeAsset{},
 		})
 		require.NoError(t, err)
 		f, err = f.Sign(networkPassphrase, initiator.KP, responder.KP)
@@ -226,6 +228,7 @@ func Test(t *testing.T) {
 			IterationNumber:            i,
 			AmountToInitiator:          rOwesI,
 			AmountToResponder:          iOwesR,
+			Asset:                      txnbuild.NativeAsset{},
 		}
 		ci, err := txbuild.Close(closeParams)
 		require.NoError(t, err)


### PR DESCRIPTION
this is the core change for [this ticket](https://github.com/stellar/experimental-payment-channels/issues/71) of supporting non-native currencies.

Steps in this PR:
(basically the initial changes in `txbuild`, which will be used by `sdk/state`)
1. change txbuild/close to create a closing channel transaction that has payments in non-native asset.
2. change txbuild/formation to configure the channel to support non-native asset

Next steps (not in this PR):
1. Escrow account creation needs trustlines for non-native assets
2. Change the open channel functionality to be able to custom choose a non-native asset
2. The `latestCloseAgreement` `lastUnconfirmedPayment` need to store what the channel asset is
3. When closing the channel the payments need to be able to be non-native assets