### PR TITLE
sdk/state: remove code not being used

### DIFF
--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -149,22 +149,3 @@ func appendNewSignatures(oldSignatures []xdr.DecoratedSignature, newSignatures [
 	}
 	return oldSignatures
 }
-
-type TxInfo struct {
-	ID        string
-	Iteration int
-	Type      string // declaration | close
-	Seq       int64
-}
-
-// helper method
-func (t *TxInfo) MyBalance() error {
-	return nil
-}
-
-type ChannelCheckResponse struct {
-	IsContestable   bool
-	Asset           Asset
-	TriggeredTxInfo TxInfo
-	LatestTxInfo    TxInfo
-}


### PR DESCRIPTION
### What
Remove code not be used.

### Why
It isn't being used, and I don't think we'll use it.