### PR TITLE
sdk/state: make close agreement details comparable

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -19,7 +19,7 @@ func (c *Channel) CloseTxs() (txDecl *txnbuild.Transaction, txClose *txnbuild.Tr
 	txDecl, err = txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
 		StartSequence:           c.startingSequence,
-		IterationNumber:         c.latestCloseAgreement.IterationNumber,
+		IterationNumber:         c.latestCloseAgreement.Details.IterationNumber,
 		IterationNumberExecuted: 0,
 	})
 	if err != nil {
@@ -55,8 +55,7 @@ func (c *Channel) ProposeCoordinatedClose() (CloseAgreement, error) {
 
 	// store an unconfirmed close agreement with new close signatures
 	c.latestUnconfirmedCloseAgreement = CloseAgreement{
-		IterationNumber: c.latestCloseAgreement.IterationNumber,
-		Balance:         c.latestCloseAgreement.Balance,
+		Details:         c.latestCloseAgreement.Details,
 		CloseSignatures: txCoordinatedClose.Signatures(),
 	}
 	return c.latestUnconfirmedCloseAgreement, nil
@@ -93,8 +92,7 @@ func (c *Channel) ConfirmCoordinatedClose(ca CloseAgreement) (closeAgreement Clo
 
 	// new close agreement is valid and fully signed, store it as latestCloseAgreement and clear latestUnconfirmedCloseAgreement
 	c.latestCloseAgreement = CloseAgreement{
-		IterationNumber:       ca.IterationNumber,
-		Balance:               ca.Balance,
+		Details:               ca.Details,
 		CloseSignatures:       appendNewSignatures(c.latestUnconfirmedCloseAgreement.CloseSignatures, ca.CloseSignatures),
 		DeclarationSignatures: c.latestUnconfirmedCloseAgreement.DeclarationSignatures,
 	}
@@ -112,9 +110,9 @@ func (c *Channel) makeCloseTx(observationPeriodTime time.Duration, observationPe
 		InitiatorEscrow:            c.initiatorEscrowAccount().Address,
 		ResponderEscrow:            c.responderEscrowAccount().Address,
 		StartSequence:              c.startingSequence,
-		IterationNumber:            c.latestCloseAgreement.IterationNumber,
+		IterationNumber:            c.latestCloseAgreement.Details.IterationNumber,
 		AmountToInitiator:          c.initiatorBalanceAmount(),
 		AmountToResponder:          c.responderBalanceAmount(),
-		Asset:                      c.latestCloseAgreement.Balance.Asset,
+		Asset:                      c.latestCloseAgreement.Details.Balance.Asset,
 	})
 }

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -184,8 +184,10 @@ func (c *Channel) ConfirmOpen(m Open) (open Open, fullySigned bool, err error) {
 	// transactions in the open.
 	fullySigned = true
 	c.latestCloseAgreement = CloseAgreement{
-		IterationNumber:       1,
-		Balance:               Amount{Asset: m.Asset},
+		Details: CloseAgreementDetails{
+			IterationNumber: 1,
+			Balance:         Amount{Asset: m.Asset},
+		},
 		CloseSignatures:       m.CloseSignatures,
 		DeclarationSignatures: m.DeclarationSignatures,
 	}

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -74,15 +74,15 @@ func NewChannel(c Config) *Channel {
 
 func (c *Channel) NextIterationNumber() int64 {
 	if !c.latestUnconfirmedCloseAgreement.isEmpty() {
-		return c.latestUnconfirmedCloseAgreement.IterationNumber
+		return c.latestUnconfirmedCloseAgreement.Details.IterationNumber
 	}
-	return c.latestCloseAgreement.IterationNumber + 1
+	return c.latestCloseAgreement.Details.IterationNumber + 1
 }
 
 // Balance returns the amount owing from the initiator to the responder, if positive, or
 // the amount owing from the responder to the initiator, if negative.
 func (c *Channel) Balance() Amount {
-	return c.latestCloseAgreement.Balance
+	return c.latestCloseAgreement.Details.Balance
 }
 
 func (c *Channel) LatestCloseAgreement() CloseAgreement {
@@ -122,15 +122,15 @@ func (c *Channel) responderSigner() *keypair.FromAddress {
 }
 
 func (c *Channel) initiatorBalanceAmount() int64 {
-	if c.latestCloseAgreement.Balance.Amount < 0 {
-		return c.latestCloseAgreement.Balance.Amount * -1
+	if c.latestCloseAgreement.Details.Balance.Amount < 0 {
+		return c.latestCloseAgreement.Details.Balance.Amount * -1
 	}
 	return 0
 }
 
 func (c *Channel) responderBalanceAmount() int64 {
-	if c.latestCloseAgreement.Balance.Amount > 0 {
-		return c.latestCloseAgreement.Balance.Amount
+	if c.latestCloseAgreement.Details.Balance.Amount > 0 {
+		return c.latestCloseAgreement.Details.Balance.Amount
 	}
 	return 0
 }

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -17,30 +17,31 @@ import (
 // 3. Sender calls ConfirmPayment
 // 4. Receiver calls ConfirmPayment
 
+// CloseAgreementDetails contains the details that the participants agree on.
+type CloseAgreementDetails struct {
+	IterationNumber int64
+	Balance         Amount
+}
+
+// CloseAgreement contains everything a participant needs to execute the close
+// agreement on the Stellar network.
 type CloseAgreement struct {
-	IterationNumber       int64
-	Balance               Amount
+	Details               CloseAgreementDetails
 	CloseSignatures       []xdr.DecoratedSignature
 	DeclarationSignatures []xdr.DecoratedSignature
 }
 
-// isEquivalent returns true if all fields for the close agreements are equal not including signatures, else false.
-// Two close agreements that are equal may have different signatures depending on who and when this method is called.
-func (ca CloseAgreement) isEquivalent(ca2 CloseAgreement) bool {
-	return ca.IterationNumber == ca2.IterationNumber && ca.Balance == ca2.Balance
-}
-
 func (ca CloseAgreement) isEmpty() bool {
-	return ca.IterationNumber == 0 && ca.Balance == (Amount{}) && len(ca.CloseSignatures) == 0 && len(ca.DeclarationSignatures) == 0
+	return ca.Details == CloseAgreementDetails{} && len(ca.CloseSignatures) == 0 && len(ca.DeclarationSignatures) == 0
 }
 
 func (c *Channel) ProposePayment(amount Amount) (CloseAgreement, error) {
 	if amount.Amount <= 0 {
 		return CloseAgreement{}, errors.New("payment amount must be greater than 0")
 	}
-	if amount.Asset != c.latestCloseAgreement.Balance.Asset {
+	if amount.Asset != c.latestCloseAgreement.Details.Balance.Asset {
 		return CloseAgreement{}, fmt.Errorf("payment asset type is invalid, got: %s want: %s",
-			amount.Asset, c.latestCloseAgreement.Balance.Asset)
+			amount.Asset, c.latestCloseAgreement.Details.Balance.Asset)
 	}
 	newBalance := int64(0)
 	if c.initiator {
@@ -70,8 +71,10 @@ func (c *Channel) ProposePayment(amount Amount) (CloseAgreement, error) {
 	}
 
 	c.latestUnconfirmedCloseAgreement = CloseAgreement{
-		IterationNumber: c.NextIterationNumber(),
-		Balance:         Amount{Asset: amount.Asset, Amount: newBalance},
+		Details: CloseAgreementDetails{
+			IterationNumber: c.NextIterationNumber(),
+			Balance:         Amount{Asset: amount.Asset, Amount: newBalance},
+		},
 		CloseSignatures: txClose.Signatures(),
 	}
 	return c.latestUnconfirmedCloseAgreement, nil
@@ -87,9 +90,9 @@ func (c *Channel) PaymentTxs(ca CloseAgreement) (close, decl *txnbuild.Transacti
 		ResponderEscrow:            c.responderEscrowAccount().Address,
 		StartSequence:              c.startingSequence,
 		IterationNumber:            c.NextIterationNumber(),
-		AmountToInitiator:          maxInt64(0, ca.Balance.Amount*-1),
-		AmountToResponder:          maxInt64(0, ca.Balance.Amount),
-		Asset:                      ca.Balance.Asset,
+		AmountToInitiator:          maxInt64(0, ca.Details.Balance.Amount*-1),
+		AmountToResponder:          maxInt64(0, ca.Details.Balance.Amount),
+		Asset:                      ca.Details.Balance.Asset,
 	})
 	if err != nil {
 		return
@@ -120,8 +123,10 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 		}
 		// update channel state with updated close agreement
 		updatedCA := CloseAgreement{
-			IterationNumber:       ca.IterationNumber,
-			Balance:               ca.Balance,
+			Details: CloseAgreementDetails{
+				IterationNumber: ca.Details.IterationNumber,
+				Balance:         ca.Details.Balance,
+			},
 			CloseSignatures:       appendNewSignatures(c.latestUnconfirmedCloseAgreement.CloseSignatures, ca.CloseSignatures),
 			DeclarationSignatures: appendNewSignatures(c.latestUnconfirmedCloseAgreement.DeclarationSignatures, ca.DeclarationSignatures),
 		}
@@ -134,17 +139,17 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	}()
 
 	// validate payment
-	if ca.IterationNumber != c.NextIterationNumber() {
+	if ca.Details.IterationNumber != c.NextIterationNumber() {
 		return ca, fullySigned, fmt.Errorf("invalid payment iteration number, got: %s want: %s",
-			strconv.FormatInt(ca.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10))
+			strconv.FormatInt(ca.Details.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10))
 	}
-	if !c.latestUnconfirmedCloseAgreement.isEmpty() && !c.latestUnconfirmedCloseAgreement.isEquivalent(ca) {
+	if !c.latestUnconfirmedCloseAgreement.isEmpty() && c.latestUnconfirmedCloseAgreement.Details != ca.Details {
 		return ca, fullySigned, errors.New("a different unconfirmed payment exists")
 	}
 
-	if ca.Balance.Asset != c.latestCloseAgreement.Balance.Asset {
+	if ca.Details.Balance.Asset != c.latestCloseAgreement.Details.Balance.Asset {
 		return ca, fullySigned, fmt.Errorf("payment asset type is invalid, got: %s want: %s",
-			ca.Balance.Asset, c.latestCloseAgreement.Balance.Asset)
+			ca.Details.Balance.Asset, c.latestCloseAgreement.Details.Balance.Asset)
 	}
 
 	// create payment transactions

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -41,8 +41,8 @@ func TestLastConfirmedPayment(t *testing.T) {
 	})
 
 	// latest close agreement should be set during open steps
-	sendingChannel.latestCloseAgreement.Balance = Amount{Asset: NativeAsset{}}
-	receiverChannel.latestCloseAgreement.Balance = Amount{Asset: NativeAsset{}}
+	sendingChannel.latestCloseAgreement.Details.Balance = Amount{Asset: NativeAsset{}}
+	receiverChannel.latestCloseAgreement.Details.Balance = Amount{Asset: NativeAsset{}}
 
 	ca, err := sendingChannel.ProposePayment(Amount{
 		Asset:  NativeAsset{},
@@ -57,10 +57,12 @@ func TestLastConfirmedPayment(t *testing.T) {
 
 	// Confirming a close agreement with same sequence number but different Amount should error
 	caDifferent := CloseAgreement{
-		IterationNumber: 1,
-		Balance: Amount{
-			Asset:  txnbuild.NativeAsset{},
-			Amount: 400,
+		Details: CloseAgreementDetails{
+			IterationNumber: 1,
+			Balance: Amount{
+				Asset:  txnbuild.NativeAsset{},
+				Amount: 400,
+			},
 		},
 		CloseSignatures: ca.CloseSignatures,
 	}
@@ -69,7 +71,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, "a different unconfirmed payment exists", err.Error())
 	assert.Equal(t, ca, receiverChannel.latestUnconfirmedCloseAgreement)
-	assert.Equal(t, CloseAgreement{Balance: Amount{Asset: NativeAsset{}}}, receiverChannel.LatestCloseAgreement())
+	assert.Equal(t, CloseAgreement{Details: CloseAgreementDetails{Balance: Amount{Asset: NativeAsset{}}}}, receiverChannel.LatestCloseAgreement())
 
 	// Confirming a payment with same sequence number and same amount should pass
 	ca, fullySigned, err = sendingChannel.ConfirmPayment(ca)


### PR DESCRIPTION
### What
Make the `CloseAgreement` fields that define what the agreement is, comparable.

### Why
In some places we're wanting to compare if two close agreements are the same and we are using a function, isEquivalent, to find out. This works, but there are some advantages to us using simple Go value comparisons for this and we can use them if we group the fields that define the details or term of the agreement together:
- The data structure communicates what parts of the agreement make up the actual agreement vs sigs.
- We can use the agreement details as map keys if we need to.
- It makes copying an agreement independent of signatures simpler.
- This follows the same pattern Stellar transactions use.

Close #105 