### PR TITLE
sdk/state: consolidate the building of close txs

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -15,8 +15,8 @@ import (
 // 3. Responder calls ConfirmCoordinatedClose
 // 4. Initiator calls ConfirmCoordinatedClose
 
-// closeTx returns a close transaction with observation values.
-func (c *Channel) closeTx(d CloseAgreementDetails, observationPeriodTime time.Duration, observationPeriodLedgerGap int64) (*txnbuild.Transaction, error) {
+// makeCloseTx returns a close transaction with observation values.
+func (c *Channel) makeCloseTx(d CloseAgreementDetails, observationPeriodTime time.Duration, observationPeriodLedgerGap int64) (*txnbuild.Transaction, error) {
 	return txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
@@ -42,7 +42,7 @@ func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transactio
 	if err != nil {
 		return nil, nil, err
 	}
-	txClose, err = c.closeTx(d, c.observationPeriodTime, c.observationPeriodLedgerGap)
+	txClose, err = c.makeCloseTx(d, c.observationPeriodTime, c.observationPeriodLedgerGap)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -64,7 +64,7 @@ func amountToResponder(balance int64) int64 {
 }
 
 func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {
-	txClose, err := c.closeTx(c.latestAuthorizedCloseAgreement.Details, 0, 0)
+	txClose, err := c.makeCloseTx(c.latestAuthorizedCloseAgreement.Details, 0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {
 func (c *Channel) ProposeCoordinatedClose() (CloseAgreement, error) {
 	d := c.latestAuthorizedCloseAgreement.Details
 
-	txCoordinatedClose, err := c.closeTx(d, 0, 0)
+	txCoordinatedClose, err := c.makeCloseTx(d, 0, 0)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("making coordianted close transactions: %w", err)
 	}
@@ -99,7 +99,7 @@ func (c *Channel) ConfirmCoordinatedClose(ca CloseAgreement) (closeAgreement Clo
 		return CloseAgreement{}, authorized, fmt.Errorf("close agreement details do not match saved latest authorized close agreement")
 	}
 
-	txCoordinatedClose, err := c.closeTx(ca.Details, 0, 0)
+	txCoordinatedClose, err := c.makeCloseTx(ca.Details, 0, 0)
 	if err != nil {
 		return CloseAgreement{}, authorized, fmt.Errorf("making coordinated close transactions: %w", err)
 	}

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -32,20 +32,6 @@ func (c *Channel) closeTx(d CloseAgreementDetails, observationPeriodTime time.Du
 	})
 }
 
-func amountToInitiator(balance int64) int64 {
-	if balance < 0 {
-		return balance * -1
-	}
-	return 0
-}
-
-func amountToResponder(balance int64) int64 {
-	if balance > 0 {
-		return balance
-	}
-	return 0
-}
-
 func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transaction, txClose *txnbuild.Transaction, err error) {
 	txDecl, err = txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
@@ -61,6 +47,20 @@ func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transactio
 		return nil, nil, err
 	}
 	return txDecl, txClose, nil
+}
+
+func amountToInitiator(balance int64) int64 {
+	if balance < 0 {
+		return balance * -1
+	}
+	return 0
+}
+
+func amountToResponder(balance int64) int64 {
+	if balance > 0 {
+		return balance
+	}
+	return 0
 }
 
 func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -15,8 +15,8 @@ import (
 // 3. Responder calls ConfirmCoordinatedClose
 // 4. Initiator calls ConfirmCoordinatedClose
 
-// makeCloseTx returns a close transaction with observation values.
-func (c *Channel) makeCloseTx(observationPeriodTime time.Duration, observationPeriodLedgerGap int64) (*txnbuild.Transaction, error) {
+// closeTx returns a close transaction with observation values.
+func (c *Channel) closeTx(d CloseAgreementDetails, observationPeriodTime time.Duration, observationPeriodLedgerGap int64) (*txnbuild.Transaction, error) {
 	return txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
@@ -25,24 +25,38 @@ func (c *Channel) makeCloseTx(observationPeriodTime time.Duration, observationPe
 		InitiatorEscrow:            c.initiatorEscrowAccount().Address,
 		ResponderEscrow:            c.responderEscrowAccount().Address,
 		StartSequence:              c.startingSequence,
-		IterationNumber:            c.latestAuthorizedCloseAgreement.Details.IterationNumber,
-		AmountToInitiator:          c.initiatorBalanceAmount(),
-		AmountToResponder:          c.responderBalanceAmount(),
-		Asset:                      c.latestAuthorizedCloseAgreement.Details.Balance.Asset,
+		IterationNumber:            d.IterationNumber,
+		AmountToInitiator:          amountToInitiator(d.Balance.Amount),
+		AmountToResponder:          amountToResponder(d.Balance.Amount),
+		Asset:                      d.Balance.Asset,
 	})
 }
 
-func (c *Channel) CloseTxs() (txDecl *txnbuild.Transaction, txClose *txnbuild.Transaction, err error) {
+func amountToInitiator(balance int64) int64 {
+	if balance < 0 {
+		return balance * -1
+	}
+	return 0
+}
+
+func amountToResponder(balance int64) int64 {
+	if balance > 0 {
+		return balance
+	}
+	return 0
+}
+
+func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transaction, txClose *txnbuild.Transaction, err error) {
 	txDecl, err = txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
 		StartSequence:           c.startingSequence,
-		IterationNumber:         c.latestAuthorizedCloseAgreement.Details.IterationNumber,
+		IterationNumber:         d.IterationNumber,
 		IterationNumberExecuted: 0,
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	txClose, err = c.makeCloseTx(c.observationPeriodTime, c.observationPeriodLedgerGap)
+	txClose, err = c.closeTx(d, c.observationPeriodTime, c.observationPeriodLedgerGap)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,7 +64,7 @@ func (c *Channel) CloseTxs() (txDecl *txnbuild.Transaction, txClose *txnbuild.Tr
 }
 
 func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {
-	txClose, err := c.makeCloseTx(0, 0)
+	txClose, err := c.closeTx(c.latestAuthorizedCloseAgreement.Details, 0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +75,9 @@ func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {
 // This should be used when participants are in agreement on the final txClose parameters, but would
 // like to submit earlier than the original observation time.
 func (c *Channel) ProposeCoordinatedClose() (CloseAgreement, error) {
-	txCoordinatedClose, err := c.makeCloseTx(0, 0)
+	d := c.latestAuthorizedCloseAgreement.Details
+
+	txCoordinatedClose, err := c.closeTx(d, 0, 0)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("making coordianted close transactions: %w", err)
 	}
@@ -72,14 +88,18 @@ func (c *Channel) ProposeCoordinatedClose() (CloseAgreement, error) {
 
 	// Store the close agreement while participants iterate on signatures.
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{
-		Details:         c.latestAuthorizedCloseAgreement.Details,
+		Details:         d,
 		CloseSignatures: txCoordinatedClose.Signatures(),
 	}
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
 func (c *Channel) ConfirmCoordinatedClose(ca CloseAgreement) (closeAgreement CloseAgreement, authorized bool, err error) {
-	txCoordinatedClose, err := c.makeCloseTx(0, 0)
+	if ca.Details != c.latestAuthorizedCloseAgreement.Details {
+		return CloseAgreement{}, authorized, fmt.Errorf("close agreement details do not match saved latest authorized close agreement")
+	}
+
+	txCoordinatedClose, err := c.closeTx(ca.Details, 0, 0)
 	if err != nil {
 		return CloseAgreement{}, authorized, fmt.Errorf("making coordinated close transactions: %w", err)
 	}
@@ -109,7 +129,7 @@ func (c *Channel) ConfirmCoordinatedClose(ca CloseAgreement) (closeAgreement Clo
 	// The new close agreement is valid and fully signed, store and promote it.
 	authorized = true
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details:       ca.Details,
+		Details:               ca.Details,
 		CloseSignatures:       appendNewSignatures(c.latestUnauthorizedCloseAgreement.CloseSignatures, ca.CloseSignatures),
 		DeclarationSignatures: c.latestUnauthorizedCloseAgreement.DeclarationSignatures,
 	}

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -127,20 +127,6 @@ func (c *Channel) responderSigner() *keypair.FromAddress {
 	}
 }
 
-func (c *Channel) initiatorBalanceAmount() int64 {
-	if c.latestAuthorizedCloseAgreement.Details.Balance.Amount < 0 {
-		return c.latestAuthorizedCloseAgreement.Details.Balance.Amount * -1
-	}
-	return 0
-}
-
-func (c *Channel) responderBalanceAmount() int64 {
-	if c.latestAuthorizedCloseAgreement.Details.Balance.Amount > 0 {
-		return c.latestAuthorizedCloseAgreement.Details.Balance.Amount
-	}
-	return 0
-}
-
 func (c *Channel) verifySigned(tx *txnbuild.Transaction, sigs []xdr.DecoratedSignature, signer keypair.KP) (bool, error) {
 	hash, err := tx.Hash(c.networkPassphrase)
 	if err != nil {

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -32,35 +32,6 @@ func (ca CloseAgreement) isEmpty() bool {
 	return ca.Details == CloseAgreementDetails{} && len(ca.CloseSignatures) == 0 && len(ca.DeclarationSignatures) == 0
 }
 
-func (c *Channel) PaymentTxs(ca CloseAgreement) (close, decl *txnbuild.Transaction, err error) {
-	close, err = txbuild.Close(txbuild.CloseParams{
-		ObservationPeriodTime:      c.observationPeriodTime,
-		ObservationPeriodLedgerGap: c.observationPeriodLedgerGap,
-		InitiatorSigner:            c.initiatorSigner(),
-		ResponderSigner:            c.responderSigner(),
-		InitiatorEscrow:            c.initiatorEscrowAccount().Address,
-		ResponderEscrow:            c.responderEscrowAccount().Address,
-		StartSequence:              c.startingSequence,
-		IterationNumber:            c.NextIterationNumber(),
-		AmountToInitiator:          maxInt64(0, ca.Details.Balance.Amount*-1),
-		AmountToResponder:          maxInt64(0, ca.Details.Balance.Amount),
-		Asset:                      ca.Details.Balance.Asset,
-	})
-	if err != nil {
-		return
-	}
-	decl, err = txbuild.Declaration(txbuild.DeclarationParams{
-		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
-		StartSequence:           c.startingSequence,
-		IterationNumber:         c.NextIterationNumber(),
-		IterationNumberExecuted: 0,
-	})
-	if err != nil {
-		return
-	}
-	return
-}
-
 func (c *Channel) ProposePayment(amount Amount) (CloseAgreement, error) {
 	if amount.Amount <= 0 {
 		return CloseAgreement{}, errors.New("payment amount must be greater than 0")


### PR DESCRIPTION
### What
Consolidate the building of close transactions so that there is only one function and one place that occurs.

### Why
Building the close transactions happens in three places currently, in `CloseTxs`, `PaymentTxs`, and in `ProposePayment`. Each location collect the input data in different ways. There should be one owner responsible for close tx building. Ideally we are always building close txs during the update or final steps the exact same way.

For #127, although does not resolve it completely.

### Merging
This PR should be merged after #130.