### PR TITLE
sdk/state: use authorized/unauthorized language

### DIFF
--- a/sdk/state/integration/state_test.go
+++ b/sdk/state/integration/state_test.go
@@ -65,17 +65,17 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{Asset: asset, AssetLimit: assetLimit})
 	require.NoError(t, err)
 	for {
-		var fullySignedR bool
-		open, fullySignedR, err = responderChannel.ConfirmOpen(open)
+		var authorizedR bool
+		open, authorizedR, err = responderChannel.ConfirmOpen(open)
 		if err != nil {
 			t.Fatal(err)
 		}
-		var fullySignedI bool
-		open, fullySignedI, err = initiatorChannel.ConfirmOpen(open)
+		var authorizedI bool
+		open, authorizedI, err = initiatorChannel.ConfirmOpen(open)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if fullySignedI && fullySignedR {
+		if authorizedI && authorizedR {
 			break
 		}
 	}
@@ -150,22 +150,22 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 		ci, di, err := sendingChannel.PaymentTxs(payment)
 		require.NoError(t, err)
 
-		var fullySigned bool
+		var authorized bool
 
 		// Receiver: receives new payment, validates, then confirms by signing both
-		payment, fullySigned, err = receivingChannel.ConfirmPayment(payment)
+		payment, authorized, err = receivingChannel.ConfirmPayment(payment)
 		require.NoError(t, err)
-		require.False(t, fullySigned)
+		require.False(t, authorized)
 
 		// Sender: re-confirms P_i by signing D_i and sending back
-		payment, fullySigned, err = sendingChannel.ConfirmPayment(payment)
+		payment, authorized, err = sendingChannel.ConfirmPayment(payment)
 		require.NoError(t, err)
-		require.True(t, fullySigned)
+		require.True(t, authorized)
 
 		// Receiver: receives new payment, validates, then confirms by signing both
-		payment, fullySigned, err = receivingChannel.ConfirmPayment(payment)
+		payment, authorized, err = receivingChannel.ConfirmPayment(payment)
 		require.NoError(t, err)
-		require.True(t, fullySigned)
+		require.True(t, authorized)
 
 		ci, err = ci.AddSignatureDecorated(payment.CloseSignatures...)
 		require.NoError(t, err)
@@ -300,17 +300,17 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{Asset: asset, AssetLimit: assetLimit})
 	require.NoError(t, err)
 	for {
-		var fullySignedR bool
-		open, fullySignedR, err = responderChannel.ConfirmOpen(open)
+		var authorizedR bool
+		open, authorizedR, err = responderChannel.ConfirmOpen(open)
 		if err != nil {
 			t.Fatal(err)
 		}
-		var fullySignedI bool
-		open, fullySignedI, err = initiatorChannel.ConfirmOpen(open)
+		var authorizedI bool
+		open, authorizedI, err = initiatorChannel.ConfirmOpen(open)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if fullySignedI && fullySignedR {
+		if authorizedI && authorizedR {
 			break
 		}
 	}
@@ -376,22 +376,22 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 		payment, err := sendingChannel.ProposePayment(state.Amount{Asset: asset, Amount: amount})
 		require.NoError(t, err)
 
-		var fullySigned bool
+		var authorized bool
 
 		// Receiver: receives new payment, validates, then confirms by signing both
-		payment, fullySigned, err = receivingChannel.ConfirmPayment(payment)
+		payment, authorized, err = receivingChannel.ConfirmPayment(payment)
 		require.NoError(t, err)
-		require.False(t, fullySigned)
+		require.False(t, authorized)
 
 		// Sender: re-confirms P_i by signing D_i and sending back
-		payment, fullySigned, err = sendingChannel.ConfirmPayment(payment)
+		payment, authorized, err = sendingChannel.ConfirmPayment(payment)
 		require.NoError(t, err)
-		require.True(t, fullySigned)
+		require.True(t, authorized)
 
 		// Receiver: receives new payment, validates, then confirms by signing both
-		payment, fullySigned, err = receivingChannel.ConfirmPayment(payment)
+		payment, authorized, err = receivingChannel.ConfirmPayment(payment)
 		require.NoError(t, err)
-		require.True(t, fullySigned)
+		require.True(t, authorized)
 		ci, di, err := sendingChannel.PaymentTxs(payment)
 		require.NoError(t, err)
 		_, err = ci.AddSignatureDecorated(payment.CloseSignatures...)
@@ -423,13 +423,13 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	ca, err := initiatorChannel.ProposeCoordinatedClose()
 	require.NoError(t, err)
 
-	ca, fullySigned, err := responderChannel.ConfirmCoordinatedClose(ca)
+	ca, authorized, err := responderChannel.ConfirmCoordinatedClose(ca)
 	require.NoError(t, err)
-	require.True(t, fullySigned)
+	require.True(t, authorized)
 
-	_, fullySigned, err = initiatorChannel.ConfirmCoordinatedClose(ca)
+	_, authorized, err = initiatorChannel.ConfirmCoordinatedClose(ca)
 	require.NoError(t, err)
-	require.True(t, fullySigned)
+	require.True(t, authorized)
 
 	t.Log("Initiator closing channel with new coordinated close transaction")
 	txCoordinated, err := initiatorChannel.CoordinatedCloseTx()

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -183,7 +183,7 @@ func (c *Channel) ConfirmOpen(m Open) (open Open, fullySigned bool, err error) {
 	// All signatures are present that would be required to submit all
 	// transactions in the open.
 	fullySigned = true
-	c.latestCloseAgreement = CloseAgreement{
+	c.latestAuthorizedCloseAgreement = CloseAgreement{
 		IterationNumber:       1,
 		Balance:               Amount{Asset: m.Asset},
 		CloseSignatures:       m.CloseSignatures,

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -40,8 +40,8 @@ type Channel struct {
 	localSigner  *keypair.Full
 	remoteSigner *keypair.FromAddress
 
-	latestCloseAgreement            CloseAgreement
-	latestUnconfirmedCloseAgreement CloseAgreement
+	latestAuthorizedCloseAgreement   CloseAgreement
+	latestUnauthorizedCloseAgreement CloseAgreement
 }
 
 type Config struct {
@@ -73,20 +73,20 @@ func NewChannel(c Config) *Channel {
 }
 
 func (c *Channel) NextIterationNumber() int64 {
-	if !c.latestUnconfirmedCloseAgreement.isEmpty() {
-		return c.latestUnconfirmedCloseAgreement.IterationNumber
+	if !c.latestUnauthorizedCloseAgreement.isEmpty() {
+		return c.latestUnauthorizedCloseAgreement.IterationNumber
 	}
-	return c.latestCloseAgreement.IterationNumber + 1
+	return c.latestAuthorizedCloseAgreement.IterationNumber + 1
 }
 
 // Balance returns the amount owing from the initiator to the responder, if positive, or
 // the amount owing from the responder to the initiator, if negative.
 func (c *Channel) Balance() Amount {
-	return c.latestCloseAgreement.Balance
+	return c.latestAuthorizedCloseAgreement.Balance
 }
 
 func (c *Channel) LatestCloseAgreement() CloseAgreement {
-	return c.latestCloseAgreement
+	return c.latestAuthorizedCloseAgreement
 }
 
 func (c *Channel) initiatorEscrowAccount() *EscrowAccount {
@@ -122,15 +122,15 @@ func (c *Channel) responderSigner() *keypair.FromAddress {
 }
 
 func (c *Channel) initiatorBalanceAmount() int64 {
-	if c.latestCloseAgreement.Balance.Amount < 0 {
-		return c.latestCloseAgreement.Balance.Amount * -1
+	if c.latestAuthorizedCloseAgreement.Balance.Amount < 0 {
+		return c.latestAuthorizedCloseAgreement.Balance.Amount * -1
 	}
 	return 0
 }
 
 func (c *Channel) responderBalanceAmount() int64 {
-	if c.latestCloseAgreement.Balance.Amount > 0 {
-		return c.latestCloseAgreement.Balance.Amount
+	if c.latestAuthorizedCloseAgreement.Balance.Amount > 0 {
+		return c.latestAuthorizedCloseAgreement.Balance.Amount
 	}
 	return 0
 }

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -140,7 +140,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %s want: %s",
 			strconv.FormatInt(ca.Details.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10))
 	}
-	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnconfirmedCloseAgreement.Details != ca.Details {
+	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
 		return ca, authorized, errors.New("close agreement does not match the close agreement already in progress")
 	}
 

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -50,8 +50,8 @@ func TestLastConfirmedPayment(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ca, fullySigned, err := receiverChannel.ConfirmPayment(ca)
-	assert.False(t, fullySigned)
+	ca, authorized, err := receiverChannel.ConfirmPayment(ca)
+	assert.False(t, authorized)
 	require.NoError(t, err)
 	assert.Equal(t, ca, receiverChannel.latestUnauthorizedCloseAgreement)
 
@@ -64,19 +64,19 @@ func TestLastConfirmedPayment(t *testing.T) {
 		},
 		CloseSignatures: ca.CloseSignatures,
 	}
-	_, fullySigned, err = receiverChannel.ConfirmPayment(caDifferent)
-	assert.False(t, fullySigned)
+	_, authorized, err = receiverChannel.ConfirmPayment(caDifferent)
+	assert.False(t, authorized)
 	require.EqualError(t, err, "close agreement does not match the close agreement already in progress")
 	assert.Equal(t, CloseAgreement{Balance: Amount{Asset: NativeAsset{}}}, receiverChannel.LatestCloseAgreement())
 
 	// Confirming a payment with same sequence number and same amount should pass
-	ca, fullySigned, err = sendingChannel.ConfirmPayment(ca)
-	assert.True(t, fullySigned)
+	ca, authorized, err = sendingChannel.ConfirmPayment(ca)
+	assert.True(t, authorized)
 	require.NoError(t, err)
 	assert.Equal(t, CloseAgreement{}, sendingChannel.latestUnauthorizedCloseAgreement)
 
-	ca, fullySigned, err = receiverChannel.ConfirmPayment(ca)
-	assert.True(t, fullySigned)
+	ca, authorized, err = receiverChannel.ConfirmPayment(ca)
+	assert.True(t, authorized)
 	require.NoError(t, err)
 	assert.Equal(t, CloseAgreement{}, receiverChannel.latestUnauthorizedCloseAgreement)
 }


### PR DESCRIPTION
### What
Use authorized and unauthorized language to refer to close agreements that have been signed by all participants or not.

### Why
The code uses two terms `fullySigned` and `unconfirmed` to refer to if a close agreement is respectively authorized or unauthorized. It's unhelpful we use two terms that aren't clearly opposites of one another as the reader must have this tribal knowledge or infer it from logic in the SDK. It would be helpful to use a single term that have simple opposites. Unfortunately `fullySigned` is not a great choice because `notFullySigned` is long and wordy. Unfortunately `unconfirmed` is not a great choice because `confirmed` is an ambiguous term to use given the `ConfirmX` functions in the SDK do not result in a completely confirmed agreement, but in many cases a partially confirmed agreement.

The term authorized is being preferred because it is consistent with language we use when we talk about the state of signatures on a transaction for the Stellar network. On the Stellar network a transaction is authorized if the signers of the account holder(s) have signed the transaction. If a transaction is only partially signed, it is not authorized. We also use this same language when discussing [pre-authorized transactions](https://developers.stellar.org/docs/glossary/multisig/#pre-authorized-transaction), and pre-authorized transaction is authorized ahead of time.

Close #104 
