### PR TITLE
sdk/state: support single asset only

### DIFF
--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -33,12 +33,9 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	rootResp, err := client.Root()
 	require.NoError(t, err)
 	distributor := keypair.Master(rootResp.NetworkPassphrase).(*keypair.Full)
-	initiator, responder := initAccounts(t, []AssetParam{
-		{
-			Asset:       asset,
-			AssetLimit:  assetLimit,
-			Distributor: distributor,
-		},
+	initiator, responder := initAccounts(t, AssetParam{
+		Asset:       asset,
+		Distributor: distributor,
 	})
 	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
 
@@ -313,12 +310,9 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 
 	asset, distributor := initAsset(t, client, "ABDC")
 	assetLimit := int64(5_000_0000000)
-	initiator, responder := initAccounts(t, []AssetParam{
-		{
-			Asset:       asset,
-			AssetLimit:  assetLimit,
-			Distributor: distributor,
-		},
+	initiator, responder := initAccounts(t, AssetParam{
+		Asset:       asset,
+		Distributor: distributor,
 	})
 	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
 
@@ -521,112 +515,6 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 	assert.Equal(t, amount.StringFromInt64(iBalanceCheck), assetBalance(asset, initiatorEscrowResponse))
 }
 
-func TestOpen_multipleAssets(t *testing.T) {
-	asset1, distributor := initAsset(t, client, "code1")
-	assetLimit1 := int64(5_000_0000000)
-	ap1 := AssetParam{
-		Asset:       asset1,
-		Distributor: distributor,
-		AssetLimit:  assetLimit1,
-	}
-
-	asset2, distributor := initAsset(t, client, "code2")
-	assetLimit2 := int64(10_000_0000000)
-	ap2 := AssetParam{
-		Asset:       asset2,
-		Distributor: distributor,
-		AssetLimit:  assetLimit2,
-	}
-
-	initiator, responder := initAccounts(t, []AssetParam{ap1, ap2})
-	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
-
-	s := initiator.EscrowSequenceNumber + 1
-	i := int64(1)
-	e := int64(0)
-	t.Log("Vars: s:", s, "i:", i, "e:", e)
-
-	// Open
-	t.Log("Open...")
-	// I signs txClose
-	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
-		Trustlines: []state.Trustline{
-			{Asset: asset1, AssetLimit: assetLimit1},
-			{Asset: asset2, AssetLimit: assetLimit2},
-		},
-	})
-	require.NoError(t, err)
-	{
-		var authorizedR bool
-		// R signs txClose and txDecl
-		open, authorizedR, err = responderChannel.ConfirmOpen(open)
-		require.NoError(t, err)
-		require.False(t, authorizedR)
-
-		var authorizedI bool
-		// I signs txDecl and F
-		open, authorizedI, err = initiatorChannel.ConfirmOpen(open)
-		require.NoError(t, err)
-		require.False(t, authorizedI)
-
-		// R signs F, R is done
-		open, authorizedR, err = responderChannel.ConfirmOpen(open)
-		require.NoError(t, err)
-		require.True(t, authorizedR)
-
-		// I receives the last signatures for F, I is done
-		_, authorizedI, err = initiatorChannel.ConfirmOpen(open)
-		require.NoError(t, err)
-		require.True(t, authorizedI)
-	}
-
-	{
-		ci, di, fi, err := initiatorChannel.OpenTxs(initiatorChannel.OpenAgreement().Details)
-		require.NoError(t, err)
-
-		_, err = ci.AddSignatureDecorated(initiatorChannel.OpenAgreement().CloseSignatures...)
-		require.NoError(t, err)
-
-		_, err = di.AddSignatureDecorated(initiatorChannel.OpenAgreement().DeclarationSignatures...)
-		require.NoError(t, err)
-
-		fi, err = fi.AddSignatureDecorated(initiatorChannel.OpenAgreement().FormationSignatures...)
-		require.NoError(t, err)
-
-		fbtx, err := txnbuild.NewFeeBumpTransaction(txnbuild.FeeBumpTransactionParams{
-			Inner:      fi,
-			FeeAccount: initiator.KP.Address(),
-			BaseFee:    txnbuild.MinBaseFee,
-		})
-		require.NoError(t, err)
-		fbtx, err = fbtx.Sign(networkPassphrase, initiator.KP)
-		require.NoError(t, err)
-		_, err = client.SubmitFeeBumpTransaction(fbtx)
-		require.NoError(t, err)
-	}
-
-	// check the balances are correct for both escrow accounts
-	accountRequest := horizonclient.AccountRequest{AccountID: responder.Escrow.Address()}
-	responderEscrowResponse, err := client.AccountDetail(accountRequest)
-	require.NoError(t, err)
-	assert.Equal(t, amount.StringFromInt64(1_000_0000000), responderEscrowResponse.Balances[0].Balance)
-	assert.Equal(t, "code1", responderEscrowResponse.Balances[0].Asset.Code)
-	assert.Equal(t, amount.StringFromInt64(assetLimit1), responderEscrowResponse.Balances[0].Limit)
-	assert.Equal(t, amount.StringFromInt64(1_000_0000000), responderEscrowResponse.Balances[1].Balance)
-	assert.Equal(t, amount.StringFromInt64(assetLimit2), responderEscrowResponse.Balances[1].Limit)
-	assert.Equal(t, "code2", responderEscrowResponse.Balances[1].Asset.Code)
-
-	accountRequest = horizonclient.AccountRequest{AccountID: initiator.Escrow.Address()}
-	initiatorEscrowResponse, err := client.AccountDetail(accountRequest)
-	require.NoError(t, err)
-	assert.Equal(t, amount.StringFromInt64(1_000_0000000), initiatorEscrowResponse.Balances[0].Balance)
-	assert.Equal(t, "code1", initiatorEscrowResponse.Balances[0].Asset.Code)
-	assert.Equal(t, amount.StringFromInt64(assetLimit1), initiatorEscrowResponse.Balances[0].Limit)
-	assert.Equal(t, amount.StringFromInt64(1_000_0000000), initiatorEscrowResponse.Balances[1].Balance)
-	assert.Equal(t, amount.StringFromInt64(assetLimit2), initiatorEscrowResponse.Balances[1].Limit)
-	assert.Equal(t, "code2", initiatorEscrowResponse.Balances[1].Asset.Code)
-}
-
 func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	// Channel constants.
 	const observationPeriodTime = 20 * time.Second
@@ -635,12 +523,9 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 
 	asset, distributor := initAsset(t, client, "ABDC")
 	assetLimit := int64(5_000_0000000)
-	initiator, responder := initAccounts(t, []AssetParam{
-		{
-			Asset:       asset,
-			AssetLimit:  assetLimit,
-			Distributor: distributor,
-		},
+	initiator, responder := initAccounts(t, AssetParam{
+		Asset:       asset,
+		Distributor: distributor,
 	})
 	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
 
@@ -853,12 +738,9 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 
 	asset, distributor := initAsset(t, client, "ABDC")
 	assetLimit := int64(5_000_0000000)
-	initiator, responder := initAccounts(t, []AssetParam{
-		{
-			Asset:       asset,
-			AssetLimit:  assetLimit,
-			Distributor: distributor,
-		},
+	initiator, responder := initAccounts(t, AssetParam{
+		Asset:       asset,
+		Distributor: distributor,
 	})
 	initiatorChannel, responderChannel := initChannels(t, initiator, responder)
 

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -29,7 +29,6 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 
 	asset := txnbuild.NativeAsset{}
 	// native asset has no asset limit
-	assetLimit := int64(0)
 	rootResp, err := client.Root()
 	require.NoError(t, err)
 	distributor := keypair.Master(rootResp.NetworkPassphrase).(*keypair.Full)
@@ -54,9 +53,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
-		Trustlines: []state.Trustline{
-			{Asset: asset, AssetLimit: assetLimit},
-		},
+		Asset:                      asset,
 	})
 	require.NoError(t, err)
 	assert.Len(t, open.CloseSignatures, 1)
@@ -309,7 +306,6 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
 
 	asset, distributor := initAsset(t, client, "ABDC")
-	assetLimit := int64(5_000_0000000)
 	initiator, responder := initAccounts(t, AssetParam{
 		Asset:       asset,
 		Distributor: distributor,
@@ -327,9 +323,7 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
-		Trustlines: []state.Trustline{
-			{Asset: asset, AssetLimit: assetLimit},
-		},
+		Asset:                      asset,
 	})
 	require.NoError(t, err)
 	assert.Len(t, open.CloseSignatures, 1)
@@ -522,7 +516,6 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
 
 	asset, distributor := initAsset(t, client, "ABDC")
-	assetLimit := int64(5_000_0000000)
 	initiator, responder := initAccounts(t, AssetParam{
 		Asset:       asset,
 		Distributor: distributor,
@@ -540,9 +533,7 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
-		Trustlines: []state.Trustline{
-			{Asset: asset, AssetLimit: assetLimit},
-		},
+		Asset:                      asset,
 	})
 
 	require.NoError(t, err)
@@ -737,7 +728,6 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
 
 	asset, distributor := initAsset(t, client, "ABDC")
-	assetLimit := int64(5_000_0000000)
 	initiator, responder := initAccounts(t, AssetParam{
 		Asset:       asset,
 		Distributor: distributor,
@@ -755,9 +745,7 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 	open, err := initiatorChannel.ProposeOpen(state.OpenParams{
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
-		Trustlines: []state.Trustline{
-			{Asset: asset, AssetLimit: assetLimit},
-		},
+		Asset:                      asset,
 	})
 
 	require.NoError(t, err)

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -9,27 +9,14 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-type Trustline = txbuild.Trustline
-
 type OpenAgreementDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
-	Trustlines                 []Trustline
+	Asset                      Asset
 }
 
 func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
-	if d.ObservationPeriodTime != d2.ObservationPeriodTime ||
-		d.ObservationPeriodLedgerGap != d2.ObservationPeriodLedgerGap ||
-		len(d.Trustlines) != len(d2.Trustlines) {
-		return false
-	}
-
-	for i, a := range d.Trustlines {
-		if a != d2.Trustlines[i] {
-			return false
-		}
-	}
-	return true
+	return d == d2
 }
 
 type OpenAgreement struct {
@@ -40,14 +27,14 @@ type OpenAgreement struct {
 }
 
 func (oa OpenAgreement) isEmpty() bool {
-	return len(oa.Details.Trustlines) == 0 && oa.Details.ObservationPeriodTime == 0 && oa.Details.ObservationPeriodLedgerGap == 0
+	return oa.Details.Equal(OpenAgreementDetails{})
 }
 
 // OpenParams are the parameters selected by the participant proposing an open channel.
 type OpenParams struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
-	Trustlines                 []Trustline
+	Asset                      Asset
 }
 
 func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *txnbuild.Transaction, err error) {
@@ -62,8 +49,7 @@ func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *t
 		IterationNumber:            1,
 		AmountToInitiator:          0,
 		AmountToResponder:          0,
-		// TODO - change to use all assets, simplifying for now
-		Asset: d.Trustlines[0].Asset,
+		Asset:                      d.Asset,
 	})
 	if err != nil {
 		return
@@ -83,7 +69,7 @@ func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *t
 		InitiatorEscrow: c.initiatorEscrowAccount().Address,
 		ResponderEscrow: c.responderEscrowAccount().Address,
 		StartSequence:   c.startingSequence,
-		Trustlines:      d.Trustlines,
+		Asset:           d.Asset,
 	})
 	return
 }
@@ -228,7 +214,7 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, authorized b
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
 			// TODO - change to use all assets, simplifying for now
-			Balance:                    Amount{Asset: m.Details.Trustlines[0].Asset},
+			Balance:                    Amount{Asset: m.Details.Asset},
 			ObservationPeriodTime:      m.Details.ObservationPeriodTime,
 			ObservationPeriodLedgerGap: m.Details.ObservationPeriodLedgerGap,
 		},

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
-	"github.com/stellar/go/txnbuild"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,81 +30,21 @@ func TestProposeOpen_validAsset(t *testing.T) {
 
 	native := NativeAsset{}
 	_, err := sendingChannel.ProposeOpen(OpenParams{
-		Trustlines: []Trustline{
-			{
-				Asset: native,
-			},
-		},
+		Asset: native,
 	})
 	require.NoError(t, err)
 
 	invalidCredit := CreditAsset{}
 	_, err = sendingChannel.ProposeOpen(OpenParams{
-		Trustlines: []Trustline{
-			{Asset: invalidCredit, AssetLimit: 100},
-		},
+		Asset: invalidCredit,
 	})
 	require.EqualError(t, err, `validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: asset code length must be between 1 and 12 characters`)
 
 	validCredit := CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
 	_, err = sendingChannel.ProposeOpen(OpenParams{
-		Trustlines: []Trustline{
-			{Asset: validCredit, AssetLimit: 100},
-		},
+		Asset: validCredit,
 	})
 	require.NoError(t, err)
-}
-
-func TestProposeOpen_multipleAssets(t *testing.T) {
-	localSigner := keypair.MustRandom()
-	remoteSigner := keypair.MustRandom()
-	localEscrowAccount := &EscrowAccount{
-		Address:        keypair.MustRandom().FromAddress(),
-		SequenceNumber: int64(101),
-	}
-	remoteEscrowAccount := &EscrowAccount{
-		Address:        keypair.MustRandom().FromAddress(),
-		SequenceNumber: int64(202),
-	}
-
-	channel := NewChannel(Config{
-		NetworkPassphrase:   network.TestNetworkPassphrase,
-		Initiator:           true,
-		LocalSigner:         localSigner,
-		RemoteSigner:        remoteSigner.FromAddress(),
-		LocalEscrowAccount:  localEscrowAccount,
-		RemoteEscrowAccount: remoteEscrowAccount,
-	})
-	channel.openAgreement = OpenAgreement{
-		Details: OpenAgreementDetails{
-			ObservationPeriodTime:      1,
-			ObservationPeriodLedgerGap: 1,
-			Trustlines: []Trustline{
-				{Asset: NativeAsset{}},
-			},
-		},
-	}
-
-	// valid open params
-	tl1 := Trustline{
-		Asset:      txnbuild.NativeAsset{},
-		AssetLimit: 100,
-	}
-	tl2 := Trustline{
-		Asset:      txnbuild.CreditAsset{Code: "ABC", Issuer: "GB3A5VJGUIXQ4X35NZQMVLO5DKSOTUFF6SLHLY7BWJLJYVQVCJM4IEAI"},
-		AssetLimit: 200,
-	}
-	p := OpenParams{
-		Trustlines: []Trustline{tl1, tl2},
-	}
-	oa, err := channel.ProposeOpen(p)
-	require.NoError(t, err)
-
-	wantDetails := OpenAgreementDetails{
-		Trustlines: []Trustline{tl1, tl2},
-	}
-	assert.Equal(t, wantDetails, oa.Details)
-	assert.Len(t, oa.CloseSignatures, 1)
 }
 
 func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
@@ -133,19 +71,14 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
-			// TODO - remove explicit native asset trustline
-			Trustlines: []Trustline{
-				{Asset: NativeAsset{}},
-			},
+			Asset:                      NativeAsset{},
 		},
 	}
 
 	oa := OpenAgreementDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
-		Trustlines: []Trustline{
-			{Asset: NativeAsset{}},
-		},
+		Asset:                      NativeAsset{},
 	}
 
 	{
@@ -158,9 +91,9 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 	}
 
 	{
-		// invalid new asset
+		// invalid different asset
 		d := oa
-		d.Trustlines = append(d.Trustlines, Trustline{Asset: CreditAsset{Code: "abc"}})
+		d.Asset = CreditAsset{Code: "abc"}
 		_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: d})
 		require.False(t, authorized)
 		require.EqualError(t, err, "input open agreement details do not match the saved open agreement details")

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -1,6 +1,8 @@
 package txbuild
 
 import (
+	"math"
+
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
@@ -10,7 +12,7 @@ type CreateEscrowParams struct {
 	Creator        *keypair.FromAddress
 	Escrow         *keypair.FromAddress
 	SequenceNumber int64
-	Trustlines     []Trustline
+	Asset          txnbuild.Asset
 }
 
 func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
@@ -32,14 +34,12 @@ func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
 			Signer:          &txnbuild.Signer{Address: p.Creator.Address(), Weight: 1},
 		},
 	}
-	for _, a := range p.Trustlines {
-		if !a.Asset.IsNative() {
-			ops = append(ops, &txnbuild.ChangeTrust{
-				Line:          a.Asset,
-				Limit:         amount.StringFromInt64(a.AssetLimit),
-				SourceAccount: p.Escrow.Address(),
-			})
-		}
+	if !p.Asset.IsNative() {
+		ops = append(ops, &txnbuild.ChangeTrust{
+			Line:          p.Asset,
+			Limit:         amount.StringFromInt64(math.MaxInt64),
+			SourceAccount: p.Escrow.Address(),
+		})
 	}
 	ops = append(ops, &txnbuild.EndSponsoringFutureReserves{
 		SourceAccount: p.Escrow.Address(),

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -1,15 +1,12 @@
 package txbuild
 
 import (
+	"math"
+
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
 )
-
-type Trustline struct {
-	Asset      txnbuild.Asset
-	AssetLimit int64
-}
 
 type FormationParams struct {
 	InitiatorSigner *keypair.FromAddress
@@ -17,7 +14,7 @@ type FormationParams struct {
 	InitiatorEscrow *keypair.FromAddress
 	ResponderEscrow *keypair.FromAddress
 	StartSequence   int64
-	Trustlines      []Trustline
+	Asset           txnbuild.Asset
 }
 
 func Formation(p FormationParams) (*txnbuild.Transaction, error) {
@@ -42,13 +39,10 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		SourceAccount: p.InitiatorEscrow.Address(),
 		Signer:        &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
 	})
-	for _, a := range p.Trustlines {
-		if a.Asset.IsNative() {
-			continue
-		}
+	if !p.Asset.IsNative() {
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
-			Line:          a.Asset,
-			Limit:         amount.StringFromInt64(a.AssetLimit),
+			Line:          p.Asset,
+			Limit:         amount.StringFromInt64(math.MaxInt64),
 			SourceAccount: p.InitiatorEscrow.Address(),
 		})
 	}
@@ -66,13 +60,10 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		SourceAccount: p.ResponderEscrow.Address(),
 		Signer:        &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
 	})
-	for _, a := range p.Trustlines {
-		if a.Asset.IsNative() {
-			continue
-		}
+	if !p.Asset.IsNative() {
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
-			Line:          a.Asset,
-			Limit:         amount.StringFromInt64(a.AssetLimit),
+			Line:          p.Asset,
+			Limit:         amount.StringFromInt64(math.MaxInt64),
 			SourceAccount: p.ResponderEscrow.Address(),
 		})
 	}

--- a/sdk/txbuild/integrationtests/integrationtests_test.go
+++ b/sdk/txbuild/integrationtests/integrationtests_test.go
@@ -209,9 +209,7 @@ func Test(t *testing.T) {
 			InitiatorEscrow: initiator.Escrow.FromAddress(),
 			ResponderEscrow: responder.Escrow.FromAddress(),
 			StartSequence:   s,
-			Trustlines: []txbuild.Trustline{
-				{Asset: txnbuild.NativeAsset{}},
-			},
+			Asset:           txnbuild.NativeAsset{},
 		})
 		require.NoError(t, err)
 		f, err = f.Sign(networkPassphrase, initiator.KP, responder.KP)

--- a/sdk/txbuild/integrationtests/integrationtests_test.go
+++ b/sdk/txbuild/integrationtests/integrationtests_test.go
@@ -47,9 +47,7 @@ func Test(t *testing.T) {
 			Creator:        initiator.KP.FromAddress(),
 			Escrow:         initiator.Escrow.FromAddress(),
 			SequenceNumber: seqNum + 1,
-			Trustlines: []txbuild.Trustline{
-				{Asset: txnbuild.NativeAsset{}},
-			},
+			Asset:          txnbuild.NativeAsset{},
 		})
 		require.NoError(t, err)
 		tx, err = tx.Sign(networkPassphrase, initiator.KP, initiator.Escrow)
@@ -112,9 +110,7 @@ func Test(t *testing.T) {
 			Creator:        responder.KP.FromAddress(),
 			Escrow:         responder.Escrow.FromAddress(),
 			SequenceNumber: seqNum + 1,
-			Trustlines: []txbuild.Trustline{
-				{Asset: txnbuild.NativeAsset{}},
-			},
+			Asset:          txnbuild.NativeAsset{},
 		})
 		require.NoError(t, err)
 		tx, err = tx.Sign(networkPassphrase, responder.KP, responder.Escrow)


### PR DESCRIPTION
### What
Change the SDK back to supporting a single asset only.

### Why
We resolved to focus on single asset payment channels because someone made a good point that if we aren't supporting exchange/swaps, then there isn't huge value in having multiple assets in the one channel vs multiple single-asset channels.

Incorporates the changes proposed by SEP changes #146 and #147.

Close #72 

