### PR TITLE
sdk/state: replace txnbuild.Asset with an internal simpler asset type

### DIFF
--- a/sdk/state/asset.go
+++ b/sdk/state/asset.go
@@ -1,0 +1,34 @@
+package state
+
+import (
+	"strings"
+
+	"github.com/stellar/go/txnbuild"
+)
+
+type Asset string
+
+const NativeAsset = Asset("native")
+
+func (a Asset) Native() bool {
+	return a.Asset().IsNative()
+}
+
+func (a Asset) Code() string {
+	return a.Asset().GetCode()
+}
+
+func (a Asset) Issuer() string {
+	return a.Asset().GetIssuer()
+}
+
+func (a Asset) Asset() txnbuild.Asset {
+	parts := strings.SplitN(string(a), ":", 2)
+	if len(parts) == 1 {
+		return txnbuild.NativeAsset{}
+	}
+	return txnbuild.CreditAsset{
+		Code:   parts[0],
+		Issuer: parts[1],
+	}
+}

--- a/sdk/state/asset.go
+++ b/sdk/state/asset.go
@@ -10,7 +10,7 @@ type Asset string
 
 const NativeAsset = Asset("native")
 
-func (a Asset) Native() bool {
+func (a Asset) IsNative() bool {
 	return a.Asset().IsNative()
 }
 

--- a/sdk/state/asset_test.go
+++ b/sdk/state/asset_test.go
@@ -1,0 +1,34 @@
+package state_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stellar/experimental-payment-channels/sdk/state"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAsset(t *testing.T) {
+	testCases := []struct {
+		Asset             state.Asset
+		WantTxnbuildAsset txnbuild.Asset
+		WantNative        bool
+		WantCode          string
+		WantIssuer        string
+	}{
+		{state.Asset(""), txnbuild.NativeAsset{}, true, "", ""},
+		{state.Asset("native"), txnbuild.NativeAsset{}, true, "", ""},
+		{state.NativeAsset, txnbuild.NativeAsset{}, true, "", ""},
+		{state.Asset(":"), txnbuild.CreditAsset{}, false, "", ""},
+		{state.Asset("ABCD:GABCD"), txnbuild.CreditAsset{Code: "ABCD", Issuer: "GABCD"}, false, "ABCD", "GABCD"},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprint(tc.Asset), func(t *testing.T) {
+			assert.Equal(t, tc.WantTxnbuildAsset, tc.Asset.Asset())
+			assert.Equal(t, tc.WantNative, tc.Asset.Native())
+			assert.Equal(t, tc.WantCode, tc.Asset.Code())
+			assert.Equal(t, tc.WantIssuer, tc.Asset.Issuer())
+		})
+	}
+}

--- a/sdk/state/asset_test.go
+++ b/sdk/state/asset_test.go
@@ -22,6 +22,7 @@ func TestAsset(t *testing.T) {
 		{state.NativeAsset, txnbuild.NativeAsset{}, true, "", ""},
 		{state.Asset(":"), txnbuild.CreditAsset{}, false, "", ""},
 		{state.Asset("ABCD:GABCD"), txnbuild.CreditAsset{Code: "ABCD", Issuer: "GABCD"}, false, "ABCD", "GABCD"},
+		{state.Asset("ABCD:GABCD:AB"), txnbuild.CreditAsset{Code: "ABCD", Issuer: "GABCD:AB"}, false, "ABCD", "GABCD:AB"},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprint(tc.Asset), func(t *testing.T) {

--- a/sdk/state/asset_test.go
+++ b/sdk/state/asset_test.go
@@ -13,7 +13,7 @@ func TestAsset(t *testing.T) {
 	testCases := []struct {
 		Asset             state.Asset
 		WantTxnbuildAsset txnbuild.Asset
-		WantNative        bool
+		WantIsNative      bool
 		WantCode          string
 		WantIssuer        string
 	}{
@@ -27,7 +27,7 @@ func TestAsset(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprint(tc.Asset), func(t *testing.T) {
 			assert.Equal(t, tc.WantTxnbuildAsset, tc.Asset.Asset())
-			assert.Equal(t, tc.WantNative, tc.Asset.Native())
+			assert.Equal(t, tc.WantIsNative, tc.Asset.IsNative())
 			assert.Equal(t, tc.WantCode, tc.Asset.Code())
 			assert.Equal(t, tc.WantIssuer, tc.Asset.Issuer())
 		})

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -39,7 +39,7 @@ func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transactio
 		IterationNumber:            d.IterationNumber,
 		AmountToInitiator:          amountToInitiator(d.Balance.Amount),
 		AmountToResponder:          amountToResponder(d.Balance.Amount),
-		Asset:                      d.Balance.Asset,
+		Asset:                      d.Balance.Asset.Asset(),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -231,7 +231,7 @@ func fundAsset(asset state.Asset, amount int64, accountKP *keypair.Full, distrib
 	}
 
 	ops := []txnbuild.Operation{}
-	if !asset.Native() {
+	if !asset.IsNative() {
 		ops = append(ops, &txnbuild.ChangeTrust{
 			SourceAccount: accountKP.Address(),
 			Line:          asset.Asset(),
@@ -253,7 +253,7 @@ func fundAsset(asset state.Asset, amount int64, accountKP *keypair.Full, distrib
 	if err != nil {
 		return err
 	}
-	if !asset.Native() {
+	if !asset.IsNative() {
 		tx, err = tx.Sign(networkPassphrase, accountKP)
 		if err != nil {
 			return err

--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -19,7 +19,7 @@ import (
 // functions to be used in the state_test integration tests
 
 type AssetParam struct {
-	Asset       txnbuild.Asset
+	Asset       state.Asset
 	Distributor *keypair.Full
 }
 
@@ -40,7 +40,7 @@ func initAccounts(t *testing.T, assetParam AssetParam) (initiator Participant, r
 		})
 		require.NoError(t, err)
 
-		t.Log("Initiator Contribution:", initiator.Contribution, "of asset:", assetParam.Asset.GetCode(), "issuer: ", assetParam.Asset.GetIssuer())
+		t.Log("Initiator Contribution:", initiator.Contribution, "of asset:", assetParam.Asset.Code(), "issuer: ", assetParam.Asset.Issuer())
 		initEscrowAccount(t, &initiator, assetParam)
 	}
 	t.Log("Initiator Escrow Sequence Number:", initiator.EscrowSequenceNumber)
@@ -62,7 +62,7 @@ func initAccounts(t *testing.T, assetParam AssetParam) (initiator Participant, r
 		})
 		require.NoError(t, err)
 
-		t.Log("Responder Contribution:", responder.Contribution, "of asset:", assetParam.Asset.GetCode(), "issuer: ", assetParam.Asset.GetIssuer())
+		t.Log("Responder Contribution:", responder.Contribution, "of asset:", assetParam.Asset.Code(), "issuer: ", assetParam.Asset.Issuer())
 		initEscrowAccount(t, &responder, assetParam)
 	}
 	t.Log("Responder Escrow Sequence Number:", responder.EscrowSequenceNumber)
@@ -81,7 +81,7 @@ func initEscrowAccount(t *testing.T, participant *Participant, assetParam AssetP
 		Creator:        participant.KP.FromAddress(),
 		Escrow:         participant.Escrow.FromAddress(),
 		SequenceNumber: seqNum + 1,
-		Asset:          assetParam.Asset,
+		Asset:          assetParam.Asset.Asset(),
 	})
 	require.NoError(t, err)
 	tx, err = tx.Sign(networkPassphrase, participant.KP, participant.Escrow)
@@ -106,7 +106,7 @@ func initEscrowAccount(t *testing.T, participant *Participant, assetParam AssetP
 		&txnbuild.Payment{
 			Destination: participant.Escrow.Address(),
 			Amount:      stellarAmount.StringFromInt64(participant.Contribution),
-			Asset:       assetParam.Asset,
+			Asset:       assetParam.Asset.Asset(),
 		},
 	}
 
@@ -154,7 +154,7 @@ func initChannels(t *testing.T, initiator Participant, responder Participant) (i
 	return initiatorChannel, responderChannel
 }
 
-func initAsset(t *testing.T, client horizonclient.ClientInterface, code string) (txnbuild.Asset, *keypair.Full) {
+func initAsset(t *testing.T, client horizonclient.ClientInterface, code string) (state.Asset, *keypair.Full) {
 	issuerKP := keypair.MustRandom()
 	distributorKP := keypair.MustRandom()
 
@@ -194,7 +194,7 @@ func initAsset(t *testing.T, client horizonclient.ClientInterface, code string) 
 	_, err = client.SubmitTransaction(tx)
 	require.NoError(t, err)
 
-	return asset, distributorKP
+	return state.Asset(asset.Code + ":" + asset.Issuer), distributorKP
 }
 
 func randomBool(t *testing.T) bool {
@@ -224,24 +224,24 @@ func retry(maxAttempts int, f func() error) (err error) {
 	return err
 }
 
-func fundAsset(asset txnbuild.Asset, amount int64, accountKP *keypair.Full, distributorKP *keypair.Full) error {
+func fundAsset(asset state.Asset, amount int64, accountKP *keypair.Full, distributorKP *keypair.Full) error {
 	distributor, err := client.AccountDetail(horizonclient.AccountRequest{AccountID: distributorKP.Address()})
 	if err != nil {
 		return err
 	}
 
 	ops := []txnbuild.Operation{}
-	if !asset.IsNative() {
+	if !asset.Native() {
 		ops = append(ops, &txnbuild.ChangeTrust{
 			SourceAccount: accountKP.Address(),
-			Line:          asset,
+			Line:          asset.Asset(),
 			Limit:         "5000",
 		})
 	}
 	ops = append(ops, &txnbuild.Payment{
 		Destination: accountKP.Address(),
 		Amount:      stellarAmount.StringFromInt64(amount),
-		Asset:       asset,
+		Asset:       asset.Asset(),
 	})
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount:        &distributor,
@@ -253,7 +253,7 @@ func fundAsset(asset txnbuild.Asset, amount int64, accountKP *keypair.Full, dist
 	if err != nil {
 		return err
 	}
-	if !asset.IsNative() {
+	if !asset.Native() {
 		tx, err = tx.Sign(networkPassphrase, accountKP)
 		if err != nil {
 			return err
@@ -316,9 +316,9 @@ func txSeqs(txs []*txnbuild.Transaction) []int64 {
 	return seqs
 }
 
-func assetBalance(asset txnbuild.Asset, account horizon.Account) string {
+func assetBalance(asset state.Asset, account horizon.Account) string {
 	for _, b := range account.Balances {
-		if b.Asset.Code == asset.GetCode() {
+		if b.Asset.Code == asset.Code() {
 			return b.Balance
 		}
 	}

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -27,7 +27,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	const averageLedgerDuration = 5 * time.Second
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
 
-	asset := txnbuild.NativeAsset{}
+	asset := state.NativeAsset
 	// native asset has no asset limit
 	rootResp, err := client.Root()
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, sends to other party
-		payment, err := sendingChannel.ProposePayment(state.Amount{Asset: state.NativeAsset{}, Amount: amount})
+		payment, err := sendingChannel.ProposePayment(state.Amount{Asset: state.NativeAsset, Amount: amount})
 		require.NoError(t, err)
 
 		var authorized bool

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -49,7 +49,7 @@ func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *t
 		IterationNumber:            1,
 		AmountToInitiator:          0,
 		AmountToResponder:          0,
-		Asset:                      d.Asset,
+		Asset:                      d.Asset.Asset(),
 	})
 	if err != nil {
 		return
@@ -69,7 +69,7 @@ func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *t
 		InitiatorEscrow: c.initiatorEscrowAccount().Address,
 		ResponderEscrow: c.responderEscrowAccount().Address,
 		StartSequence:   c.startingSequence,
-		Asset:           d.Asset,
+		Asset:           d.Asset.Asset(),
 	})
 	return
 }

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -34,6 +34,16 @@ func TestProposeOpen_validAsset(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = sendingChannel.ProposeOpen(OpenParams{
+		Asset: ":GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P",
+	})
+	require.EqualError(t, err, `validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: asset code length must be between 1 and 12 characters`)
+
+	_, err = sendingChannel.ProposeOpen(OpenParams{
+		Asset: "ABCD:GABCD:AB",
+	})
+	require.EqualError(t, err, `validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: asset issuer: GABCD:AB is not a valid stellar public key`)
+
+	_, err = sendingChannel.ProposeOpen(OpenParams{
 		Asset: "ABCD:GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P",
 	})
 	require.NoError(t, err)

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -28,21 +28,13 @@ func TestProposeOpen_validAsset(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 
-	native := NativeAsset{}
 	_, err := sendingChannel.ProposeOpen(OpenParams{
-		Asset: native,
+		Asset: NativeAsset,
 	})
 	require.NoError(t, err)
 
-	invalidCredit := CreditAsset{}
 	_, err = sendingChannel.ProposeOpen(OpenParams{
-		Asset: invalidCredit,
-	})
-	require.EqualError(t, err, `validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: asset code length must be between 1 and 12 characters`)
-
-	validCredit := CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
-	_, err = sendingChannel.ProposeOpen(OpenParams{
-		Asset: validCredit,
+		Asset: "ABCD:GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P",
 	})
 	require.NoError(t, err)
 }
@@ -71,14 +63,14 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
-			Asset:                      NativeAsset{},
+			Asset:                      NativeAsset,
 		},
 	}
 
 	oa := OpenAgreementDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
-		Asset:                      NativeAsset{},
+		Asset:                      NativeAsset,
 	}
 
 	{
@@ -93,7 +85,7 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 	{
 		// invalid different asset
 		d := oa
-		d.Asset = CreditAsset{Code: "abc"}
+		d.Asset = "ABC:GCDFU7RNY6HTYQKP7PYHBMXXKXZ4HET6LMJ5CDO7YL5NMYH4T2BSZCPZ"
 		_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: d})
 		require.False(t, authorized)
 		require.EqualError(t, err, "input open agreement details do not match the saved open agreement details")

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -1,39 +1,10 @@
 package state
 
 import (
-	"strings"
-
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 )
-
-type Asset string
-
-const NativeAsset = Asset("native")
-
-func (a Asset) Native() bool {
-	return a.Asset().IsNative()
-}
-
-func (a Asset) Code() string {
-	return a.Asset().GetCode()
-}
-
-func (a Asset) Issuer() string {
-	return a.Asset().GetIssuer()
-}
-
-func (a Asset) Asset() txnbuild.Asset {
-	parts := strings.SplitN(string(a), ":", 2)
-	if len(parts) == 1 {
-		return txnbuild.NativeAsset{}
-	}
-	return txnbuild.CreditAsset{
-		Code:   parts[0],
-		Issuer: parts[1],
-	}
-}
 
 type Amount struct {
 	Asset  Asset

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -1,16 +1,39 @@
 package state
 
 import (
+	"strings"
+
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 )
 
-type (
-	Asset       = txnbuild.Asset
-	NativeAsset = txnbuild.NativeAsset
-	CreditAsset = txnbuild.CreditAsset
-)
+type Asset string
+
+const NativeAsset = Asset("native")
+
+func (a Asset) Native() bool {
+	return a.Asset().IsNative()
+}
+
+func (a Asset) Code() string {
+	return a.Asset().GetCode()
+}
+
+func (a Asset) Issuer() string {
+	return a.Asset().GetIssuer()
+}
+
+func (a Asset) Asset() txnbuild.Asset {
+	parts := strings.SplitN(string(a), ":", 2)
+	if len(parts) == 1 {
+		return txnbuild.NativeAsset{}
+	}
+	return txnbuild.CreditAsset{
+		Code:   parts[0],
+		Issuer: parts[1],
+	}
+}
 
 type Amount struct {
 	Asset  Asset

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
-	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,7 +112,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentToRemote(t *testing.T) {
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
 			Balance: Amount{
-				Asset:  NativeAsset{},
+				Asset:  NativeAsset,
 				Amount: 100, // Local (initiator) owes remote (responder) 100.
 			},
 		},
@@ -121,7 +120,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentToRemote(t *testing.T) {
 	ca := CloseAgreementDetails{
 		IterationNumber: 2,
 		Balance: Amount{
-			Asset:  NativeAsset{},
+			Asset:  NativeAsset,
 			Amount: 110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
 		},
 	}
@@ -164,7 +163,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentToRemote(t *testing.T) {
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
 			Balance: Amount{
-				Asset:  NativeAsset{},
+				Asset:  NativeAsset,
 				Amount: 100, // Remote (initiator) owes local (responder) 100.
 			},
 		},
@@ -172,7 +171,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentToRemote(t *testing.T) {
 	ca := CloseAgreementDetails{
 		IterationNumber: 2,
 		Balance: Amount{
-			Asset:  NativeAsset{},
+			Asset:  NativeAsset,
 			Amount: 90, // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
 		},
 	}
@@ -216,11 +215,11 @@ func TestLastConfirmedPayment(t *testing.T) {
 	})
 
 	// latest close agreement should be set during open steps
-	sendingChannel.latestAuthorizedCloseAgreement.Details.Balance = Amount{Asset: NativeAsset{}}
-	receiverChannel.latestAuthorizedCloseAgreement.Details.Balance = Amount{Asset: NativeAsset{}}
+	sendingChannel.latestAuthorizedCloseAgreement.Details.Balance = Amount{Asset: NativeAsset}
+	receiverChannel.latestAuthorizedCloseAgreement.Details.Balance = Amount{Asset: NativeAsset}
 
 	ca, err := sendingChannel.ProposePayment(Amount{
-		Asset:  NativeAsset{},
+		Asset:  NativeAsset,
 		Amount: 200,
 	})
 	require.NoError(t, err)
@@ -235,7 +234,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
 			Balance: Amount{
-				Asset:  txnbuild.NativeAsset{},
+				Asset:  NativeAsset,
 				Amount: 400,
 			},
 		},
@@ -244,7 +243,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	_, authorized, err = receiverChannel.ConfirmPayment(caDifferent)
 	assert.False(t, authorized)
 	require.EqualError(t, err, "close agreement does not match the close agreement already in progress")
-	assert.Equal(t, CloseAgreement{Details: CloseAgreementDetails{Balance: Amount{Asset: NativeAsset{}}}}, receiverChannel.LatestCloseAgreement())
+	assert.Equal(t, CloseAgreement{Details: CloseAgreementDetails{Balance: Amount{Asset: NativeAsset}}}, receiverChannel.LatestCloseAgreement())
 
 	// Confirming a payment with same sequence number and same amount should pass
 	ca, authorized, err = sendingChannel.ConfirmPayment(ca)


### PR DESCRIPTION
### What
Replace txnbuild.Asset in the state package with an internal simpler asset type, a string that follows [SEP-11 Txrep]'s format.

### Why
While experimenting with the state package (#122) I found the interface type txnbuild.Asset inconvenient. Interfaces can't be used to deserialize. While working around that issue I realized we don't really need an interface for what we're doing, we only need a simple value and it is more convenient to be able to specify a concrete value in the simplest form and to convert it to what the txnbuild package needs at the point it needs it.

I chose a string because we have a specification for assets as string in [SEP-11 Txrep] which has been used in Horizon for new endpoints that reference assets.

[SEP-11 Txrep]: https://stellar.org/protocol/sep-11