### PR TITLE
sdk/state: move helper test function into helpers file

### DIFF
--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	stellarAmount "github.com/stellar/go/amount"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/require"
 )
@@ -308,4 +309,13 @@ func txSeqs(txs []*txnbuild.Transaction) []int64 {
 		seqs[i] = txs[i].SequenceNumber()
 	}
 	return seqs
+}
+
+func assetBalance(asset txnbuild.Asset, account horizon.Account) string {
+	for _, b := range account.Balances {
+		if b.Asset.Code == asset.GetCode() {
+			return b.Balance
+		}
+	}
+	return "0"
 }

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stellar/experimental-payment-channels/sdk/state"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
-	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -445,12 +445,3 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, fmt.Sprintf("%.7f", float64(iBalanceCheck)/float64(1_000_0000)), assetBalance(asset, initiatorEscrowResponse))
 }
-
-func assetBalance(asset txnbuild.Asset, account horizon.Account) string {
-	for _, b := range account.Balances {
-		if b.Asset.Code == asset.GetCode() {
-			return b.Balance
-		}
-	}
-	return "0"
-}


### PR DESCRIPTION
### What
Move the `assetBalance` helper function into the `helpers_test.go`.

### Why
It seems to be where our other helpers have landed.