### PR TITLE
sdk/state: add support for non-native assets in the escrow accounts

### DIFF
--- a/sdk/state/integration/helpers_test.go
+++ b/sdk/state/integration/helpers_test.go
@@ -17,7 +17,7 @@ import (
 
 // functions to be used in the state_test integration tests
 
-func initAccounts(t *testing.T) (initiator Participant, responder Participant) {
+func initAccounts(t *testing.T, client horizonclient.ClientInterface, asset txnbuild.Asset, assetLimit string, distributorKP *keypair.Full) (initiator Participant, responder Participant) {
 	initiator = Participant{
 		Name:         "Initiator",
 		KP:           keypair.MustRandom(),
@@ -27,35 +27,15 @@ func initAccounts(t *testing.T) (initiator Participant, responder Participant) {
 	t.Log("Initiator:", initiator.KP.Address())
 	t.Log("Initiator Escrow:", initiator.Escrow.Address())
 	{
-		err := retry(2, func() error { return fund(client, initiator.KP.FromAddress(), 10_000_0000000) })
+		err := retry(2, func() error { return createAccount(client, initiator.KP.FromAddress(), 10_000_0000000) })
 		require.NoError(t, err)
-		account, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: initiator.KP.Address()})
+		err = retry(2, func() error { return fundAsset(client, asset, initiator.Contribution, initiator.KP, distributorKP) })
 		require.NoError(t, err)
-		seqNum, err := account.GetSequenceNumber()
-		require.NoError(t, err)
-		tx, err := txbuild.CreateEscrow(txbuild.CreateEscrowParams{
-			Creator:             initiator.KP.FromAddress(),
-			Escrow:              initiator.Escrow.FromAddress(),
-			SequenceNumber:      seqNum + 1,
-			InitialContribution: initiator.Contribution,
-		})
-		require.NoError(t, err)
-		tx, err = tx.Sign(networkPassphrase, initiator.KP, initiator.Escrow)
-		require.NoError(t, err)
-		fbtx, err := txnbuild.NewFeeBumpTransaction(txnbuild.FeeBumpTransactionParams{
-			Inner:      tx,
-			FeeAccount: initiator.KP.Address(),
-			BaseFee:    txnbuild.MinBaseFee,
-		})
-		require.NoError(t, err)
-		fbtx, err = fbtx.Sign(networkPassphrase, initiator.KP)
-		require.NoError(t, err)
-		txResp, err := client.SubmitFeeBumpTransaction(fbtx)
-		require.NoError(t, err)
-		initiator.EscrowSequenceNumber = int64(txResp.Ledger) << 32
+		initEscrowAccount(t, client, &initiator, asset, assetLimit)
 	}
+
 	t.Log("Initiator Escrow Sequence Number:", initiator.EscrowSequenceNumber)
-	t.Log("Initiator Contribution:", initiator.Contribution)
+	t.Log("Initiator Contribution:", initiator.Contribution, "of asset:", asset.GetCode(), "issuer: ", asset.GetIssuer())
 
 	// Setup responder.
 	responder = Participant{
@@ -67,89 +47,147 @@ func initAccounts(t *testing.T) (initiator Participant, responder Participant) {
 	t.Log("Responder:", responder.KP.Address())
 	t.Log("Responder Escrow:", responder.Escrow.Address())
 	{
-		err := retry(2, func() error { return fund(client, responder.KP.FromAddress(), 10_000_0000000) })
+		err := retry(2, func() error { return createAccount(client, responder.KP.FromAddress(), 10_000_0000000) })
 		require.NoError(t, err)
-		account, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: responder.KP.Address()})
+		err = retry(2, func() error { return fundAsset(client, asset, responder.Contribution, responder.KP, distributorKP) })
 		require.NoError(t, err)
-		seqNum, err := account.GetSequenceNumber()
-		require.NoError(t, err)
-		tx, err := txbuild.CreateEscrow(txbuild.CreateEscrowParams{
-			Creator:             responder.KP.FromAddress(),
-			Escrow:              responder.Escrow.FromAddress(),
-			SequenceNumber:      seqNum + 1,
-			InitialContribution: responder.Contribution,
-		})
-		require.NoError(t, err)
-		tx, err = tx.Sign(networkPassphrase, responder.KP, responder.Escrow)
-		require.NoError(t, err)
-		fbtx, err := txnbuild.NewFeeBumpTransaction(txnbuild.FeeBumpTransactionParams{
-			Inner:      tx,
-			FeeAccount: responder.KP.Address(),
-			BaseFee:    txnbuild.MinBaseFee,
-		})
-		require.NoError(t, err)
-		fbtx, err = fbtx.Sign(networkPassphrase, responder.KP)
-		require.NoError(t, err)
-		txResp, err := client.SubmitFeeBumpTransaction(fbtx)
-		require.NoError(t, err)
-		responder.EscrowSequenceNumber = int64(txResp.Ledger) << 32
+		initEscrowAccount(t, client, &responder, asset, assetLimit)
 	}
 	t.Log("Responder Escrow Sequence Number:", responder.EscrowSequenceNumber)
-	t.Log("Responder Contribution:", responder.Contribution)
+	t.Log("Responder Contribution:", responder.Contribution, "of asset:", asset.GetCode(), "issuer: ", asset.GetIssuer())
 	return initiator, responder
 }
 
-func initChannels(t *testing.T, initiator Participant, responder Participant) (initiatorChannel *state.Channel, responderChannel *state.Channel) {
+func initEscrowAccount(t *testing.T, client horizonclient.ClientInterface, participant *Participant, asset txnbuild.Asset, assetLimit string) {
+	// create escrow account
+	account, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: participant.KP.Address()})
+	require.NoError(t, err)
+	seqNum, err := account.GetSequenceNumber()
+	require.NoError(t, err)
+	tx, err := txbuild.CreateEscrow(txbuild.CreateEscrowParams{
+		Creator:        participant.KP.FromAddress(),
+		Escrow:         participant.Escrow.FromAddress(),
+		SequenceNumber: seqNum + 1,
+		Asset:          asset,
+		AssetLimit:     assetLimit,
+	})
+	require.NoError(t, err)
+	tx, err = tx.Sign(networkPassphrase, participant.KP, participant.Escrow)
+	require.NoError(t, err)
+	fbtx, err := txnbuild.NewFeeBumpTransaction(txnbuild.FeeBumpTransactionParams{
+		Inner:      tx,
+		FeeAccount: participant.KP.Address(),
+		BaseFee:    txnbuild.MinBaseFee,
+	})
+	require.NoError(t, err)
+	fbtx, err = fbtx.Sign(networkPassphrase, participant.KP)
+	require.NoError(t, err)
+	txResp, err := client.SubmitFeeBumpTransaction(fbtx)
+	require.NoError(t, err)
+	participant.EscrowSequenceNumber = int64(txResp.Ledger) << 32
+
+	// add initial contribution
+	_, err = account.IncrementSequenceNumber()
+	require.NoError(t, err)
+
+	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &account,
+		BaseFee:              txnbuild.MinBaseFee,
+		Timebounds:           txnbuild.NewTimeout(300),
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.Payment{
+				Destination: participant.Escrow.Address(),
+				Amount:      stellarAmount.StringFromInt64(participant.Contribution),
+				Asset:       asset,
+			},
+		},
+	})
+
+	tx, err = tx.Sign(networkPassphrase, participant.KP)
+	require.NoError(t, err)
+	_, err = client.SubmitTransaction(tx)
+	require.NoError(t, err)
+}
+
+func initChannels(t *testing.T, client horizonclient.ClientInterface, initiator Participant, responder Participant) (initiatorChannel *state.Channel, responderChannel *state.Channel) {
 	// Channel constants.
 	const observationPeriodTime = 20 * time.Second
 	const averageLedgerDuration = 5 * time.Second
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
+
+	initiatorEscrowAccount := state.EscrowAccount{
+		Address:        initiator.Escrow.FromAddress(),
+		SequenceNumber: initiator.EscrowSequenceNumber,
+	}
+	responderEscrowAccount := state.EscrowAccount{
+		Address:        responder.Escrow.FromAddress(),
+		SequenceNumber: responder.EscrowSequenceNumber,
+	}
 
 	initiatorChannel = state.NewChannel(state.Config{
 		NetworkPassphrase:          networkPassphrase,
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
 		Initiator:                  true,
-		LocalEscrowAccount: &state.EscrowAccount{
-			Address:        initiator.Escrow.FromAddress(),
-			SequenceNumber: initiator.EscrowSequenceNumber,
-			Balances: []state.Amount{
-				{Asset: state.NativeAsset{}, Amount: initiator.Contribution},
-			},
-		},
-		RemoteEscrowAccount: &state.EscrowAccount{
-			Address:        responder.Escrow.FromAddress(),
-			SequenceNumber: responder.EscrowSequenceNumber,
-			Balances: []state.Amount{
-				{Asset: state.NativeAsset{}, Amount: responder.Contribution},
-			},
-		},
-		LocalSigner:  initiator.KP,
-		RemoteSigner: responder.KP.FromAddress(),
+		LocalEscrowAccount:         &initiatorEscrowAccount,
+		RemoteEscrowAccount:        &responderEscrowAccount,
+		LocalSigner:                initiator.KP,
+		RemoteSigner:               responder.KP.FromAddress(),
 	})
 	responderChannel = state.NewChannel(state.Config{
 		NetworkPassphrase:          networkPassphrase,
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
 		Initiator:                  false,
-		LocalEscrowAccount: &state.EscrowAccount{
-			Address:        responder.Escrow.FromAddress(),
-			SequenceNumber: responder.EscrowSequenceNumber,
-			Balances: []state.Amount{
-				{Asset: state.NativeAsset{}, Amount: responder.Contribution},
-			},
-		},
-		RemoteEscrowAccount: &state.EscrowAccount{
-			Address:        initiator.Escrow.FromAddress(),
-			SequenceNumber: initiator.EscrowSequenceNumber,
-			Balances: []state.Amount{
-				{Asset: state.NativeAsset{}, Amount: initiator.Contribution},
-			},
-		},
-		LocalSigner:  responder.KP,
-		RemoteSigner: initiator.KP.FromAddress(),
+		LocalEscrowAccount:         &responderEscrowAccount,
+		RemoteEscrowAccount:        &initiatorEscrowAccount,
+		LocalSigner:                responder.KP,
+		RemoteSigner:               initiator.KP.FromAddress(),
 	})
 	return initiatorChannel, responderChannel
+}
+
+func initAsset(t *testing.T, client horizonclient.ClientInterface) (txnbuild.Asset, *keypair.Full) {
+	issuerKP := keypair.MustRandom()
+	distributorKP := keypair.MustRandom()
+
+	err := retry(2, func() error { return createAccount(client, issuerKP.FromAddress(), 1_000_0000000) })
+	require.NoError(t, err)
+	err = retry(2, func() error { return createAccount(client, distributorKP.FromAddress(), 1_000_0000000) })
+	require.NoError(t, err)
+
+	distributor, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: distributorKP.Address()})
+	require.NoError(t, err)
+
+	abcdAsset := txnbuild.CreditAsset{Code: "ABCD", Issuer: issuerKP.Address()}
+
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &distributor,
+			IncrementSequenceNum: true,
+			BaseFee:              txnbuild.MinBaseFee,
+			Timebounds:           txnbuild.NewInfiniteTimeout(),
+			Operations: []txnbuild.Operation{
+				&txnbuild.ChangeTrust{
+					Line:  abcdAsset,
+					Limit: "5000",
+				},
+				&txnbuild.Payment{
+					Destination:   distributorKP.Address(),
+					Asset:         abcdAsset,
+					Amount:        "5000",
+					SourceAccount: issuerKP.Address(),
+				},
+			},
+		},
+	)
+	tx, err = tx.Sign(networkPassphrase, distributorKP, issuerKP)
+	require.NoError(t, err)
+	_, err = client.SubmitTransaction(tx)
+	require.NoError(t, err)
+
+	return abcdAsset, distributorKP
 }
 
 func randomBool(t *testing.T) bool {
@@ -178,7 +216,53 @@ func retry(maxAttempts int, f func() error) (err error) {
 	return err
 }
 
-func fund(client horizonclient.ClientInterface, account *keypair.FromAddress, startingBalance int64) error {
+func fundAsset(client horizonclient.ClientInterface, asset txnbuild.Asset, amount int64, accountKP *keypair.Full, distributorKP *keypair.Full) error {
+	distributor, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: distributorKP.Address()})
+	if err != nil {
+		return err
+	}
+
+	ops := []txnbuild.Operation{}
+	if !asset.IsNative() {
+		ops = append(ops, &txnbuild.ChangeTrust{
+			SourceAccount: accountKP.Address(),
+			Line:          asset,
+			Limit:         "5000",
+		})
+	}
+	ops = append(ops, &txnbuild.Payment{
+		Destination: accountKP.Address(),
+		Amount:      stellarAmount.StringFromInt64(amount),
+		Asset:       asset,
+	})
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &distributor,
+		IncrementSequenceNum: true,
+		BaseFee:              txnbuild.MinBaseFee,
+		Timebounds:           txnbuild.NewTimeout(300),
+		Operations:           ops,
+	})
+	if err != nil {
+		return err
+	}
+	if !asset.IsNative() {
+		tx, err = tx.Sign(networkPassphrase, accountKP)
+		if err != nil {
+			return err
+		}
+	}
+	tx, err = tx.Sign(networkPassphrase, distributorKP)
+	if err != nil {
+		return err
+	}
+	_, err = client.SubmitTransaction(tx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createAccount(client horizonclient.ClientInterface, account *keypair.FromAddress, startingBalance int64) error {
 	rootResp, err := client.Root()
 	if err != nil {
 		return err

--- a/sdk/state/integration/state_test.go
+++ b/sdk/state/integration/state_test.go
@@ -41,8 +41,13 @@ func TestMain(m *testing.M) {
 }
 
 func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
-	initiator, responder := initAccounts(t)
-	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
+	asset := txnbuild.NativeAsset{}
+	assetLimit := ""
+	rootResp, err := client.Root()
+	require.NoError(t, err)
+	distributor := keypair.Master(rootResp.NetworkPassphrase).(*keypair.Full)
+	initiator, responder := initAccounts(t, client, asset, assetLimit, distributor)
+	initiatorChannel, responderChannel := initChannels(t, client, initiator, responder)
 
 	// Tx history.
 	closeTxs := []*txnbuild.Transaction{}
@@ -278,8 +283,14 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 }
 
 func TestOpenUpdatesCoordinatedClose(t *testing.T) {
-	initiator, responder := initAccounts(t)
-	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
+	// TODO - test nonnative asset
+	asset := txnbuild.NativeAsset{}
+	assetLimit := ""
+	rootResp, err := client.Root()
+	require.NoError(t, err)
+	distributor := keypair.Master(rootResp.NetworkPassphrase).(*keypair.Full)
+	initiator, responder := initAccounts(t, client, asset, assetLimit, distributor)
+	initiatorChannel, responderChannel := initChannels(t, client, initiator, responder)
 
 	s := initiator.EscrowSequenceNumber + 1
 	i := int64(1)

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -1,47 +1,57 @@
 package txbuild
 
 import (
-	"github.com/stellar/go/amount"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
 )
 
 type CreateEscrowParams struct {
-	Creator             *keypair.FromAddress
-	Escrow              *keypair.FromAddress
-	SequenceNumber      int64
-	InitialContribution int64
+	Creator        *keypair.FromAddress
+	Escrow         *keypair.FromAddress
+	SequenceNumber int64
+	Asset          txnbuild.Asset
+	AssetLimit     string
 }
 
 func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
+	ops := []txnbuild.Operation{
+		&txnbuild.BeginSponsoringFutureReserves{
+			SponsoredID: p.Escrow.Address(),
+		},
+		&txnbuild.CreateAccount{
+			Destination: p.Escrow.Address(),
+			// base reserves sponsored by p.Creator
+			Amount: "0",
+		},
+		&txnbuild.SetOptions{
+			SourceAccount:   p.Escrow.Address(),
+			MasterWeight:    txnbuild.NewThreshold(0),
+			LowThreshold:    txnbuild.NewThreshold(1),
+			MediumThreshold: txnbuild.NewThreshold(1),
+			HighThreshold:   txnbuild.NewThreshold(1),
+			Signer:          &txnbuild.Signer{Address: p.Creator.Address(), Weight: 1},
+		},
+	}
+	if !p.Asset.IsNative() {
+		ops = append(ops, &txnbuild.ChangeTrust{
+			Line:          p.Asset,
+			Limit:         p.AssetLimit,
+			SourceAccount: p.Escrow.Address(),
+		})
+	}
+	ops = append(ops, &txnbuild.EndSponsoringFutureReserves{
+		SourceAccount: p.Escrow.Address(),
+	})
+
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
 			SourceAccount: &txnbuild.SimpleAccount{
 				AccountID: p.Creator.Address(),
 				Sequence:  p.SequenceNumber,
 			},
-			BaseFee:              0,
-			Timebounds:           txnbuild.NewTimeout(300),
-			Operations: []txnbuild.Operation{
-				&txnbuild.BeginSponsoringFutureReserves{
-					SponsoredID: p.Escrow.Address(),
-				},
-				&txnbuild.CreateAccount{
-					Destination: p.Escrow.Address(),
-					Amount:      amount.StringFromInt64(p.InitialContribution),
-				},
-				&txnbuild.SetOptions{
-					SourceAccount:   p.Escrow.Address(),
-					MasterWeight:    txnbuild.NewThreshold(0),
-					LowThreshold:    txnbuild.NewThreshold(1),
-					MediumThreshold: txnbuild.NewThreshold(1),
-					HighThreshold:   txnbuild.NewThreshold(1),
-					Signer:          &txnbuild.Signer{Address: p.Creator.Address(), Weight: 1},
-				},
-				&txnbuild.EndSponsoringFutureReserves{
-					SourceAccount: p.Escrow.Address(),
-				},
-			},
+			BaseFee:    0,
+			Timebounds: txnbuild.NewTimeout(300),
+			Operations: ops,
 		},
 	)
 	if err != nil {

--- a/sdk/txbuild/test_test.go
+++ b/sdk/txbuild/test_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
-	"github.com/stellar/go/amount"
+	stellarAmount "github.com/stellar/go/amount"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
@@ -52,10 +52,10 @@ func Test(t *testing.T) {
 		seqNum, err := account.GetSequenceNumber()
 		require.NoError(t, err)
 		tx, err := txbuild.CreateEscrow(txbuild.CreateEscrowParams{
-			Creator:             initiator.KP.FromAddress(),
-			Escrow:              initiator.Escrow.FromAddress(),
-			SequenceNumber:      seqNum + 1,
-			InitialContribution: initiator.Contribution,
+			Creator:        initiator.KP.FromAddress(),
+			Escrow:         initiator.Escrow.FromAddress(),
+			SequenceNumber: seqNum + 1,
+			Asset:          txnbuild.NativeAsset{},
 		})
 		require.NoError(t, err)
 		tx, err = tx.Sign(networkPassphrase, initiator.KP, initiator.Escrow)
@@ -71,6 +71,28 @@ func Test(t *testing.T) {
 		txResp, err := client.SubmitFeeBumpTransaction(fbtx)
 		require.NoError(t, err)
 		initiator.EscrowSequenceNumber = int64(txResp.Ledger) << 32
+
+		// add initial contribution
+		_, err = account.IncrementSequenceNumber()
+		require.NoError(t, err)
+
+		tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+			SourceAccount:        &account,
+			BaseFee:              txnbuild.MinBaseFee,
+			Timebounds:           txnbuild.NewTimeout(300),
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					Destination: initiator.Escrow.Address(),
+					Amount:      stellarAmount.StringFromInt64(initiator.Contribution),
+					Asset:       txnbuild.NativeAsset{},
+				},
+			},
+		})
+		tx, err = tx.Sign(networkPassphrase, initiator.KP)
+		require.NoError(t, err)
+		_, err = client.SubmitTransaction(tx)
+		require.NoError(t, err)
 	}
 	t.Log("Initiator Escrow Sequence Number:", initiator.EscrowSequenceNumber)
 	t.Log("Initiator Contribution:", initiator.Contribution)
@@ -92,10 +114,10 @@ func Test(t *testing.T) {
 		seqNum, err := account.GetSequenceNumber()
 		require.NoError(t, err)
 		tx, err := txbuild.CreateEscrow(txbuild.CreateEscrowParams{
-			Creator:             responder.KP.FromAddress(),
-			Escrow:              responder.Escrow.FromAddress(),
-			SequenceNumber:      seqNum + 1,
-			InitialContribution: responder.Contribution,
+			Creator:        responder.KP.FromAddress(),
+			Escrow:         responder.Escrow.FromAddress(),
+			SequenceNumber: seqNum + 1,
+			Asset:          txnbuild.NativeAsset{},
 		})
 		require.NoError(t, err)
 		tx, err = tx.Sign(networkPassphrase, responder.KP, responder.Escrow)
@@ -111,6 +133,28 @@ func Test(t *testing.T) {
 		txResp, err := client.SubmitFeeBumpTransaction(fbtx)
 		require.NoError(t, err)
 		responder.EscrowSequenceNumber = int64(txResp.Ledger) << 32
+
+		// add initial contribution
+		_, err = account.IncrementSequenceNumber()
+		require.NoError(t, err)
+
+		tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
+			SourceAccount:        &account,
+			BaseFee:              txnbuild.MinBaseFee,
+			Timebounds:           txnbuild.NewTimeout(300),
+			IncrementSequenceNum: true,
+			Operations: []txnbuild.Operation{
+				&txnbuild.Payment{
+					Destination: responder.Escrow.Address(),
+					Amount:      stellarAmount.StringFromInt64(responder.Contribution),
+					Asset:       txnbuild.NativeAsset{},
+				},
+			},
+		})
+		tx, err = tx.Sign(networkPassphrase, responder.KP)
+		require.NoError(t, err)
+		_, err = client.SubmitTransaction(tx)
+		require.NoError(t, err)
 	}
 	t.Log("Responder Escrow Sequence Number:", responder.EscrowSequenceNumber)
 	t.Log("Responder Contribution:", responder.Contribution)
@@ -382,7 +426,7 @@ func fund(client horizonclient.ClientInterface, account *keypair.FromAddress, st
 			Operations: []txnbuild.Operation{
 				&txnbuild.CreateAccount{
 					Destination: account.Address(),
-					Amount:      amount.StringFromInt64(startingBalance),
+					Amount:      stellarAmount.StringFromInt64(startingBalance),
 				},
 			},
 		},


### PR DESCRIPTION
escrow accounts supporting non-native assets. Currently escrow accounts are for xlm only. This changes that

In order to test this there needed to be changes done in the test files. Comments point out where

closes part of [this ticket](https://github.com/stellar/experimental-payment-channels/issues/71)

