### PR TITLE
sdk: add golangci-lint ci run

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -8,6 +8,22 @@ on:
 
 jobs:
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.41.1
+          working-directory: sdk
+          skip-go-installation: true
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/sdk/state/integration/helpers_test.go
+++ b/sdk/state/integration/helpers_test.go
@@ -103,6 +103,7 @@ func initEscrowAccount(t *testing.T, client horizonclient.ClientInterface, parti
 			},
 		},
 	})
+	require.NoError(t, err)
 
 	tx, err = tx.Sign(networkPassphrase, participant.KP)
 	require.NoError(t, err)
@@ -182,6 +183,7 @@ func initAsset(t *testing.T, client horizonclient.ClientInterface) (txnbuild.Ass
 			},
 		},
 	)
+	require.NoError(t, err)
 	tx, err = tx.Sign(networkPassphrase, distributorKP, issuerKP)
 	require.NoError(t, err)
 	_, err = client.SubmitTransaction(tx)

--- a/sdk/state/integration/state_test.go
+++ b/sdk/state/integration/state_test.go
@@ -62,7 +62,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 
 	// Open
 	t.Log("Open...")
-	open, err := initiatorChannel.ProposeOpen(state.OpenParams{asset, assetLimit})
+	open, err := initiatorChannel.ProposeOpen(state.OpenParams{Asset: asset, AssetLimit: assetLimit})
 	require.NoError(t, err)
 	for {
 		var fullySignedR bool
@@ -81,7 +81,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	}
 
 	{
-		ci, di, fi, err := initiatorChannel.OpenTxs(state.OpenParams{asset, assetLimit})
+		ci, di, fi, err := initiatorChannel.OpenTxs(state.OpenParams{Asset: asset, AssetLimit: assetLimit})
 		require.NoError(t, err)
 
 		ci, err = ci.AddSignatureDecorated(open.CloseSignatures...)
@@ -319,10 +319,10 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 		ci, di, fi, err := initiatorChannel.OpenTxs(state.OpenParams{Asset: asset, AssetLimit: assetLimit})
 		require.NoError(t, err)
 
-		ci, err = ci.AddSignatureDecorated(open.CloseSignatures...)
+		_, err = ci.AddSignatureDecorated(open.CloseSignatures...)
 		require.NoError(t, err)
 
-		di, err = di.AddSignatureDecorated(open.DeclarationSignatures...)
+		_, err = di.AddSignatureDecorated(open.DeclarationSignatures...)
 		require.NoError(t, err)
 
 		fi, err = fi.AddSignatureDecorated(open.FormationSignatures...)
@@ -394,9 +394,9 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 		require.True(t, fullySigned)
 		ci, di, err := sendingChannel.PaymentTxs(payment)
 		require.NoError(t, err)
-		ci, err = ci.AddSignatureDecorated(payment.CloseSignatures...)
+		_, err = ci.AddSignatureDecorated(payment.CloseSignatures...)
 		require.NoError(t, err)
-		di, err = di.AddSignatureDecorated(payment.DeclarationSignatures...)
+		_, err = di.AddSignatureDecorated(payment.DeclarationSignatures...)
 		require.NoError(t, err)
 	}
 
@@ -425,7 +425,7 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	cc, fullySigned, err := responderChannel.ConfirmCoordinatedClose(cc)
 	require.NoError(t, err)
 	require.True(t, fullySigned)
-	cc, fullySigned, err = initiatorChannel.ConfirmCoordinatedClose(cc)
+	_, fullySigned, err = initiatorChannel.ConfirmCoordinatedClose(cc)
 	require.NoError(t, err)
 	require.True(t, fullySigned)
 
@@ -433,6 +433,7 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	txCoordinated, err := initiatorChannel.CoordinatedCloseTx()
 	require.NoError(t, err)
 	txCoordinated, err = txCoordinated.AddSignatureDecorated(initiatorChannel.CoordinatedClose().CloseSignatures...)
+	require.NoError(t, err)
 	fbtx, err = txnbuild.NewFeeBumpTransaction(txnbuild.FeeBumpTransactionParams{
 		Inner:      txCoordinated,
 		FeeAccount: initiator.KP.Address(),

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -138,14 +138,14 @@ func (c *Channel) ConfirmPayment(p Payment) (payment Payment, fullySigned bool, 
 
 	// validate payment
 	if p.IterationNumber != c.NextIterationNumber() {
-		return p, fullySigned, errors.New(fmt.Sprintf("invalid payment iteration number, got: %s want: %s",
+		return p, fullySigned, fmt.Errorf("invalid payment iteration number, got: %s want: %s",
 			strconv.FormatInt(p.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10)))
 	}
 	if !c.latestUnconfirmedPayment.isEmpty() && !c.latestUnconfirmedPayment.isEquivalent(p) {
 		return p, fullySigned, errors.New("a different unconfirmed payment exists")
 	}
 	if p.Amount.Asset != c.latestCloseAgreement.Balance.Asset {
-		return Payment{}, fullySigned, errors.New(fmt.Sprintf("payment asset type is invalid, got: %s want: %s",
+		return Payment{}, fullySigned, fmt.Errorf("payment asset type is invalid, got: %s want: %s",
 			p.Amount.Asset, c.latestCloseAgreement.Balance.Asset))
 	}
 

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -32,7 +32,7 @@ func (p Payment) isEquivalent(p2 Payment) bool {
 }
 
 func (p Payment) isEmpty() bool {
-	return p.IterationNumber == 0 && p.Amount == (Amount{}) && p.FromInitiator == false && len(p.CloseSignatures) == 0 && len(p.DeclarationSignatures) == 0
+	return p.IterationNumber == 0 && p.Amount == (Amount{}) && !p.FromInitiator && len(p.CloseSignatures) == 0 && len(p.DeclarationSignatures) == 0
 }
 
 type CloseAgreement struct {
@@ -47,8 +47,8 @@ func (c *Channel) ProposePayment(amount Amount) (Payment, error) {
 		return Payment{}, errors.New("payment amount must be greater than 0")
 	}
 	if amount.Asset != c.latestCloseAgreement.Balance.Asset {
-		return Payment{}, errors.New(fmt.Sprintf("payment asset type is invalid, got: %s want: %s",
-			amount.Asset, c.latestCloseAgreement.Balance.Asset))
+		return Payment{}, fmt.Errorf("payment asset type is invalid, got: %s want: %s",
+			amount.Asset, c.latestCloseAgreement.Balance.Asset)
 	}
 	newBalance := int64(0)
 	if c.initiator {

--- a/sdk/txbuild/test_test.go
+++ b/sdk/txbuild/test_test.go
@@ -89,6 +89,7 @@ func Test(t *testing.T) {
 				},
 			},
 		})
+		require.NoError(t, err)
 		tx, err = tx.Sign(networkPassphrase, initiator.KP)
 		require.NoError(t, err)
 		_, err = client.SubmitTransaction(tx)
@@ -151,6 +152,7 @@ func Test(t *testing.T) {
 				},
 			},
 		})
+		require.NoError(t, err)
 		tx, err = tx.Sign(networkPassphrase, responder.KP)
 		require.NoError(t, err)
 		_, err = client.SubmitTransaction(tx)


### PR DESCRIPTION
### What
Add golangci-lint linter to run on PRs.

### Why
To get some of the basic lint checks that we use in other repos, like staticcheck, to reduce warnings that some IDEs like VSCode will display when viewing the code in this repo.

We don't actually use golangci-lint in the stellar/go repo, but it is a popular and simple way to run a variety of linters including staticcheck, and if it goes well here I think I'll propose we replace staticcheck there with it too.