### PR TITLE
sdk/state: finish adding non-native asset support

### DIFF
--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+// TODO - should store on channel like Update and Close proposals?
 type Open struct {
 	CloseSignatures       []xdr.DecoratedSignature
 	DeclarationSignatures []xdr.DecoratedSignature
 	FormationSignatures   []xdr.DecoratedSignature
 
-	// TODO - should store on channel or pull from channel?
 	Asset      Asset
 	AssetLimit string
 }

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -19,6 +19,7 @@ type Open struct {
 	AssetLimit string
 }
 
+// OpenParams are the parameters selected by the participant proposing an open channel.
 type OpenParams struct {
 	Asset      Asset
 	AssetLimit string

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -1,0 +1,47 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProposePayment_valid_asset(t *testing.T) {
+	localSigner := keypair.MustRandom()
+	remoteSigner := keypair.MustRandom()
+	localEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(101),
+	}
+	remoteEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(202),
+	}
+	sendingChannel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           true,
+		LocalSigner:         localSigner,
+		RemoteSigner:        remoteSigner.FromAddress(),
+		LocalEscrowAccount:  localEscrowAccount,
+		RemoteEscrowAccount: remoteEscrowAccount,
+	})
+
+	native := NativeAsset{}
+	_, err := sendingChannel.ProposeOpen(OpenParams{Asset: native, AssetLimit: ""})
+	require.NoError(t, err)
+
+	invalidCredit := CreditAsset{}
+	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: invalidCredit, AssetLimit: ""})
+	require.Error(t, err)
+
+	validCredit := CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
+	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: validCredit, AssetLimit: ""})
+	require.Error(t, err)
+	require.Equal(t, "parsing asset limit: strconv.Atoi: parsing \"\": invalid syntax", err.Error())
+
+	validCredit = CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
+	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: validCredit, AssetLimit: "100"})
+	require.NoError(t, err)
+}

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -22,7 +22,6 @@ type Amount struct {
 type EscrowAccount struct {
 	Address        *keypair.FromAddress
 	SequenceNumber int64
-	Balances       []Amount
 }
 
 type Channel struct {

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -38,8 +38,12 @@ func TestLastConfirmedPayment(t *testing.T) {
 		RemoteEscrowAccount: localEscrowAccount,
 	})
 
+	// latest close agreement should be set during open steps
+	sendingChannel.latestCloseAgreement.Balance = Amount{Asset: NativeAsset{}}
+	receiverChannel.latestCloseAgreement.Balance = Amount{Asset: NativeAsset{}}
+
 	p, err := sendingChannel.ProposePayment(Amount{
-		Asset:  txnbuild.NativeAsset{},
+		Asset:  NativeAsset{},
 		Amount: 200,
 	})
 	require.NoError(t, err)
@@ -63,7 +67,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, "a different unconfirmed payment exists", err.Error())
 	assert.Equal(t, p, receiverChannel.latestUnconfirmedPayment)
-	assert.Equal(t, CloseAgreement{}, receiverChannel.LatestCloseAgreement())
+	assert.Equal(t, CloseAgreement{Balance: Amount{Asset: NativeAsset{}}}, receiverChannel.LatestCloseAgreement())
 
 	// Confirming a payment with same sequence number and same amount should pass
 	p, fullySigned, err = sendingChannel.ConfirmPayment(p)


### PR DESCRIPTION
this is the final changes for supporting non-native assets.

1. Changes the Open functions to take asset type as an input, so that we can create channels with non-native
2. Changes the Update functions to support non-native
3. Add non-native functionality to tests

(note the closing functions are already supporting non-native from previous PRs)