### PR TITLE
sdk/state: keep amounts in int64

### DIFF
--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -3,7 +3,6 @@ package integrationtests
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"strconv"
 	"testing"
 	"time"
 
@@ -70,7 +69,7 @@ func initEscrowAccount(t *testing.T, participant *Participant, asset txnbuild.As
 		Escrow:         participant.Escrow.FromAddress(),
 		SequenceNumber: seqNum + 1,
 		Asset:          asset,
-		AssetLimit:     strconv.FormatInt(assetLimit, 10),
+		AssetLimit:     assetLimit,
 	})
 	require.NoError(t, err)
 	tx, err = tx.Sign(networkPassphrase, participant.KP, participant.Escrow)

--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -3,6 +3,7 @@ package integrationtests
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"strconv"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 
 // functions to be used in the state_test integration tests
 
-func initAccounts(t *testing.T, asset txnbuild.Asset, assetLimit string, distributorKP *keypair.Full) (initiator Participant, responder Participant) {
+func initAccounts(t *testing.T, asset txnbuild.Asset, assetLimit int64, distributorKP *keypair.Full) (initiator Participant, responder Participant) {
 	initiator = Participant{
 		Name:         "Initiator",
 		KP:           keypair.MustRandom(),
@@ -58,7 +59,7 @@ func initAccounts(t *testing.T, asset txnbuild.Asset, assetLimit string, distrib
 	return initiator, responder
 }
 
-func initEscrowAccount(t *testing.T, participant *Participant, asset txnbuild.Asset, assetLimit string) {
+func initEscrowAccount(t *testing.T, participant *Participant, asset txnbuild.Asset, assetLimit int64) {
 	// create escrow account
 	account, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: participant.KP.Address()})
 	require.NoError(t, err)
@@ -69,7 +70,7 @@ func initEscrowAccount(t *testing.T, participant *Participant, asset txnbuild.As
 		Escrow:         participant.Escrow.FromAddress(),
 		SequenceNumber: seqNum + 1,
 		Asset:          asset,
-		AssetLimit:     assetLimit,
+		AssetLimit:     strconv.FormatInt(assetLimit, 10),
 	})
 	require.NoError(t, err)
 	tx, err = tx.Sign(networkPassphrase, participant.KP, participant.Escrow)

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -25,7 +25,7 @@ type Participant struct {
 func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	asset := txnbuild.NativeAsset{}
 	// native asset has no asset limit
-	assetLimit := ""
+	assetLimit := int64(0)
 	rootResp, err := client.Root()
 	require.NoError(t, err)
 	distributor := keypair.Master(rootResp.NetworkPassphrase).(*keypair.Full)
@@ -267,7 +267,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 
 func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	asset, distributor := initAsset(t, client)
-	assetLimit := "5000"
+	assetLimit := int64(5000)
 	initiator, responder := initAccounts(t, asset, assetLimit, distributor)
 	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
 

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -267,7 +267,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 
 func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	asset, distributor := initAsset(t, client)
-	assetLimit := int64(5000)
+	assetLimit := int64(5_000_0000000)
 	initiator, responder := initAccounts(t, asset, assetLimit, distributor)
 	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
 

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
 	"github.com/stellar/go/txnbuild"
@@ -16,13 +15,13 @@ type Open struct {
 	FormationSignatures   []xdr.DecoratedSignature
 
 	Asset      Asset
-	AssetLimit string
+	AssetLimit int64
 }
 
 // OpenParams are the parameters selected by the participant proposing an open channel.
 type OpenParams struct {
 	Asset      Asset
-	AssetLimit string
+	AssetLimit int64
 }
 
 func (c *Channel) OpenTxs(p OpenParams) (txClose, txDecl, formation *txnbuild.Transaction, err error) {
@@ -66,11 +65,6 @@ func (c *Channel) OpenTxs(p OpenParams) (txClose, txDecl, formation *txnbuild.Tr
 // ProposeOpen proposes the open of the channel, it is called by the participant
 // initiating the channel.
 func (c *Channel) ProposeOpen(p OpenParams) (Open, error) {
-	if !p.Asset.IsNative() {
-		if _, err := strconv.Atoi(p.AssetLimit); err != nil {
-			return Open{}, fmt.Errorf("parsing asset limit: %w", err)
-		}
-	}
 	c.startingSequence = c.initiatorEscrowAccount().SequenceNumber + 1
 
 	txClose, _, _, err := c.OpenTxs(p)

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -29,18 +29,14 @@ func TestProposePayment_validAsset(t *testing.T) {
 	})
 
 	native := NativeAsset{}
-	_, err := sendingChannel.ProposeOpen(OpenParams{Asset: native, AssetLimit: ""})
+	_, err := sendingChannel.ProposeOpen(OpenParams{Asset: native})
 	require.NoError(t, err)
 
 	invalidCredit := CreditAsset{}
-	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: invalidCredit, AssetLimit: "100"})
+	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: invalidCredit, AssetLimit: 100})
 	require.EqualError(t, err, `validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: asset code length must be between 1 and 12 characters`)
 
 	validCredit := CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
-	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: validCredit, AssetLimit: ""})
-	require.EqualError(t, err, `parsing asset limit: strconv.Atoi: parsing "": invalid syntax`)
-
-	validCredit = CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
-	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: validCredit, AssetLimit: "100"})
+	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: validCredit, AssetLimit: 100})
 	require.NoError(t, err)
 }

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -138,7 +138,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	// validate payment
 	if ca.Details.IterationNumber != c.NextIterationNumber() {
 		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %s want: %s",
- 			strconv.FormatInt(ca.Details.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10))
+			strconv.FormatInt(ca.Details.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10))
 	}
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
 		return ca, authorized, errors.New("close agreement does not match the close agreement already in progress")

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -3,7 +3,6 @@ package state
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
 	"github.com/stellar/go/txnbuild"
@@ -137,8 +136,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 
 	// validate payment
 	if ca.Details.IterationNumber != c.NextIterationNumber() {
-		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %s want: %s",
-			strconv.FormatInt(ca.Details.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10))
+		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
 	}
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
 		return ca, authorized, errors.New("close agreement does not match the close agreement already in progress")

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -3,6 +3,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
 	"github.com/stellar/go/txnbuild"
@@ -136,7 +137,8 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 
 	// validate payment
 	if ca.Details.IterationNumber != c.NextIterationNumber() {
-		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
+		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %s want: %s",
+ 			strconv.FormatInt(ca.Details.IterationNumber, 10), strconv.FormatInt(c.NextIterationNumber(), 10))
 	}
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
 		return ca, authorized, errors.New("close agreement does not match the close agreement already in progress")

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -1,6 +1,7 @@
 package txbuild
 
 import (
+	"github.com/stellar/go/amount"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
 )
@@ -10,7 +11,7 @@ type CreateEscrowParams struct {
 	Escrow         *keypair.FromAddress
 	SequenceNumber int64
 	Asset          txnbuild.Asset
-	AssetLimit     string
+	AssetLimit     int64
 }
 
 func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
@@ -35,7 +36,7 @@ func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
 	if !p.Asset.IsNative() {
 		ops = append(ops, &txnbuild.ChangeTrust{
 			Line:          p.Asset,
-			Limit:         p.AssetLimit,
+			Limit:         amount.StringFromInt64(p.AssetLimit),
 			SourceAccount: p.Escrow.Address(),
 		})
 	}

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -1,8 +1,6 @@
 package txbuild
 
 import (
-	"strconv"
-
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -1,6 +1,9 @@
 package txbuild
 
 import (
+	"strconv"
+
+	"github.com/stellar/go/amount"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
 )
@@ -12,7 +15,7 @@ type FormationParams struct {
 	ResponderEscrow *keypair.FromAddress
 	StartSequence   int64
 	Asset           txnbuild.Asset
-	AssetLimit      string
+	AssetLimit      int64
 }
 
 func Formation(p FormationParams) (*txnbuild.Transaction, error) {
@@ -40,7 +43,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 	if !p.Asset.IsNative() {
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
 			Line:          p.Asset,
-			Limit:         p.AssetLimit,
+			Limit:         amount.StringFromInt64(p.AssetLimit),
 			SourceAccount: p.InitiatorEscrow.Address(),
 		})
 	}
@@ -61,7 +64,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 	if !p.Asset.IsNative() {
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
 			Line:          p.Asset,
-			Limit:         p.AssetLimit,
+			Limit:         amount.StringFromInt64(p.AssetLimit),
 			SourceAccount: p.ResponderEscrow.Address(),
 		})
 	}


### PR DESCRIPTION
### What
Change the asset limit to be an int64 to be consistent with the Amount Balance being stored as an int64.

### Why
For consistency, so all amounts are stored the same way. This also makes it easier to work with the value since we can use simple math operations on it if we need to.