### PR TITLE
sdk/txbuild: move integration test helpers into another file

### DIFF
--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -214,6 +214,7 @@ func retry(maxAttempts int, f func() error) (err error) {
 		if err == nil {
 			return
 		}
+		time.Sleep(time.Second)
 	}
 	return err
 }

--- a/sdk/txbuild/integrationtests/helpers_test.go
+++ b/sdk/txbuild/integrationtests/helpers_test.go
@@ -1,0 +1,79 @@
+package integrationtests
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	stellarAmount "github.com/stellar/go/amount"
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stretchr/testify/require"
+)
+
+func randomBool(t *testing.T) bool {
+	t.Helper()
+	b := [1]byte{}
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	return b[0]%2 == 0
+}
+
+func randomPositiveInt64(t *testing.T, max int64) int64 {
+	t.Helper()
+	var i uint32
+	err := binary.Read(rand.Reader, binary.LittleEndian, &i)
+	require.NoError(t, err)
+	return int64(i) % max
+}
+
+func retry(maxAttempts int, f func() error) (err error) {
+	for i := 0; i < maxAttempts; i++ {
+		err = f()
+		if err == nil {
+			return
+		}
+		time.Sleep(time.Second)
+	}
+	return err
+}
+
+func fund(client horizonclient.ClientInterface, account *keypair.FromAddress, startingBalance int64) error {
+	rootResp, err := client.Root()
+	if err != nil {
+		return err
+	}
+	root := keypair.Master(rootResp.NetworkPassphrase).(*keypair.Full)
+	sourceAccount, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: root.Address()})
+	if err != nil {
+		return err
+	}
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &sourceAccount,
+			IncrementSequenceNum: true,
+			BaseFee:              txnbuild.MinBaseFee,
+			Timebounds:           txnbuild.NewTimeout(300),
+			Operations: []txnbuild.Operation{
+				&txnbuild.CreateAccount{
+					Destination: account.Address(),
+					Amount:      stellarAmount.StringFromInt64(startingBalance),
+				},
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+	tx, err = tx.Sign(rootResp.NetworkPassphrase, root)
+	if err != nil {
+		return err
+	}
+	_, err = client.SubmitTransaction(tx)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/sdk/txbuild/integrationtests/integrationtests_test.go
+++ b/sdk/txbuild/integrationtests/integrationtests_test.go
@@ -1,8 +1,6 @@
 package integrationtests
 
 import (
-	"crypto/rand"
-	"encoding/binary"
 	"testing"
 	"time"
 
@@ -375,69 +373,4 @@ func Test(t *testing.T) {
 	case <-time.After(1 * time.Minute):
 		t.Fatal("Channel close timed out after waiting 1 minute.")
 	}
-}
-
-func randomBool(t *testing.T) bool {
-	t.Helper()
-	b := [1]byte{}
-	_, err := rand.Read(b[:])
-	require.NoError(t, err)
-	return b[0]%2 == 0
-}
-
-func randomPositiveInt64(t *testing.T, max int64) int64 {
-	t.Helper()
-	var i uint32
-	err := binary.Read(rand.Reader, binary.LittleEndian, &i)
-	require.NoError(t, err)
-	return int64(i) % max
-}
-
-func retry(maxAttempts int, f func() error) (err error) {
-	for i := 0; i < maxAttempts; i++ {
-		err = f()
-		if err == nil {
-			return
-		}
-		time.Sleep(time.Second)
-	}
-	return err
-}
-
-func fund(client horizonclient.ClientInterface, account *keypair.FromAddress, startingBalance int64) error {
-	rootResp, err := client.Root()
-	if err != nil {
-		return err
-	}
-	root := keypair.Master(rootResp.NetworkPassphrase).(*keypair.Full)
-	sourceAccount, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: root.Address()})
-	if err != nil {
-		return err
-	}
-	tx, err := txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &sourceAccount,
-			IncrementSequenceNum: true,
-			BaseFee:              txnbuild.MinBaseFee,
-			Timebounds:           txnbuild.NewTimeout(300),
-			Operations: []txnbuild.Operation{
-				&txnbuild.CreateAccount{
-					Destination: account.Address(),
-					Amount:      stellarAmount.StringFromInt64(startingBalance),
-				},
-			},
-		},
-	)
-	if err != nil {
-		return err
-	}
-	tx, err = tx.Sign(rootResp.NetworkPassphrase, root)
-	if err != nil {
-		return err
-	}
-	_, err = client.SubmitTransaction(tx)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/sdk/txbuild/integrationtests/integrationtests_test.go
+++ b/sdk/txbuild/integrationtests/integrationtests_test.go
@@ -399,6 +399,7 @@ func retry(maxAttempts int, f func() error) (err error) {
 		if err == nil {
 			return
 		}
+		time.Sleep(time.Second)
 	}
 	return err
 }


### PR DESCRIPTION
### What
Move integration test helpers into a `helpers_test.go`.

### Why
@acharb introduced this pattern in the `state` package and it has worked pretty well in that package.

### Note
This PR contains commits from #115 that should disappear once that PR is merged.