### PR TITLE
sdk/state: remove CoordinatedCloseTxs and build observation into closing agreements

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -15,8 +15,8 @@ import (
 // 3. Responder calls ConfirmCoordinatedClose
 // 4. Initiator calls ConfirmCoordinatedClose
 
-// closeTx returns a close transaction with observation values.
-func (c *Channel) closeTx(d CloseAgreementDetails, observationPeriodTime time.Duration, observationPeriodLedgerGap int64) (*txnbuild.Transaction, error) {
+// makeCloseTx returns a close transaction with observation values.
+func (c *Channel) makeCloseTx(d CloseAgreementDetails, observationPeriodTime time.Duration, observationPeriodLedgerGap int64) (*txnbuild.Transaction, error) {
 	return txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
@@ -42,7 +42,7 @@ func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transactio
 	if err != nil {
 		return nil, nil, err
 	}
-	txClose, err = c.closeTx(d, c.observationPeriodTime, c.observationPeriodLedgerGap)
+	txClose, err = c.makeCloseTx(d, c.observationPeriodTime, c.observationPeriodLedgerGap)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -64,7 +64,7 @@ func amountToResponder(balance int64) int64 {
 }
 
 func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {
-	txClose, err := c.closeTx(c.latestAuthorizedCloseAgreement.Details, 0, 0)
+	txClose, err := c.makeCloseTx(c.latestAuthorizedCloseAgreement.Details, 0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {
 func (c *Channel) ProposeCoordinatedClose() (CloseAgreement, error) {
 	d := c.latestAuthorizedCloseAgreement.Details
 
-	txCoordinatedClose, err := c.closeTx(d, 0, 0)
+	txCoordinatedClose, err := c.makeCloseTx(d, 0, 0)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("making coordianted close transactions: %w", err)
 	}
@@ -99,7 +99,7 @@ func (c *Channel) ConfirmCoordinatedClose(ca CloseAgreement) (closeAgreement Clo
 		return CloseAgreement{}, authorized, fmt.Errorf("close agreement details do not match saved latest authorized close agreement")
 	}
 
-	txCoordinatedClose, err := c.closeTx(ca.Details, 0, 0)
+	txCoordinatedClose, err := c.makeCloseTx(ca.Details, 0, 0)
 	if err != nil {
 		return CloseAgreement{}, authorized, fmt.Errorf("making coordinated close transactions: %w", err)
 	}

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -32,20 +32,6 @@ func (c *Channel) closeTx(d CloseAgreementDetails, observationPeriodTime time.Du
 	})
 }
 
-func amountToInitiator(balance int64) int64 {
-	if balance < 0 {
-		return balance * -1
-	}
-	return 0
-}
-
-func amountToResponder(balance int64) int64 {
-	if balance > 0 {
-		return balance
-	}
-	return 0
-}
-
 func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transaction, txClose *txnbuild.Transaction, err error) {
 	txDecl, err = txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
@@ -61,6 +47,20 @@ func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transactio
 		return nil, nil, err
 	}
 	return txDecl, txClose, nil
+}
+
+func amountToInitiator(balance int64) int64 {
+	if balance < 0 {
+		return balance * -1
+	}
+	return 0
+}
+
+func amountToResponder(balance int64) int64 {
+	if balance > 0 {
+		return balance
+	}
+	return 0
 }
 
 func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -15,8 +15,8 @@ import (
 // 3. Responder calls ConfirmCoordinatedClose
 // 4. Initiator calls ConfirmCoordinatedClose
 
-// makeCloseTx returns a close transaction with observation values.
-func (c *Channel) makeCloseTx(observationPeriodTime time.Duration, observationPeriodLedgerGap int64) (*txnbuild.Transaction, error) {
+// closeTx returns a close transaction with observation values.
+func (c *Channel) closeTx(d CloseAgreementDetails, observationPeriodTime time.Duration, observationPeriodLedgerGap int64) (*txnbuild.Transaction, error) {
 	return txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
@@ -25,24 +25,38 @@ func (c *Channel) makeCloseTx(observationPeriodTime time.Duration, observationPe
 		InitiatorEscrow:            c.initiatorEscrowAccount().Address,
 		ResponderEscrow:            c.responderEscrowAccount().Address,
 		StartSequence:              c.startingSequence,
-		IterationNumber:            c.latestAuthorizedCloseAgreement.Details.IterationNumber,
-		AmountToInitiator:          c.initiatorBalanceAmount(),
-		AmountToResponder:          c.responderBalanceAmount(),
-		Asset:                      c.latestAuthorizedCloseAgreement.Details.Balance.Asset,
+		IterationNumber:            d.IterationNumber,
+		AmountToInitiator:          amountToInitiator(d.Balance.Amount),
+		AmountToResponder:          amountToResponder(d.Balance.Amount),
+		Asset:                      d.Balance.Asset,
 	})
 }
 
-func (c *Channel) CloseTxs() (txDecl *txnbuild.Transaction, txClose *txnbuild.Transaction, err error) {
+func amountToInitiator(balance int64) int64 {
+	if balance < 0 {
+		return balance * -1
+	}
+	return 0
+}
+
+func amountToResponder(balance int64) int64 {
+	if balance > 0 {
+		return balance
+	}
+	return 0
+}
+
+func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transaction, txClose *txnbuild.Transaction, err error) {
 	txDecl, err = txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
 		StartSequence:           c.startingSequence,
-		IterationNumber:         c.latestAuthorizedCloseAgreement.Details.IterationNumber,
+		IterationNumber:         d.IterationNumber,
 		IterationNumberExecuted: 0,
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	txClose, err = c.makeCloseTx(c.observationPeriodTime, c.observationPeriodLedgerGap)
+	txClose, err = c.closeTx(d, c.observationPeriodTime, c.observationPeriodLedgerGap)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,7 +64,7 @@ func (c *Channel) CloseTxs() (txDecl *txnbuild.Transaction, txClose *txnbuild.Tr
 }
 
 func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {
-	txClose, err := c.makeCloseTx(0, 0)
+	txClose, err := c.closeTx(c.latestAuthorizedCloseAgreement.Details, 0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +75,9 @@ func (c *Channel) CoordinatedCloseTx() (*txnbuild.Transaction, error) {
 // This should be used when participants are in agreement on the final txClose parameters, but would
 // like to submit earlier than the original observation time.
 func (c *Channel) ProposeCoordinatedClose() (CloseAgreement, error) {
-	txCoordinatedClose, err := c.makeCloseTx(0, 0)
+	d := c.latestAuthorizedCloseAgreement.Details
+
+	txCoordinatedClose, err := c.closeTx(d, 0, 0)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("making coordianted close transactions: %w", err)
 	}
@@ -72,14 +88,18 @@ func (c *Channel) ProposeCoordinatedClose() (CloseAgreement, error) {
 
 	// Store the close agreement while participants iterate on signatures.
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{
-		Details:         c.latestAuthorizedCloseAgreement.Details,
+		Details:         d,
 		CloseSignatures: txCoordinatedClose.Signatures(),
 	}
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
 func (c *Channel) ConfirmCoordinatedClose(ca CloseAgreement) (closeAgreement CloseAgreement, authorized bool, err error) {
-	txCoordinatedClose, err := c.makeCloseTx(0, 0)
+	if ca.Details != c.latestAuthorizedCloseAgreement.Details {
+		return CloseAgreement{}, authorized, fmt.Errorf("close agreement details do not match saved latest authorized close agreement")
+	}
+
+	txCoordinatedClose, err := c.closeTx(ca.Details, 0, 0)
 	if err != nil {
 		return CloseAgreement{}, authorized, fmt.Errorf("making coordinated close transactions: %w", err)
 	}
@@ -109,7 +129,7 @@ func (c *Channel) ConfirmCoordinatedClose(ca CloseAgreement) (closeAgreement Clo
 	// The new close agreement is valid and fully signed, store and promote it.
 	authorized = true
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details:       ca.Details,
+		Details:               ca.Details,
 		CloseSignatures:       appendNewSignatures(c.latestUnauthorizedCloseAgreement.CloseSignatures, ca.CloseSignatures),
 		DeclarationSignatures: c.latestUnauthorizedCloseAgreement.DeclarationSignatures,
 	}

--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -113,11 +113,6 @@ func initEscrowAccount(t *testing.T, participant *Participant, asset txnbuild.As
 }
 
 func initChannels(t *testing.T, initiator Participant, responder Participant) (initiatorChannel *state.Channel, responderChannel *state.Channel) {
-	// Channel constants.
-	const observationPeriodTime = 20 * time.Second
-	const averageLedgerDuration = 5 * time.Second
-	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
-
 	initiatorEscrowAccount := state.EscrowAccount{
 		Address:        initiator.Escrow.FromAddress(),
 		SequenceNumber: initiator.EscrowSequenceNumber,
@@ -129,8 +124,6 @@ func initChannels(t *testing.T, initiator Participant, responder Participant) (i
 
 	initiatorChannel = state.NewChannel(state.Config{
 		NetworkPassphrase:          networkPassphrase,
-		ObservationPeriodTime:      observationPeriodTime,
-		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
 		Initiator:                  true,
 		LocalEscrowAccount:         &initiatorEscrowAccount,
 		RemoteEscrowAccount:        &responderEscrowAccount,
@@ -139,8 +132,6 @@ func initChannels(t *testing.T, initiator Participant, responder Participant) (i
 	})
 	responderChannel = state.NewChannel(state.Config{
 		NetworkPassphrase:          networkPassphrase,
-		ObservationPeriodTime:      observationPeriodTime,
-		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
 		Initiator:                  false,
 		LocalEscrowAccount:         &responderEscrowAccount,
 		RemoteEscrowAccount:        &initiatorEscrowAccount,

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -460,7 +460,7 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	require.True(t, authorized)
 
 	t.Log("Initiator closing channel with new coordinated close transaction")
-	txCoordinated, err := initiatorChannel.CoordinatedCloseTx()
+	_, txCoordinated, err := initiatorChannel.CloseTxs(initiatorChannel.LatestCloseAgreement().Details)
 	require.NoError(t, err)
 	txCoordinated, err = txCoordinated.AddSignatureDecorated(initiatorChannel.LatestCloseAgreement().CloseSignatures...)
 	require.NoError(t, err)

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -22,6 +22,11 @@ type Participant struct {
 }
 
 func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
+	// Channel constants.
+	const observationPeriodTime = 20 * time.Second
+	const averageLedgerDuration = 5 * time.Second
+	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
+
 	asset := txnbuild.NativeAsset{}
 	// native asset has no asset limit
 	assetLimit := int64(0)
@@ -43,7 +48,12 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	// Open
 	t.Log("Open...")
 	// I signs txClose
-	open, err := initiatorChannel.ProposeOpen(state.OpenParams{Asset: asset, AssetLimit: assetLimit})
+	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
+		ObservationPeriodTime: observationPeriodTime,
+		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
+		Asset: asset,
+		AssetLimit: assetLimit,
+	})
 	require.NoError(t, err)
 	assert.Len(t, open.CloseSignatures, 1)
 	assert.Len(t, open.DeclarationSignatures, 0)
@@ -85,10 +95,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	}
 
 	{
-		ci, di, fi, err := initiatorChannel.OpenTxs(state.OpenParams{
-			Asset:      initiatorChannel.OpenAgreement().Details.Asset,
-			AssetLimit: initiatorChannel.OpenAgreement().Details.AssetLimit,
-		})
+		ci, di, fi, err := initiatorChannel.OpenTxs(initiatorChannel.OpenAgreement().Details)
 		require.NoError(t, err)
 
 		ci, err = ci.AddSignatureDecorated(initiatorChannel.OpenAgreement().CloseSignatures...)
@@ -292,6 +299,11 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 }
 
 func TestOpenUpdatesCoordinatedClose(t *testing.T) {
+	// Channel constants.
+	const observationPeriodTime = 20 * time.Second
+	const averageLedgerDuration = 5 * time.Second
+	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
+
 	asset, distributor := initAsset(t, client)
 	assetLimit := int64(5_000_0000000)
 	initiator, responder := initAccounts(t, asset, assetLimit, distributor)
@@ -305,7 +317,12 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	// Open
 	t.Log("Open...")
 	// I signs txClose
-	open, err := initiatorChannel.ProposeOpen(state.OpenParams{Asset: asset, AssetLimit: assetLimit})
+	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
+		ObservationPeriodTime: observationPeriodTime,
+		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
+		Asset: asset,
+		AssetLimit: assetLimit,
+	})
 	require.NoError(t, err)
 	assert.Len(t, open.CloseSignatures, 1)
 	assert.Len(t, open.DeclarationSignatures, 0)
@@ -347,10 +364,7 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	}
 
 	{
-		ci, di, fi, err := initiatorChannel.OpenTxs(state.OpenParams{
-			Asset:      initiatorChannel.OpenAgreement().Details.Asset,
-			AssetLimit: initiatorChannel.OpenAgreement().Details.AssetLimit,
-		})
+		ci, di, fi, err := initiatorChannel.OpenTxs(initiatorChannel.OpenAgreement().Details)
 		require.NoError(t, err)
 
 		_, err = ci.AddSignatureDecorated(initiatorChannel.OpenAgreement().CloseSignatures...)

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -207,8 +207,10 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, authorized b
 	authorized = true
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
-			IterationNumber: 1,
-			Balance:         Amount{Asset: m.Details.Asset},
+			IterationNumber:            1,
+			Balance:                    Amount{Asset: m.Details.Asset},
+			ObservationPeriodTime:      c.observationPeriodTime,
+			ObservationPeriodLedgerGap: c.observationPeriodLedgerGap,
 		},
 		CloseSignatures:       m.CloseSignatures,
 		DeclarationSignatures: m.DeclarationSignatures,

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -1,8 +1,6 @@
 package state
 
 import (
-	"time"
-
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
@@ -26,8 +24,6 @@ type EscrowAccount struct {
 
 type Channel struct {
 	networkPassphrase          string
-	observationPeriodTime      time.Duration
-	observationPeriodLedgerGap int64
 
 	startingSequence int64
 	// TODO - leave execution out for now
@@ -48,8 +44,6 @@ type Channel struct {
 
 type Config struct {
 	NetworkPassphrase          string
-	ObservationPeriodTime      time.Duration
-	ObservationPeriodLedgerGap int64
 
 	Initiator bool
 
@@ -63,8 +57,6 @@ type Config struct {
 func NewChannel(c Config) *Channel {
 	channel := &Channel{
 		networkPassphrase:          c.NetworkPassphrase,
-		observationPeriodTime:      c.ObservationPeriodTime,
-		observationPeriodLedgerGap: c.ObservationPeriodLedgerGap,
 		initiator:                  c.Initiator,
 		localEscrowAccount:         c.LocalEscrowAccount,
 		remoteEscrowAccount:        c.RemoteEscrowAccount,

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -127,20 +127,6 @@ func (c *Channel) responderSigner() *keypair.FromAddress {
 	}
 }
 
-func (c *Channel) initiatorBalanceAmount() int64 {
-	if c.latestAuthorizedCloseAgreement.Details.Balance.Amount < 0 {
-		return c.latestAuthorizedCloseAgreement.Details.Balance.Amount * -1
-	}
-	return 0
-}
-
-func (c *Channel) responderBalanceAmount() int64 {
-	if c.latestAuthorizedCloseAgreement.Details.Balance.Amount > 0 {
-		return c.latestAuthorizedCloseAgreement.Details.Balance.Amount
-	}
-	return 0
-}
-
 func (c *Channel) verifySigned(tx *txnbuild.Transaction, sigs []xdr.DecoratedSignature, signer keypair.KP) (bool, error) {
 	hash, err := tx.Hash(c.networkPassphrase)
 	if err != nil {

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -80,7 +80,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
 	}
 	if ca.Details.ObservationPeriodTime != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime || ca.Details.ObservationPeriodLedgerGap != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap {
-		return ca, authorized, fmt.Errorf("invalid payment observation period")
+		return ca, authorized, fmt.Errorf("invalid payment observation period: different than channel state")
 	}
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
 		return ca, authorized, errors.New("close agreement does not match the close agreement already in progress")

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -17,10 +17,10 @@ import (
 
 // CloseAgreementDetails contains the details that the participants agree on.
 type CloseAgreementDetails struct {
-	IterationNumber            int64
-	Balance                    Amount
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
+	IterationNumber            int64
+	Balance                    Amount
 }
 
 // CloseAgreement contains everything a participant needs to execute the close
@@ -50,10 +50,10 @@ func (c *Channel) ProposePayment(amount Amount) (CloseAgreement, error) {
 		newBalance = c.Balance().Amount - amount.Amount
 	}
 	d := CloseAgreementDetails{
+		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime,
+		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap,
 		IterationNumber:            c.NextIterationNumber(),
 		Balance:                    Amount{Asset: amount.Asset, Amount: newBalance},
-		ObservationPeriodTime:      c.observationPeriodTime,
-		ObservationPeriodLedgerGap: c.observationPeriodLedgerGap,
 	}
 	_, txClose, err := c.CloseTxs(d)
 	if err != nil {
@@ -79,7 +79,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	if ca.Details.IterationNumber != c.NextIterationNumber() {
 		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
 	}
-	if ca.Details.ObservationPeriodTime != c.observationPeriodTime || ca.Details.ObservationPeriodLedgerGap != c.observationPeriodLedgerGap {
+	if ca.Details.ObservationPeriodTime != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime || ca.Details.ObservationPeriodLedgerGap != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap {
 		return ca, authorized, fmt.Errorf("invalid payment observation period")
 	}
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -32,35 +32,6 @@ func (ca CloseAgreement) isEmpty() bool {
 	return ca.Details == CloseAgreementDetails{} && len(ca.CloseSignatures) == 0 && len(ca.DeclarationSignatures) == 0
 }
 
-func (c *Channel) PaymentTxs(ca CloseAgreement) (close, decl *txnbuild.Transaction, err error) {
-	close, err = txbuild.Close(txbuild.CloseParams{
-		ObservationPeriodTime:      c.observationPeriodTime,
-		ObservationPeriodLedgerGap: c.observationPeriodLedgerGap,
-		InitiatorSigner:            c.initiatorSigner(),
-		ResponderSigner:            c.responderSigner(),
-		InitiatorEscrow:            c.initiatorEscrowAccount().Address,
-		ResponderEscrow:            c.responderEscrowAccount().Address,
-		StartSequence:              c.startingSequence,
-		IterationNumber:            c.NextIterationNumber(),
-		AmountToInitiator:          maxInt64(0, ca.Details.Balance.Amount*-1),
-		AmountToResponder:          maxInt64(0, ca.Details.Balance.Amount),
-		Asset:                      ca.Details.Balance.Asset,
-	})
-	if err != nil {
-		return
-	}
-	decl, err = txbuild.Declaration(txbuild.DeclarationParams{
-		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
-		StartSequence:           c.startingSequence,
-		IterationNumber:         c.NextIterationNumber(),
-		IterationNumberExecuted: 0,
-	})
-	if err != nil {
-		return
-	}
-	return
-}
-
 func (c *Channel) ProposePayment(amount Amount) (CloseAgreement, error) {
 	if amount.Amount <= 0 {
 		return CloseAgreement{}, errors.New("payment amount must be greater than 0")

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -3,6 +3,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/stellar/go/xdr"
 )
@@ -16,8 +17,10 @@ import (
 
 // CloseAgreementDetails contains the details that the participants agree on.
 type CloseAgreementDetails struct {
-	IterationNumber int64
-	Balance         Amount
+	IterationNumber            int64
+	Balance                    Amount
+	ObservationPeriodTime      time.Duration
+	ObservationPeriodLedgerGap int64
 }
 
 // CloseAgreement contains everything a participant needs to execute the close
@@ -47,8 +50,10 @@ func (c *Channel) ProposePayment(amount Amount) (CloseAgreement, error) {
 		newBalance = c.Balance().Amount - amount.Amount
 	}
 	d := CloseAgreementDetails{
-		IterationNumber: c.NextIterationNumber(),
-		Balance:         Amount{Asset: amount.Asset, Amount: newBalance},
+		IterationNumber:            c.NextIterationNumber(),
+		Balance:                    Amount{Asset: amount.Asset, Amount: newBalance},
+		ObservationPeriodTime:      c.observationPeriodTime,
+		ObservationPeriodLedgerGap: c.observationPeriodLedgerGap,
 	}
 	_, txClose, err := c.CloseTxs(d)
 	if err != nil {
@@ -73,6 +78,9 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	// If the close agreement details don't match the close agreement in progress, error.
 	if ca.Details.IterationNumber != c.NextIterationNumber() {
 		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
+	}
+	if ca.Details.ObservationPeriodTime != c.observationPeriodTime || ca.Details.ObservationPeriodLedgerGap != c.observationPeriodLedgerGap {
+		return ca, authorized, fmt.Errorf("invalid payment observation period")
 	}
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
 		return ca, authorized, errors.New("close agreement does not match the close agreement already in progress")

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -24,17 +24,21 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 		SequenceNumber: int64(202),
 	}
 
-	// Given a channel with observation periods set to 1.
+	// Given a channel with observation periods set to 1, that is already open.
 	channel := NewChannel(Config{
-		NetworkPassphrase:          network.TestNetworkPassphrase,
-		ObservationPeriodTime:      1,
-		ObservationPeriodLedgerGap: 1,
-		Initiator:                  true,
-		LocalSigner:                localSigner,
-		RemoteSigner:               remoteSigner.FromAddress(),
-		LocalEscrowAccount:         localEscrowAccount,
-		RemoteEscrowAccount:        remoteEscrowAccount,
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           true,
+		LocalSigner:         localSigner,
+		RemoteSigner:        remoteSigner.FromAddress(),
+		LocalEscrowAccount:  localEscrowAccount,
+		RemoteEscrowAccount: remoteEscrowAccount,
 	})
+	channel.latestAuthorizedCloseAgreement = CloseAgreement{
+		Details: CloseAgreementDetails{
+			ObservationPeriodTime:      1,
+			ObservationPeriodLedgerGap: 1,
+		},
+	}
 
 	// A close agreement from the remote participant should be accepted if the
 	// observation period matches the channels observation period.

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -81,7 +81,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 			},
 			CloseSignatures: txClose.Signatures(),
 		})
-		require.EqualError(t, err, "invalid payment observation period")
+		require.EqualError(t, err, "invalid payment observation period: different than channel state")
 	}
 }
 


### PR DESCRIPTION
### What
Remove `CoordinatedCloseTxs` and build the observation parameters into the `ClosingAgreement`.

### Why
Coordinated close is the happy path and so we should make it the default way to close, with closing without the additional signatures being the fallback. There's a few changes we need to make for this to happen, and this is the first, that there aren't separate functions, like `CoordinatedCloseTxs` for getting the coordinated closing transaction. The user should be able to just get the closing transactions, via `CloseTxs`, and if the agreement is a coordinated close agreement, it should just work.

There was another reason we were thinking of moving observation parameters into the closing agreement, but I don't remember what they were.

Related to #127 

### Merging

This should be merged after #131 and contains commits from that PR until it is merged.