### PR TITLE
sdk/state: reject payments from remote if they change balance in their favor

### DIFF
--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -127,7 +127,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 		return ca, authorized, fmt.Errorf("verifying close signed by remote: not signed by remote")
 	}
 
-	// If local has not signed close, check that the payment is not from local to remote, then sign.
+	// If local has not signed close, check that the payment is not to the proposer, then sign.
 	signed, err = c.verifySigned(txClose, ca.CloseSignatures, c.localSigner)
 	if err != nil {
 		return ca, authorized, fmt.Errorf("verifying close signed by local: %w", err)

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -135,7 +135,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	if !signed {
 		if (c.initiator && ca.Details.Balance.Amount > c.latestAuthorizedCloseAgreement.Details.Balance.Amount) ||
 			(!c.initiator && ca.Details.Balance.Amount < c.latestAuthorizedCloseAgreement.Details.Balance.Amount) {
-			return ca, authorized, fmt.Errorf("close agreement from remote changes the balance in their favor")
+			return ca, authorized, fmt.Errorf("close agreement is a payment to the proposer")
 		}
 		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
 		if err != nil {

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -127,7 +127,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 		return ca, authorized, fmt.Errorf("verifying close signed by remote: not signed by remote")
 	}
 
-	// If local has not signed close, check that the payment is in locals favor, then sign.
+	// If local has not signed close, check that the payment is not from local to remote, then sign.
 	signed, err = c.verifySigned(txClose, ca.CloseSignatures, c.localSigner)
 	if err != nil {
 		return ca, authorized, fmt.Errorf("verifying close signed by local: %w", err)

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -165,7 +165,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentToRemote(t *testing.T) {
 			IterationNumber: 1,
 			Balance: Amount{
 				Asset:  NativeAsset{},
-				Amount: 100, // Local (responder) owes remote (initiator) 100.
+				Amount: 100, // Remote (initiator) owes local (responder) 100.
 			},
 		},
 	}
@@ -173,7 +173,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentToRemote(t *testing.T) {
 		IterationNumber: 2,
 		Balance: Amount{
 			Asset:  NativeAsset{},
-			Amount: 90, // Local (responder) owes remote (initiator) 110, payment of 10 from ❌ local to remote.
+			Amount: 90, // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
 		},
 	}
 	_, txClose, err := channel.CloseTxs(ca)

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -133,7 +133,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentToRemote(t *testing.T) {
 		Details:         ca,
 		CloseSignatures: txClose.Signatures(),
 	})
-	require.EqualError(t, err, "close agreement from remote changes the balance in their favor")
+	require.EqualError(t, err, "close agreement is a payment to the proposer")
 }
 
 func TestChannel_ConfirmPayment_responderRejectsPaymentToRemote(t *testing.T) {
@@ -184,7 +184,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentToRemote(t *testing.T) {
 		Details:         ca,
 		CloseSignatures: txClose.Signatures(),
 	})
-	require.EqualError(t, err, "close agreement from remote changes the balance in their favor")
+	require.EqualError(t, err, "close agreement is a payment to the proposer")
 }
 
 func TestLastConfirmedPayment(t *testing.T) {


### PR DESCRIPTION
### What
Change the `ConfirmPayment` function so it rejects payments from the remote if the remote is proposing that the local pay the remote.

### Why
This is a payment channel where either party can send money to the other party, and it isn't designed fro requesting/invoicing the other party for funds. There's several reasons for this. It is safer and easier to write confirm functionality that enforces this rather than require that the user always check the balance is an okay change. The channel is designed to always move forward and in disagreement it becomes unclear if the channel should close or stay open and skip a generation. Mostly this is for simplicity for the major use case.

Close #112