### PR TITLE
sdk/txbuild: remove comment about time bounds

### DIFF
--- a/sdk/txbuild/close.go
+++ b/sdk/txbuild/close.go
@@ -29,7 +29,6 @@ func Close(p CloseParams) (*txnbuild.Transaction, error) {
 			Sequence:  startSequenceOfIteration(p.StartSequence, p.IterationNumber) + 1, // Close is the second transaction in an iteration's transaction set.
 		},
 		BaseFee: 0,
-		// TODO - Timebounds needs to be explicit
 		Timebounds:           txnbuild.NewInfiniteTimeout(),
 		MinSequenceAge:       int64(p.ObservationPeriodTime.Seconds()),
 		MinSequenceLedgerGap: p.ObservationPeriodLedgerGap,

--- a/sdk/txbuild/declaration.go
+++ b/sdk/txbuild/declaration.go
@@ -20,7 +20,6 @@ func Declaration(p DeclarationParams) (*txnbuild.Transaction, error) {
 			Sequence:  startSequenceOfIteration(p.StartSequence, p.IterationNumber) + 0, // Declaration is the first transaction in an iteration's transaction set.
 		},
 		BaseFee: 0,
-		// TODO - Timebounds needs to be explicit
 		Timebounds:        txnbuild.NewInfiniteTimeout(),
 		MinSequenceNumber: &minSequenceNumber,
 		Operations: []txnbuild.Operation{


### PR DESCRIPTION
### What
Remove the todo comment saying we need to make the time bounds explicit.

### Why
Channels are long lived and we actually want the closes to be valid for a long time, indefinitely. There's no need to restrict the window within which they are valid. We're using the new relative bounds mechanisms introduced in CAP-21 to limit when they can be executed instead.