### PR TITLE
sdk/state: remove Coordinated term from func names

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -71,7 +71,7 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 
 	_, txClose, err := c.CloseTxs(d)
 	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("making coordianted close transactions: %w", err)
+		return CloseAgreement{}, fmt.Errorf("making close transactions: %w", err)
 	}
 	txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
 	if err != nil {

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -7,12 +7,15 @@ import (
 	"github.com/stellar/go/txnbuild"
 )
 
-// The steps for a channel coordinated close are as followed:
-// 1. Initiator or Responder submits latest declaration tx
-// 2. Initiator calls ProposeCoordinatedClose (in steps 2-4 Initiator and Responder are interchangeable,
-//    as long as they alternate)
-// 3. Responder calls ConfirmCoordinatedClose
-// 4. Initiator calls ConfirmCoordinatedClose
+// The steps for a channel close are as follows:
+// 1. A submits latest declaration tx
+// 2. A calls ProposeClose to propose an immediate close by resigning the
+//    current close tx
+// 3. B calls ConfirmClose to sign and store result
+// 4. A calls ConfirmClose to store result
+// 5. A or B submit the new close tx
+// 6. If A or B declines or is not responsive at any step, A or B may submit the
+//    original close tx after the observation period.
 
 func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transaction, txClose *txnbuild.Transaction, err error) {
 	txDecl, err = txbuild.Declaration(txbuild.DeclarationParams{
@@ -57,32 +60,37 @@ func amountToResponder(balance int64) int64 {
 	return 0
 }
 
-// ProposeCoordinatedClose proposes a close transaction to be submitted immediately.
-// This should be used when participants are in agreement on the final txClose parameters, but would
-// like to submit earlier than the original observation time.
-func (c *Channel) ProposeCoordinatedClose() (CloseAgreement, error) {
+// ProposeClose proposes that the latest authorized close agreement be submitted
+// without waiting the observation period. This should be used when participants
+// are in agreement on the final close state, but would like to submit earlier
+// than the original observation time.
+func (c *Channel) ProposeClose() (CloseAgreement, error) {
 	d := c.latestAuthorizedCloseAgreement.Details
 	d.ObservationPeriodTime = 0
 	d.ObservationPeriodLedgerGap = 0
 
-	_, txCoordinatedClose, err := c.CloseTxs(d)
+	_, txClose, err := c.CloseTxs(d)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("making coordianted close transactions: %w", err)
 	}
-	txCoordinatedClose, err = txCoordinatedClose.Sign(c.networkPassphrase, c.localSigner)
+	txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
 	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("signing coordinated close transaction: %w", err)
+		return CloseAgreement{}, fmt.Errorf("signing  close transaction: %w", err)
 	}
 
 	// Store the close agreement while participants iterate on signatures.
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{
 		Details:         d,
-		CloseSignatures: txCoordinatedClose.Signatures(),
+		CloseSignatures: txClose.Signatures(),
 	}
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
-func (c *Channel) ConfirmCoordinatedClose(ca CloseAgreement) (closeAgreement CloseAgreement, authorized bool, err error) {
+// ConfirmClose agrees to a close agreement to be submitted without waiting the
+// observation period. The agreement will always be accepted if it is identical
+// to the latest authorized close agreement, and it is signed by the participant
+// proposing the close.
+func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement, authorized bool, err error) {
 	latestWithoutObservation := c.latestAuthorizedCloseAgreement.Details
 	latestWithoutObservation.ObservationPeriodTime = 0
 	latestWithoutObservation.ObservationPeriodLedgerGap = 0
@@ -91,34 +99,34 @@ func (c *Channel) ConfirmCoordinatedClose(ca CloseAgreement) (closeAgreement Clo
 		return CloseAgreement{}, authorized, fmt.Errorf("close agreement details do not match saved latest authorized close agreement")
 	}
 
-	_, txCoordinatedClose, err := c.CloseTxs(ca.Details)
+	_, txClose, err := c.CloseTxs(ca.Details)
 	if err != nil {
-		return CloseAgreement{}, authorized, fmt.Errorf("making coordinated close transactions: %w", err)
+		return CloseAgreement{}, authorized, fmt.Errorf("making close transactions: %w", err)
 	}
 
 	// If remote has not signed, error as is invalid.
-	signed, err := c.verifySigned(txCoordinatedClose, ca.CloseSignatures, c.remoteSigner)
+	signed, err := c.verifySigned(txClose, ca.CloseSignatures, c.remoteSigner)
 	if err != nil {
-		return CloseAgreement{}, authorized, fmt.Errorf("verifying coordinated close signature with remote: %w", err)
+		return CloseAgreement{}, authorized, fmt.Errorf("verifying close signature with remote: %w", err)
 	}
 	if !signed {
-		return CloseAgreement{}, authorized, fmt.Errorf("verifying coordinated close: not signed by remote")
+		return CloseAgreement{}, authorized, fmt.Errorf("verifying close: not signed by remote")
 	}
 
 	// If local has not signed, sign.
-	signed, err = c.verifySigned(txCoordinatedClose, ca.CloseSignatures, c.localSigner)
+	signed, err = c.verifySigned(txClose, ca.CloseSignatures, c.localSigner)
 	if err != nil {
-		return CloseAgreement{}, authorized, fmt.Errorf("verifying coordinated close signature with local: %w", err)
+		return CloseAgreement{}, authorized, fmt.Errorf("verifying close signature with local: %w", err)
 	}
 	if !signed {
-		txCoordinatedClose, err = txCoordinatedClose.Sign(c.networkPassphrase, c.localSigner)
+		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return CloseAgreement{}, authorized, fmt.Errorf("signing coordinated close transaction: %w", err)
+			return CloseAgreement{}, authorized, fmt.Errorf("signing close transaction: %w", err)
 		}
-		ca.CloseSignatures = append(ca.CloseSignatures, txCoordinatedClose.Signatures()...)
+		ca.CloseSignatures = append(ca.CloseSignatures, txClose.Signatures()...)
 	}
 
-	// The new close agreement is valid and fully signed, store and promote it.
+	// The new close agreement is valid and authorized, store and promote it.
 	authorized = true
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details:               ca.Details,

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -75,7 +75,7 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 	}
 	txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
 	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("signing  close transaction: %w", err)
+		return CloseAgreement{}, fmt.Errorf("signing close transaction: %w", err)
 	}
 
 	// Store the close agreement while participants iterate on signatures.

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -462,14 +462,14 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Initiator proposes a coordinated close")
-	ca, err := initiatorChannel.ProposeCoordinatedClose()
+	ca, err := initiatorChannel.ProposeClose()
 	require.NoError(t, err)
 
-	ca, authorized, err := responderChannel.ConfirmCoordinatedClose(ca)
+	ca, authorized, err := responderChannel.ConfirmClose(ca)
 	require.NoError(t, err)
 	require.True(t, authorized)
 
-	_, authorized, err = initiatorChannel.ConfirmCoordinatedClose(ca)
+	_, authorized, err = initiatorChannel.ConfirmClose(ca)
 	require.NoError(t, err)
 	require.True(t, authorized)
 


### PR DESCRIPTION
### What
Remove the term `Coordinated` from function names and code.

### Why
The default happy path is to do a coordinated close, or rather, it should just be part of the standard close process which involves declaring, trying to coordinate the immediate close, and falling back to using the existing close transactions. While we call this coordinated close in the SEP, I don't think we get much value of using the term in the SDK because in practice there will be one close process not two.