### PR TITLE
sdk/state: fix TestProposePayment_validAsset test

### DIFF
--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProposePayment_valid_asset(t *testing.T) {
+func TestProposePayment_validAsset(t *testing.T) {
 	localSigner := keypair.MustRandom()
 	remoteSigner := keypair.MustRandom()
 	localEscrowAccount := &EscrowAccount{
@@ -33,13 +33,12 @@ func TestProposePayment_valid_asset(t *testing.T) {
 	require.NoError(t, err)
 
 	invalidCredit := CreditAsset{}
-	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: invalidCredit, AssetLimit: ""})
-	require.Error(t, err)
+	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: invalidCredit, AssetLimit: "100"})
+	require.EqualError(t, err, `validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: asset code length must be between 1 and 12 characters`)
 
 	validCredit := CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
 	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: validCredit, AssetLimit: ""})
-	require.Error(t, err)
-	require.Equal(t, "parsing asset limit: strconv.Atoi: parsing \"\": invalid syntax", err.Error())
+	require.EqualError(t, err, `parsing asset limit: strconv.Atoi: parsing "": invalid syntax`)
 
 	validCredit = CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
 	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: validCredit, AssetLimit: "100"})


### PR DESCRIPTION
### What

Small changes to the `TestProposePayment_valid_asset` test:

- Rename to `TestProposePayment_validAsset`.
- Change the setup of the invalid asset test so that a valid asset limit is provided.
- Use EqualError instead of separate Error and Equal assertions.

### Why

Camel case for test descriptions is more common after the first underscore that separates the test entity from the description.

The invalid asset test had an invalid asset limit so it was testing the same thing as the invalid asset limit test and not actually testing that invalid assets provided to the function will be caught.

We can use EqualError to check that an error occurred and that its error string matches the given value.