### PR TITLE
sdk/state: use CloseAgreement instead of Payment and CoordinatedClose structs

### DIFF
--- a/sdk/state/integration/state_test.go
+++ b/sdk/state/integration/state_test.go
@@ -427,7 +427,7 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, fullySigned)
 
-	ca, fullySigned, err = initiatorChannel.ConfirmCoordinatedClose(ca)
+	_, fullySigned, err = initiatorChannel.ConfirmCoordinatedClose(ca)
 	require.NoError(t, err)
 	require.True(t, fullySigned)
 

--- a/sdk/state/integration/state_test.go
+++ b/sdk/state/integration/state_test.go
@@ -423,20 +423,18 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	ca, err := initiatorChannel.ProposeCoordinatedClose()
 	require.NoError(t, err)
 
-	ca, fullySigned, err := responderChannel.ConfirmCoordinatedClose(cc)
+	ca, fullySigned, err := responderChannel.ConfirmCoordinatedClose(ca)
 	require.NoError(t, err)
 	require.True(t, fullySigned)
-	require.Equal(t, CloseAgreement{}, responderChannel.latestUnconfirmedCloseAgreement)
 
-	ca, fullySigned, err = initiatorChannel.ConfirmCoordinatedClose(cc)
+	ca, fullySigned, err = initiatorChannel.ConfirmCoordinatedClose(ca)
 	require.NoError(t, err)
 	require.True(t, fullySigned)
-	require.Equal(t, CloseAgreement{}, initiatorChannel.latestUnconfirmedCloseAgreement)
 
 	t.Log("Initiator closing channel with new coordinated close transaction")
 	txCoordinated, err := initiatorChannel.CoordinatedCloseTx()
 	require.NoError(t, err)
-	txCoordinated, err = txCoordinated.AddSignatureDecorated(initiatorChannel.CoordinatedClose().CloseSignatures...)
+	txCoordinated, err = txCoordinated.AddSignatureDecorated(initiatorChannel.LatestCloseAgreement().CloseSignatures...)
 	require.NoError(t, err)
 	fbtx, err = txnbuild.NewFeeBumpTransaction(txnbuild.FeeBumpTransactionParams{
 		Inner:      txCoordinated,

--- a/sdk/state/integration/state_test.go
+++ b/sdk/state/integration/state_test.go
@@ -420,14 +420,18 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Initiator proposes a coordinated close")
-	cc, err := initiatorChannel.ProposeCoordinatedClose()
+	ca, err := initiatorChannel.ProposeCoordinatedClose()
 	require.NoError(t, err)
-	cc, fullySigned, err := responderChannel.ConfirmCoordinatedClose(cc)
-	require.NoError(t, err)
-	require.True(t, fullySigned)
-	cc, fullySigned, err = initiatorChannel.ConfirmCoordinatedClose(cc)
+
+	ca, fullySigned, err := responderChannel.ConfirmCoordinatedClose(cc)
 	require.NoError(t, err)
 	require.True(t, fullySigned)
+	require.Equal(t, CloseAgreement{}, responderChannel.latestUnconfirmedCloseAgreement)
+
+	ca, fullySigned, err = initiatorChannel.ConfirmCoordinatedClose(cc)
+	require.NoError(t, err)
+	require.True(t, fullySigned)
+	require.Equal(t, CloseAgreement{}, initiatorChannel.latestUnconfirmedCloseAgreement)
 
 	t.Log("Initiator closing channel with new coordinated close transaction")
 	txCoordinated, err := initiatorChannel.CoordinatedCloseTx()

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -73,8 +73,8 @@ func NewChannel(c Config) *Channel {
 }
 
 func (c *Channel) NextIterationNumber() int64 {
-	if !c.latestUnconfirmedPayment.isEmpty() {
-		return c.latestUnconfirmedPayment.IterationNumber
+	if !c.latestUnconfirmedCloseAgreement.isEmpty() {
+		return c.latestUnconfirmedCloseAgreement.IterationNumber
 	}
 	return c.latestCloseAgreement.IterationNumber + 1
 }
@@ -87,25 +87,6 @@ func (c *Channel) Balance() Amount {
 
 func (c *Channel) LatestCloseAgreement() CloseAgreement {
 	return c.latestCloseAgreement
-}
-
-func (c *Channel) CoordinatedClose() CoordinatedClose {
-	return c.coordinatedClose
-}
-
-// newBalance is a hlper method for computing what the new channel balance will be if
-// the input payment is submitted successfully.
-func (c *Channel) newBalance(p Payment) Amount {
-	var amountFromInitiator, amountFromResponder int64
-	if p.FromInitiator {
-		amountFromInitiator = p.Amount.Amount
-	} else {
-		amountFromResponder = p.Amount.Amount
-	}
-	return Amount{
-		Asset:  p.Amount.Asset,
-		Amount: c.Balance().Amount + amountFromInitiator - amountFromResponder,
-	}
 }
 
 func (c *Channel) initiatorEscrowAccount() *EscrowAccount {

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -40,10 +40,8 @@ type Channel struct {
 	localSigner  *keypair.Full
 	remoteSigner *keypair.FromAddress
 
-	latestCloseAgreement     CloseAgreement
-	latestUnconfirmedPayment Payment
-
-	coordinatedClose CoordinatedClose
+	latestCloseAgreement            CloseAgreement
+	latestUnconfirmedCloseAgreement CloseAgreement
 }
 
 type Config struct {

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -44,43 +44,43 @@ func TestLastConfirmedPayment(t *testing.T) {
 	sendingChannel.latestCloseAgreement.Balance = Amount{Asset: NativeAsset{}}
 	receiverChannel.latestCloseAgreement.Balance = Amount{Asset: NativeAsset{}}
 
-	p, err := sendingChannel.ProposePayment(Amount{
+	ca, err := sendingChannel.ProposePayment(Amount{
 		Asset:  NativeAsset{},
 		Amount: 200,
 	})
 	require.NoError(t, err)
 
-	p, fullySigned, err := receiverChannel.ConfirmPayment(p)
+	ca, fullySigned, err := receiverChannel.ConfirmPayment(ca)
 	assert.False(t, fullySigned)
 	require.NoError(t, err)
-	assert.Equal(t, p, receiverChannel.latestUnconfirmedPayment)
+	assert.Equal(t, ca, receiverChannel.latestUnconfirmedCloseAgreement)
 
-	// Confirming a payment with same sequence number but different Amount should error
-	pDifferent := Payment{
+	// Confirming a close agreement with same sequence number but different Amount should error
+	caDifferent := CloseAgreement{
 		IterationNumber: 1,
-		Amount: Amount{
+		Balance: Amount{
 			Asset:  txnbuild.NativeAsset{},
 			Amount: 400,
 		},
-		CloseSignatures: p.CloseSignatures,
+		CloseSignatures: ca.CloseSignatures,
 	}
-	_, fullySigned, err = receiverChannel.ConfirmPayment(pDifferent)
+	_, fullySigned, err = receiverChannel.ConfirmPayment(caDifferent)
 	assert.False(t, fullySigned)
 	require.Error(t, err)
 	require.Equal(t, "a different unconfirmed payment exists", err.Error())
-	assert.Equal(t, p, receiverChannel.latestUnconfirmedPayment)
+	assert.Equal(t, ca, receiverChannel.latestUnconfirmedCloseAgreement)
 	assert.Equal(t, CloseAgreement{Balance: Amount{Asset: NativeAsset{}}}, receiverChannel.LatestCloseAgreement())
 
 	// Confirming a payment with same sequence number and same amount should pass
-	p, fullySigned, err = sendingChannel.ConfirmPayment(p)
+	ca, fullySigned, err = sendingChannel.ConfirmPayment(ca)
 	assert.True(t, fullySigned)
 	require.NoError(t, err)
-	assert.Equal(t, Payment{}, sendingChannel.latestUnconfirmedPayment)
+	assert.Equal(t, CloseAgreement{}, sendingChannel.latestUnconfirmedCloseAgreement)
 
-	p, fullySigned, err = receiverChannel.ConfirmPayment(p)
+	ca, fullySigned, err = receiverChannel.ConfirmPayment(ca)
 	assert.True(t, fullySigned)
 	require.NoError(t, err)
-	assert.Equal(t, Payment{}, receiverChannel.latestUnconfirmedPayment)
+	assert.Equal(t, CloseAgreement{}, receiverChannel.latestUnconfirmedCloseAgreement)
 }
 
 func TestAppendNewSignature(t *testing.T) {


### PR DESCRIPTION
from [this comment](https://github.com/stellar/experimental-payment-channels/pull/83#discussion_r657387696) I removed `CoordinatedClose` and changed `channel.latestUnconfirmedPayment` to `channel.latestUnconfirmedCloseAgreement`. 

In doing so it became apparent we don't need the `Payment` struct, and can just pass around / store a `CloseAgreement` 😄 . So made those changes here