### PR TITLE
sdk/state, sdk/txbuild: support multiple assets when forming and opening accounts 

### DIFF
--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -86,7 +86,7 @@ func initEscrowAccount(t *testing.T, participant *Participant, assets []AssetPar
 		Creator:        participant.KP.FromAddress(),
 		Escrow:         participant.Escrow.FromAddress(),
 		SequenceNumber: seqNum + 1,
-		Assets:         tl,
+		Trustlines:     tl,
 	})
 	require.NoError(t, err)
 	tx, err = tx.Sign(networkPassphrase, participant.KP, participant.Escrow)

--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -18,7 +18,13 @@ import (
 
 // functions to be used in the state_test integration tests
 
-func initAccounts(t *testing.T, asset txnbuild.Asset, assetLimit int64, distributorKP *keypair.Full) (initiator Participant, responder Participant) {
+type AssetParam struct {
+	Asset       txnbuild.Asset
+	Distributor *keypair.Full
+	AssetLimit  int64
+}
+
+func initAccounts(t *testing.T, assets []AssetParam) (initiator Participant, responder Participant) {
 	initiator = Participant{
 		Name:         "Initiator",
 		KP:           keypair.MustRandom(),
@@ -30,13 +36,15 @@ func initAccounts(t *testing.T, asset txnbuild.Asset, assetLimit int64, distribu
 	{
 		err := retry(2, func() error { return createAccount(initiator.KP.FromAddress(), 10_000_0000000) })
 		require.NoError(t, err)
-		err = retry(2, func() error { return fundAsset(asset, initiator.Contribution, initiator.KP, distributorKP) })
-		require.NoError(t, err)
-		initEscrowAccount(t, &initiator, asset, assetLimit)
-	}
+		for _, asset := range assets {
+			err = retry(2, func() error { return fundAsset(asset.Asset, initiator.Contribution, initiator.KP, asset.Distributor) })
+			require.NoError(t, err)
 
+			t.Log("Initiator Contribution:", initiator.Contribution, "of asset:", asset.Asset.GetCode(), "issuer: ", asset.Asset.GetIssuer())
+		}
+		initEscrowAccount(t, &initiator, assets)
+	}
 	t.Log("Initiator Escrow Sequence Number:", initiator.EscrowSequenceNumber)
-	t.Log("Initiator Contribution:", initiator.Contribution, "of asset:", asset.GetCode(), "issuer: ", asset.GetIssuer())
 
 	// Setup responder.
 	responder = Participant{
@@ -50,27 +58,35 @@ func initAccounts(t *testing.T, asset txnbuild.Asset, assetLimit int64, distribu
 	{
 		err := retry(2, func() error { return createAccount(responder.KP.FromAddress(), 10_000_0000000) })
 		require.NoError(t, err)
-		err = retry(2, func() error { return fundAsset(asset, responder.Contribution, responder.KP, distributorKP) })
-		require.NoError(t, err)
-		initEscrowAccount(t, &responder, asset, assetLimit)
+		for _, asset := range assets {
+			err = retry(2, func() error { return fundAsset(asset.Asset, responder.Contribution, responder.KP, asset.Distributor) })
+			require.NoError(t, err)
+
+			t.Log("Responder Contribution:", responder.Contribution, "of asset:", asset.Asset.GetCode(), "issuer: ", asset.Asset.GetIssuer())
+		}
+		initEscrowAccount(t, &responder, assets)
 	}
 	t.Log("Responder Escrow Sequence Number:", responder.EscrowSequenceNumber)
-	t.Log("Responder Contribution:", responder.Contribution, "of asset:", asset.GetCode(), "issuer: ", asset.GetIssuer())
+
 	return initiator, responder
 }
 
-func initEscrowAccount(t *testing.T, participant *Participant, asset txnbuild.Asset, assetLimit int64) {
+func initEscrowAccount(t *testing.T, participant *Participant, assets []AssetParam) {
 	// create escrow account
 	account, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: participant.KP.Address()})
 	require.NoError(t, err)
 	seqNum, err := account.GetSequenceNumber()
 	require.NoError(t, err)
+
+	tl := []txbuild.Trustline{}
+	for _, a := range assets {
+		tl = append(tl, txbuild.Trustline{a.Asset, a.AssetLimit})
+	}
 	tx, err := txbuild.CreateEscrow(txbuild.CreateEscrowParams{
 		Creator:        participant.KP.FromAddress(),
 		Escrow:         participant.Escrow.FromAddress(),
 		SequenceNumber: seqNum + 1,
-		Asset:          asset,
-		AssetLimit:     assetLimit,
+		Assets:         tl,
 	})
 	require.NoError(t, err)
 	tx, err = tx.Sign(networkPassphrase, participant.KP, participant.Escrow)
@@ -87,22 +103,25 @@ func initEscrowAccount(t *testing.T, participant *Participant, asset txnbuild.As
 	require.NoError(t, err)
 	participant.EscrowSequenceNumber = int64(txResp.Ledger) << 32
 
-	// add initial contribution
+	// add initial contribution, use the same contribution for each asset
 	_, err = account.IncrementSequenceNumber()
 	require.NoError(t, err)
+
+	payments := []txnbuild.Operation{}
+	for _, asset := range assets {
+		payments = append(payments, &txnbuild.Payment{
+			Destination: participant.Escrow.Address(),
+			Amount:      stellarAmount.StringFromInt64(participant.Contribution),
+			Asset:       asset.Asset,
+		})
+	}
 
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount:        &account,
 		BaseFee:              txnbuild.MinBaseFee,
 		Timebounds:           txnbuild.NewTimeout(300),
 		IncrementSequenceNum: true,
-		Operations: []txnbuild.Operation{
-			&txnbuild.Payment{
-				Destination: participant.Escrow.Address(),
-				Amount:      stellarAmount.StringFromInt64(participant.Contribution),
-				Asset:       asset,
-			},
-		},
+		Operations:           payments,
 	})
 	require.NoError(t, err)
 
@@ -150,7 +169,7 @@ func initChannels(t *testing.T, initiator Participant, responder Participant) (i
 	return initiatorChannel, responderChannel
 }
 
-func initAsset(t *testing.T, client horizonclient.ClientInterface) (txnbuild.Asset, *keypair.Full) {
+func initAsset(t *testing.T, client horizonclient.ClientInterface, code string) (txnbuild.Asset, *keypair.Full) {
 	issuerKP := keypair.MustRandom()
 	distributorKP := keypair.MustRandom()
 
@@ -162,7 +181,7 @@ func initAsset(t *testing.T, client horizonclient.ClientInterface) (txnbuild.Ass
 	distributor, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: distributorKP.Address()})
 	require.NoError(t, err)
 
-	abcdAsset := txnbuild.CreditAsset{Code: "ABCD", Issuer: issuerKP.Address()}
+	asset := txnbuild.CreditAsset{Code: code, Issuer: issuerKP.Address()}
 
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
@@ -172,12 +191,12 @@ func initAsset(t *testing.T, client horizonclient.ClientInterface) (txnbuild.Ass
 			Timebounds:           txnbuild.NewInfiniteTimeout(),
 			Operations: []txnbuild.Operation{
 				&txnbuild.ChangeTrust{
-					Line:  abcdAsset,
+					Line:  asset,
 					Limit: "5000",
 				},
 				&txnbuild.Payment{
 					Destination:   distributorKP.Address(),
-					Asset:         abcdAsset,
+					Asset:         asset,
 					Amount:        "5000",
 					SourceAccount: issuerKP.Address(),
 				},
@@ -190,7 +209,7 @@ func initAsset(t *testing.T, client horizonclient.ClientInterface) (txnbuild.Ass
 	_, err = client.SubmitTransaction(tx)
 	require.NoError(t, err)
 
-	return abcdAsset, distributorKP
+	return asset, distributorKP
 }
 
 func randomBool(t *testing.T) bool {

--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -80,7 +80,7 @@ func initEscrowAccount(t *testing.T, participant *Participant, assets []AssetPar
 
 	tl := []txbuild.Trustline{}
 	for _, a := range assets {
-		tl = append(tl, txbuild.Trustline{a.Asset, a.AssetLimit})
+		tl = append(tl, txbuild.Trustline{Asset: a.Asset, AssetLimit: a.AssetLimit})
 	}
 	tx, err := txbuild.CreateEscrow(txbuild.CreateEscrowParams{
 		Creator:        participant.KP.FromAddress(),
@@ -142,20 +142,20 @@ func initChannels(t *testing.T, initiator Participant, responder Participant) (i
 	}
 
 	initiatorChannel = state.NewChannel(state.Config{
-		NetworkPassphrase:          networkPassphrase,
-		Initiator:                  true,
-		LocalEscrowAccount:         &initiatorEscrowAccount,
-		RemoteEscrowAccount:        &responderEscrowAccount,
-		LocalSigner:                initiator.KP,
-		RemoteSigner:               responder.KP.FromAddress(),
+		NetworkPassphrase:   networkPassphrase,
+		Initiator:           true,
+		LocalEscrowAccount:  &initiatorEscrowAccount,
+		RemoteEscrowAccount: &responderEscrowAccount,
+		LocalSigner:         initiator.KP,
+		RemoteSigner:        responder.KP.FromAddress(),
 	})
 	responderChannel = state.NewChannel(state.Config{
-		NetworkPassphrase:          networkPassphrase,
-		Initiator:                  false,
-		LocalEscrowAccount:         &responderEscrowAccount,
-		RemoteEscrowAccount:        &initiatorEscrowAccount,
-		LocalSigner:                responder.KP,
-		RemoteSigner:               initiator.KP.FromAddress(),
+		NetworkPassphrase:   networkPassphrase,
+		Initiator:           false,
+		LocalEscrowAccount:  &responderEscrowAccount,
+		RemoteEscrowAccount: &initiatorEscrowAccount,
+		LocalSigner:         responder.KP,
+		RemoteSigner:        initiator.KP.FromAddress(),
 	})
 	return initiatorChannel, responderChannel
 }

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -56,7 +56,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
-		Assets: []state.Trustline{
+		Trustlines: []state.Trustline{
 			state.Trustline{Asset: asset, AssetLimit: assetLimit},
 		},
 	})
@@ -331,7 +331,7 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
-		Assets: []state.Trustline{
+		Trustlines: []state.Trustline{
 			state.Trustline{Asset: asset, AssetLimit: assetLimit},
 		},
 	})
@@ -548,7 +548,7 @@ func TestOpen_multipleAssets(t *testing.T) {
 	t.Log("Open...")
 	// I signs txClose
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
-		Assets: []state.Trustline{
+		Trustlines: []state.Trustline{
 			state.Trustline{Asset: asset1, AssetLimit: assetLimit1},
 			state.Trustline{Asset: asset2, AssetLimit: assetLimit2},
 		},

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -631,9 +631,14 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	const averageLedgerDuration = 5 * time.Second
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
 
-	asset, distributor := initAsset(t, client)
+	asset, distributor := initAsset(t, client, "ABDC")
 	assetLimit := int64(5_000_0000000)
-	initiator, responder := initAccounts(t, asset, assetLimit, distributor)
+	initiator, responder := initAccounts(t, []AssetParam{
+		AssetParam{
+			Asset:       asset,
+			AssetLimit:  assetLimit,
+			Distributor: distributor,
+		}})
 	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
 
 	s := initiator.EscrowSequenceNumber + 1
@@ -647,9 +652,11 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
-		Asset:                      asset,
-		AssetLimit:                 assetLimit,
+		Trustlines: []state.Trustline{
+			state.Trustline{Asset: asset, AssetLimit: assetLimit},
+		},
 	})
+
 	require.NoError(t, err)
 	assert.Len(t, open.CloseSignatures, 1)
 	assert.Len(t, open.DeclarationSignatures, 0)

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -101,9 +101,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	}
 
 	{
-		ci, di, fi, err := initiatorChannel.OpenTxs(state.OpenParams{
-			Assets: initiatorChannel.OpenAgreement().Details.Assets,
-		})
+		ci, di, fi, err := initiatorChannel.OpenTxs(initiatorChannel.OpenAgreement().Details)
 		require.NoError(t, err)
 
 		ci, err = ci.AddSignatureDecorated(initiatorChannel.OpenAgreement().CloseSignatures...)
@@ -378,9 +376,7 @@ func TestOpenUpdatesCoordinatedClose(t *testing.T) {
 	}
 
 	{
-		ci, di, fi, err := initiatorChannel.OpenTxs(state.OpenParams{
-			Assets: initiatorChannel.OpenAgreement().Details.Assets,
-		})
+		ci, di, fi, err := initiatorChannel.OpenTxs(initiatorChannel.OpenAgreement().Details)
 		require.NoError(t, err)
 
 		_, err = ci.AddSignatureDecorated(initiatorChannel.OpenAgreement().CloseSignatures...)
@@ -583,9 +579,7 @@ func TestOpen_multipleAssets(t *testing.T) {
 	}
 
 	{
-		ci, di, fi, err := initiatorChannel.OpenTxs(state.OpenParams{
-			Assets: initiatorChannel.OpenAgreement().Details.Assets,
-		})
+		ci, di, fi, err := initiatorChannel.OpenTxs(initiatorChannel.OpenAgreement().Details)
 		require.NoError(t, err)
 
 		_, err = ci.AddSignatureDecorated(initiatorChannel.OpenAgreement().CloseSignatures...)

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -51,11 +51,6 @@ type OpenParams struct {
 }
 
 func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *txnbuild.Transaction, err error) {
-	if len(d.Assets) == 0 {
-		err = fmt.Errorf("invalid open params: trying to open a channel with no assets")
-		return
-	}
-
 	txClose, err = txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: d.ObservationPeriodLedgerGap,

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// TODO - check on this
 type Trustline = txbuild.Trustline
 
 type OpenAgreementDetails struct {

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -14,18 +14,18 @@ type Trustline = txbuild.Trustline
 type OpenAgreementDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
-	Assets                     []Trustline
+	Trustlines                 []Trustline
 }
 
 func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
 	if d.ObservationPeriodTime != d2.ObservationPeriodTime ||
 		d.ObservationPeriodLedgerGap != d2.ObservationPeriodLedgerGap ||
-		len(d.Assets) != len(d2.Assets) {
+		len(d.Trustlines) != len(d2.Trustlines) {
 		return false
 	}
 
-	for i, a := range d.Assets {
-		if a != d2.Assets[i] {
+	for i, a := range d.Trustlines {
+		if a != d2.Trustlines[i] {
 			return false
 		}
 	}
@@ -40,14 +40,14 @@ type OpenAgreement struct {
 }
 
 func (oa OpenAgreement) isEmpty() bool {
-	return len(oa.Details.Assets) == 0 && oa.Details.ObservationPeriodTime == 0 && oa.Details.ObservationPeriodLedgerGap == 0
+	return len(oa.Details.Trustlines) == 0 && oa.Details.ObservationPeriodTime == 0 && oa.Details.ObservationPeriodLedgerGap == 0
 }
 
 // OpenParams are the parameters selected by the participant proposing an open channel.
 type OpenParams struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
-	Assets                     []Trustline
+	Trustlines                 []Trustline
 }
 
 func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *txnbuild.Transaction, err error) {
@@ -63,7 +63,7 @@ func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *t
 		AmountToInitiator:          0,
 		AmountToResponder:          0,
 		// TODO - change to use all assets, simplifying for now
-		Asset: d.Assets[0].Asset,
+		Asset: d.Trustlines[0].Asset,
 	})
 	if err != nil {
 		return
@@ -83,7 +83,7 @@ func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *t
 		InitiatorEscrow: c.initiatorEscrowAccount().Address,
 		ResponderEscrow: c.responderEscrowAccount().Address,
 		StartSequence:   c.startingSequence,
-		Assets:          d.Assets,
+		Trustlines:      d.Trustlines,
 	})
 	return
 }
@@ -228,7 +228,7 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, authorized b
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
 			// TODO - change to use all assets, simplifying for now
-			Balance:                    Amount{Asset: m.Details.Assets[0].Asset},
+			Balance:                    Amount{Asset: m.Details.Trustlines[0].Asset},
 			ObservationPeriodTime:      m.Details.ObservationPeriodTime,
 			ObservationPeriodLedgerGap: m.Details.ObservationPeriodLedgerGap,
 		},

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -45,14 +45,12 @@ type OpenParams struct {
 	Assets                     []Trustline
 }
 
-func (c *Channel) OpenTxs(p OpenParams) (txClose, txDecl, formation *txnbuild.Transaction, err error) {
-	if len(p.Assets) == 0 {
+func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *txnbuild.Transaction, err error) {
+	if len(d.Assets) == 0 {
 		err = fmt.Errorf("invalid open params: trying to open a channel with no assets")
 		return
 	}
-}
 
-func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *txnbuild.Transaction, err error) {
 	txClose, err = txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: d.ObservationPeriodLedgerGap,
@@ -152,7 +150,7 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, authorized b
 
 	c.startingSequence = c.initiatorEscrowAccount().SequenceNumber + 1
 
-	txClose, txDecl, formation, err := c.OpenTxs(OpenParams{Assets: m.Details.Assets})
+	txClose, txDecl, formation, err := c.OpenTxs(m.Details)
 	if err != nil {
 		return m, authorized, err
 	}

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -18,6 +18,9 @@ type OpenAgreementDetails struct {
 }
 
 func (d OpenAgreementDetails) isEqual(d2 OpenAgreementDetails) bool {
+	if d.ObservationPeriodTime != d2.ObservationPeriodTime || d.ObservationPeriodLedgerGap != d2.ObservationPeriodLedgerGap {
+		return false
+	}
 	for i, a := range d.Assets {
 		if a != d2.Assets[i] {
 			return false

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -18,9 +18,12 @@ type OpenAgreementDetails struct {
 }
 
 func (d OpenAgreementDetails) isEqual(d2 OpenAgreementDetails) bool {
-	if d.ObservationPeriodTime != d2.ObservationPeriodTime || d.ObservationPeriodLedgerGap != d2.ObservationPeriodLedgerGap {
+	if d.ObservationPeriodTime != d2.ObservationPeriodTime ||
+		d.ObservationPeriodLedgerGap != d2.ObservationPeriodLedgerGap ||
+		len(d.Assets) != len(d2.Assets) {
 		return false
 	}
+
 	for i, a := range d.Assets {
 		if a != d2.Assets[i] {
 			return false

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -17,7 +17,7 @@ type OpenAgreementDetails struct {
 	Assets                     []Trustline
 }
 
-func (d OpenAgreementDetails) isEqual(d2 OpenAgreementDetails) bool {
+func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
 	if d.ObservationPeriodTime != d2.ObservationPeriodTime ||
 		d.ObservationPeriodLedgerGap != d2.ObservationPeriodLedgerGap ||
 		len(d.Assets) != len(d2.Assets) {
@@ -135,7 +135,7 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 // completely signed, fully signed will be true, otherwise it will be false.
 func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, authorized bool, err error) {
 	// If the open agreement details don't match the open agreement in progress, error.
-	if !c.openAgreement.isEmpty() && !m.Details.isEqual(c.openAgreement.Details) {
+	if !c.openAgreement.isEmpty() && !m.Details.Equal(c.openAgreement.Details) {
 		return m, authorized, fmt.Errorf("input open agreement details do not match the saved open agreement details")
 	}
 

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -32,7 +32,7 @@ func TestProposeOpen_validAsset(t *testing.T) {
 
 	native := NativeAsset{}
 	_, err := sendingChannel.ProposeOpen(OpenParams{
-		Assets: []Trustline{Trustline{
+		Trustlines: []Trustline{Trustline{
 			Asset: native},
 		},
 	})
@@ -40,7 +40,7 @@ func TestProposeOpen_validAsset(t *testing.T) {
 
 	invalidCredit := CreditAsset{}
 	_, err = sendingChannel.ProposeOpen(OpenParams{
-		Assets: []Trustline{
+		Trustlines: []Trustline{
 			Trustline{Asset: invalidCredit, AssetLimit: 100},
 		},
 	})
@@ -48,7 +48,7 @@ func TestProposeOpen_validAsset(t *testing.T) {
 
 	validCredit := CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
 	_, err = sendingChannel.ProposeOpen(OpenParams{
-		Assets: []Trustline{
+		Trustlines: []Trustline{
 			Trustline{Asset: validCredit, AssetLimit: 100},
 		},
 	})
@@ -79,7 +79,7 @@ func TestProposeOpen_multipleAssets(t *testing.T) {
 		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
-			Assets: []Trustline{
+			Trustlines: []Trustline{
 				Trustline{Asset: NativeAsset{}},
 			},
 		},
@@ -100,13 +100,13 @@ func TestProposeOpen_multipleAssets(t *testing.T) {
 		AssetLimit: 200,
 	}
 	p = OpenParams{
-		Assets: []Trustline{ca1, ca2},
+		Trustlines: []Trustline{ca1, ca2},
 	}
 	oa, err := channel.ProposeOpen(p)
 	require.NoError(t, err)
 
 	wantDetails := OpenAgreementDetails{
-		Assets: []Trustline{ca1, ca2},
+		Trustlines: []Trustline{ca1, ca2},
 	}
 	assert.Equal(t, wantDetails, oa.Details)
 	assert.Len(t, oa.CloseSignatures, 1)
@@ -136,7 +136,7 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
-			Assets: []Trustline{
+			Trustlines: []Trustline{
 				Trustline{Asset: NativeAsset{}},
 			},
 		},
@@ -145,7 +145,7 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 	oa := OpenAgreementDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
-		Assets: []Trustline{
+		Trustlines: []Trustline{
 			Trustline{Asset: NativeAsset{}},
 		},
 	}
@@ -162,7 +162,7 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 	{
 		// invalid new asset
 		d := oa
-		d.Assets = append(d.Assets, Trustline{Asset: CreditAsset{Code: "abc"}})
+		d.Trustlines = append(d.Trustlines, Trustline{Asset: CreditAsset{Code: "abc"}})
 		_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: d})
 		require.False(t, authorized)
 		require.EqualError(t, err, "input open agreement details do not match the saved open agreement details")

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -131,6 +131,7 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
+			// TODO - remove explicit native asset trustline
 			Trustlines: []Trustline{
 				Trustline{Asset: NativeAsset{}},
 			},

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -96,7 +96,7 @@ func TestProposeOpen_multipleAssets(t *testing.T) {
 		AssetLimit: 100,
 	}
 	ca2 := Trustline{
-		Asset:      txnbuild.CreditAsset{Code: "ABC", Issuer: "abcIssuer"},
+		Asset:      txnbuild.CreditAsset{Code: "ABC", Issuer: "GB3A5VJGUIXQ4X35NZQMVLO5DKSOTUFF6SLHLY7BWJLJYVQVCJM4IEAI"},
 		AssetLimit: 200,
 	}
 	p = OpenParams{
@@ -109,7 +109,7 @@ func TestProposeOpen_multipleAssets(t *testing.T) {
 		Assets: []Trustline{ca1, ca2},
 	}
 	assert.Equal(t, wantDetails, oa.Details)
-	assert.Len(t, 1, len(oa.CloseSignatures))
+	assert.Len(t, oa.CloseSignatures, 1)
 }
 
 func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestProposePayment_validAsset(t *testing.T) {
+func TestProposeOpen_validAsset(t *testing.T) {
 	localSigner := keypair.MustRandom()
 	remoteSigner := keypair.MustRandom()
 	localEscrowAccount := &EscrowAccount{
@@ -39,4 +41,33 @@ func TestProposePayment_validAsset(t *testing.T) {
 	validCredit := CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
 	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: validCredit, AssetLimit: 100})
 	require.NoError(t, err)
+}
+
+func TestProposeOpen_multipleAssets(t *testing.T) {
+	// invalid open params
+	p := OpenParams{}
+	_, err := channel.ProposeOpen(p)
+	assert.EqualError(t, err, `invalid open params: trying to open a channel with no assets`)
+
+	// valid open params
+	ca1 := Trustline{
+		Asset:      txnbuild.NativeAsset{},
+		AssetLimit: 100,
+	}
+	ca2 := Trustline{
+		Asset:      txnbuild.CreditAsset{Code: "ABC", Issuer: "abcIssuer"},
+		AssetLimit: 200,
+	}
+	p = OpenParams{
+		Assets: []Trustline{ca1, ca2},
+	}
+	oa, err := channel.ProposeOpen(p)
+	require.NoError(t, err)
+
+	wantDetails := OpenAgreementDetails{
+		Assets: []Trustline{ca1, ca2},
+	}
+	assert.Equal(t, wantDetails, oa.Details)
+	assert.Len(t, 1, oa.CloseSignatures)
+
 }

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -91,22 +91,22 @@ func TestProposeOpen_multipleAssets(t *testing.T) {
 	assert.EqualError(t, err, `invalid open params: trying to open a channel with no assets`)
 
 	// valid open params
-	ca1 := Trustline{
+	tl1 := Trustline{
 		Asset:      txnbuild.NativeAsset{},
 		AssetLimit: 100,
 	}
-	ca2 := Trustline{
+	tl2 := Trustline{
 		Asset:      txnbuild.CreditAsset{Code: "ABC", Issuer: "GB3A5VJGUIXQ4X35NZQMVLO5DKSOTUFF6SLHLY7BWJLJYVQVCJM4IEAI"},
 		AssetLimit: 200,
 	}
 	p = OpenParams{
-		Trustlines: []Trustline{ca1, ca2},
+		Trustlines: []Trustline{tl1, tl2},
 	}
 	oa, err := channel.ProposeOpen(p)
 	require.NoError(t, err)
 
 	wantDetails := OpenAgreementDetails{
-		Trustlines: []Trustline{ca1, ca2},
+		Trustlines: []Trustline{tl1, tl2},
 	}
 	assert.Equal(t, wantDetails, oa.Details)
 	assert.Len(t, oa.CloseSignatures, 1)

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -85,11 +85,6 @@ func TestProposeOpen_multipleAssets(t *testing.T) {
 		},
 	}
 
-	// invalid open params
-	p := OpenParams{}
-	_, err := channel.ProposeOpen(p)
-	assert.EqualError(t, err, `invalid open params: trying to open a channel with no assets`)
-
 	// valid open params
 	tl1 := Trustline{
 		Asset:      txnbuild.NativeAsset{},
@@ -99,7 +94,7 @@ func TestProposeOpen_multipleAssets(t *testing.T) {
 		Asset:      txnbuild.CreditAsset{Code: "ABC", Issuer: "GB3A5VJGUIXQ4X35NZQMVLO5DKSOTUFF6SLHLY7BWJLJYVQVCJM4IEAI"},
 		AssetLimit: 200,
 	}
-	p = OpenParams{
+	p := OpenParams{
 		Trustlines: []Trustline{tl1, tl2},
 	}
 	oa, err := channel.ProposeOpen(p)

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -31,19 +31,60 @@ func TestProposeOpen_validAsset(t *testing.T) {
 	})
 
 	native := NativeAsset{}
-	_, err := sendingChannel.ProposeOpen(OpenParams{Asset: native})
+	_, err := sendingChannel.ProposeOpen(OpenParams{
+		Assets: []Trustline{Trustline{
+			Asset: native},
+		},
+	})
 	require.NoError(t, err)
 
 	invalidCredit := CreditAsset{}
-	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: invalidCredit, AssetLimit: 100})
+	_, err = sendingChannel.ProposeOpen(OpenParams{
+		Assets: []Trustline{
+			Trustline{Asset: invalidCredit, AssetLimit: 100},
+		},
+	})
 	require.EqualError(t, err, `validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: asset code length must be between 1 and 12 characters`)
 
 	validCredit := CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
-	_, err = sendingChannel.ProposeOpen(OpenParams{Asset: validCredit, AssetLimit: 100})
+	_, err = sendingChannel.ProposeOpen(OpenParams{
+		Assets: []Trustline{
+			Trustline{Asset: validCredit, AssetLimit: 100},
+		},
+	})
 	require.NoError(t, err)
 }
 
 func TestProposeOpen_multipleAssets(t *testing.T) {
+	localSigner := keypair.MustRandom()
+	remoteSigner := keypair.MustRandom()
+	localEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(101),
+	}
+	remoteEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(202),
+	}
+
+	channel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           true,
+		LocalSigner:         localSigner,
+		RemoteSigner:        remoteSigner.FromAddress(),
+		LocalEscrowAccount:  localEscrowAccount,
+		RemoteEscrowAccount: remoteEscrowAccount,
+	})
+	channel.openAgreement = OpenAgreement{
+		Details: OpenAgreementDetails{
+			ObservationPeriodTime:      1,
+			ObservationPeriodLedgerGap: 1,
+			Assets: []Trustline{
+				Trustline{Asset: NativeAsset{}},
+			},
+		},
+	}
+
 	// invalid open params
 	p := OpenParams{}
 	_, err := channel.ProposeOpen(p)
@@ -68,6 +109,63 @@ func TestProposeOpen_multipleAssets(t *testing.T) {
 		Assets: []Trustline{ca1, ca2},
 	}
 	assert.Equal(t, wantDetails, oa.Details)
-	assert.Len(t, 1, oa.CloseSignatures)
+	assert.Len(t, 1, len(oa.CloseSignatures))
+}
+
+func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
+	localSigner := keypair.MustRandom()
+	remoteSigner := keypair.MustRandom()
+	localEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(101),
+	}
+	remoteEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(202),
+	}
+
+	channel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           true,
+		LocalSigner:         localSigner,
+		RemoteSigner:        remoteSigner.FromAddress(),
+		LocalEscrowAccount:  localEscrowAccount,
+		RemoteEscrowAccount: remoteEscrowAccount,
+	})
+	channel.openAgreement = OpenAgreement{
+		Details: OpenAgreementDetails{
+			ObservationPeriodTime:      1,
+			ObservationPeriodLedgerGap: 1,
+			Assets: []Trustline{
+				Trustline{Asset: NativeAsset{}},
+			},
+		},
+	}
+
+	oa := OpenAgreementDetails{
+		ObservationPeriodTime:      1,
+		ObservationPeriodLedgerGap: 1,
+		Assets: []Trustline{
+			Trustline{Asset: NativeAsset{}},
+		},
+	}
+
+	{
+		// invalid ObservationPeriodTime
+		d := oa
+		d.ObservationPeriodTime = 0
+		_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: d})
+		require.False(t, authorized)
+		require.EqualError(t, err, "input open agreement details do not match the saved open agreement details")
+	}
+
+	{
+		// invalid new asset
+		d := oa
+		d.Assets = append(d.Assets, Trustline{Asset: CreditAsset{Code: "abc"}})
+		_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: d})
+		require.False(t, authorized)
+		require.EqualError(t, err, "input open agreement details do not match the saved open agreement details")
+	}
 
 }

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -10,7 +10,7 @@ type CreateEscrowParams struct {
 	Creator        *keypair.FromAddress
 	Escrow         *keypair.FromAddress
 	SequenceNumber int64
-	Assets         []Trustline
+	Trustlines     []Trustline
 }
 
 func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
@@ -32,7 +32,7 @@ func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
 			Signer:          &txnbuild.Signer{Address: p.Creator.Address(), Weight: 1},
 		},
 	}
-	for _, a := range p.Assets {
+	for _, a := range p.Trustlines {
 		if !a.Asset.IsNative() {
 			ops = append(ops, &txnbuild.ChangeTrust{
 				Line:          a.Asset,

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -10,8 +10,7 @@ type CreateEscrowParams struct {
 	Creator        *keypair.FromAddress
 	Escrow         *keypair.FromAddress
 	SequenceNumber int64
-	Asset          txnbuild.Asset
-	AssetLimit     int64
+	Assets         []Trustline
 }
 
 func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
@@ -33,12 +32,14 @@ func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
 			Signer:          &txnbuild.Signer{Address: p.Creator.Address(), Weight: 1},
 		},
 	}
-	if !p.Asset.IsNative() {
-		ops = append(ops, &txnbuild.ChangeTrust{
-			Line:          p.Asset,
-			Limit:         amount.StringFromInt64(p.AssetLimit),
-			SourceAccount: p.Escrow.Address(),
-		})
+	for _, a := range p.Assets {
+		if !a.Asset.IsNative() {
+			ops = append(ops, &txnbuild.ChangeTrust{
+				Line:          a.Asset,
+				Limit:         amount.StringFromInt64(a.AssetLimit),
+				SourceAccount: p.Escrow.Address(),
+			})
+		}
 	}
 	ops = append(ops, &txnbuild.EndSponsoringFutureReserves{
 		SourceAccount: p.Escrow.Address(),

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -67,7 +67,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		Signer:        &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
 	})
 	for _, a := range p.Trustlines {
-		if !a.Asset.IsNative() {
+		if a.Asset.IsNative() {
 			continue
 		}
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -43,13 +43,14 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		Signer:        &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
 	})
 	for _, a := range p.Trustlines {
-		if !a.Asset.IsNative() {
-			tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
-				Line:          a.Asset,
-				Limit:         amount.StringFromInt64(a.AssetLimit),
-				SourceAccount: p.InitiatorEscrow.Address(),
-			})
+		if a.Asset.IsNative() {
+			continue
 		}
+		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
+			Line:          a.Asset,
+			Limit:         amount.StringFromInt64(a.AssetLimit),
+			SourceAccount: p.InitiatorEscrow.Address(),
+		})
 	}
 	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.InitiatorEscrow.Address()})
 	tp.Operations = append(tp.Operations, &txnbuild.BeginSponsoringFutureReserves{SourceAccount: p.ResponderSigner.Address(), SponsoredID: p.ResponderEscrow.Address()})
@@ -67,12 +68,13 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 	})
 	for _, a := range p.Trustlines {
 		if !a.Asset.IsNative() {
-			tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
-				Line:          a.Asset,
-				Limit:         amount.StringFromInt64(a.AssetLimit),
-				SourceAccount: p.ResponderEscrow.Address(),
-			})
+			continue
 		}
+		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
+			Line:          a.Asset,
+			Limit:         amount.StringFromInt64(a.AssetLimit),
+			SourceAccount: p.ResponderEscrow.Address(),
+		})
 	}
 	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.ResponderEscrow.Address()})
 	tx, err := txnbuild.NewTransaction(tp)

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -17,7 +17,7 @@ type FormationParams struct {
 	InitiatorEscrow *keypair.FromAddress
 	ResponderEscrow *keypair.FromAddress
 	StartSequence   int64
-	Assets          []Trustline
+	Trustlines      []Trustline
 }
 
 func Formation(p FormationParams) (*txnbuild.Transaction, error) {
@@ -42,7 +42,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		SourceAccount: p.InitiatorEscrow.Address(),
 		Signer:        &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
 	})
-	for _, a := range p.Assets {
+	for _, a := range p.Trustlines {
 		if !a.Asset.IsNative() {
 			tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
 				Line:          a.Asset,
@@ -65,7 +65,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		SourceAccount: p.ResponderEscrow.Address(),
 		Signer:        &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
 	})
-	for _, a := range p.Assets {
+	for _, a := range p.Trustlines {
 		if !a.Asset.IsNative() {
 			tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
 				Line:          a.Asset,

--- a/sdk/txbuild/integrationtests/integrationtests_test.go
+++ b/sdk/txbuild/integrationtests/integrationtests_test.go
@@ -47,7 +47,7 @@ func Test(t *testing.T) {
 			Creator:        initiator.KP.FromAddress(),
 			Escrow:         initiator.Escrow.FromAddress(),
 			SequenceNumber: seqNum + 1,
-			Assets: []txbuild.Trustline{
+			Trustlines: []txbuild.Trustline{
 				txbuild.Trustline{Asset: txnbuild.NativeAsset{}},
 			},
 		})
@@ -112,7 +112,7 @@ func Test(t *testing.T) {
 			Creator:        responder.KP.FromAddress(),
 			Escrow:         responder.Escrow.FromAddress(),
 			SequenceNumber: seqNum + 1,
-			Assets: []txbuild.Trustline{
+			Trustlines: []txbuild.Trustline{
 				txbuild.Trustline{Asset: txnbuild.NativeAsset{}},
 			},
 		})
@@ -213,7 +213,7 @@ func Test(t *testing.T) {
 			InitiatorEscrow: initiator.Escrow.FromAddress(),
 			ResponderEscrow: responder.Escrow.FromAddress(),
 			StartSequence:   s,
-			Assets: []txbuild.Trustline{
+			Trustlines: []txbuild.Trustline{
 				txbuild.Trustline{Asset: txnbuild.NativeAsset{}},
 			},
 		})

--- a/sdk/txbuild/integrationtests/integrationtests_test.go
+++ b/sdk/txbuild/integrationtests/integrationtests_test.go
@@ -209,7 +209,7 @@ func Test(t *testing.T) {
 			InitiatorEscrow: initiator.Escrow.FromAddress(),
 			ResponderEscrow: responder.Escrow.FromAddress(),
 			StartSequence:   s,
-			Asset:           txnbuild.NativeAsset{},
+			Assets:          []Trustline{Trustline{Asset: txnbuild.NativeAsset{}}},
 		})
 		require.NoError(t, err)
 		f, err = f.Sign(networkPassphrase, initiator.KP, responder.KP)

--- a/sdk/txbuild/integrationtests/integrationtests_test.go
+++ b/sdk/txbuild/integrationtests/integrationtests_test.go
@@ -47,7 +47,9 @@ func Test(t *testing.T) {
 			Creator:        initiator.KP.FromAddress(),
 			Escrow:         initiator.Escrow.FromAddress(),
 			SequenceNumber: seqNum + 1,
-			Asset:          txnbuild.NativeAsset{},
+			Assets: []txbuild.Trustline{
+				txbuild.Trustline{Asset: txnbuild.NativeAsset{}},
+			},
 		})
 		require.NoError(t, err)
 		tx, err = tx.Sign(networkPassphrase, initiator.KP, initiator.Escrow)
@@ -110,7 +112,9 @@ func Test(t *testing.T) {
 			Creator:        responder.KP.FromAddress(),
 			Escrow:         responder.Escrow.FromAddress(),
 			SequenceNumber: seqNum + 1,
-			Asset:          txnbuild.NativeAsset{},
+			Assets: []txbuild.Trustline{
+				txbuild.Trustline{Asset: txnbuild.NativeAsset{}},
+			},
 		})
 		require.NoError(t, err)
 		tx, err = tx.Sign(networkPassphrase, responder.KP, responder.Escrow)
@@ -209,7 +213,9 @@ func Test(t *testing.T) {
 			InitiatorEscrow: initiator.Escrow.FromAddress(),
 			ResponderEscrow: responder.Escrow.FromAddress(),
 			StartSequence:   s,
-			Assets:          []Trustline{Trustline{Asset: txnbuild.NativeAsset{}}},
+			Assets: []txbuild.Trustline{
+				txbuild.Trustline{Asset: txnbuild.NativeAsset{}},
+			},
 		})
 		require.NoError(t, err)
 		f, err = f.Sign(networkPassphrase, initiator.KP, responder.KP)


### PR DESCRIPTION
supports multiple assets when forming the accounts (`txbuild/formation`, `txbuild/create_escrow`) and in the open steps
 (`state/open`)

After this PR will add support in the rest of the code (`close` and `update` steps)

Fulfills part of https://github.com/stellar/experimental-payment-channels/issues/72