### PR TITLE
sdk/state: make formation expiry deterministic

### DIFF
--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -137,6 +137,7 @@ func initChannels(t *testing.T, initiator Participant, responder Participant) (i
 
 	initiatorChannel = state.NewChannel(state.Config{
 		NetworkPassphrase:   networkPassphrase,
+		MaxOpenExpiry:       5 * time.Minute,
 		Initiator:           true,
 		LocalEscrowAccount:  &initiatorEscrowAccount,
 		RemoteEscrowAccount: &responderEscrowAccount,
@@ -145,6 +146,7 @@ func initChannels(t *testing.T, initiator Participant, responder Participant) (i
 	})
 	responderChannel = state.NewChannel(state.Config{
 		NetworkPassphrase:   networkPassphrase,
+		MaxOpenExpiry:       5 * time.Minute,
 		Initiator:           false,
 		LocalEscrowAccount:  &responderEscrowAccount,
 		RemoteEscrowAccount: &initiatorEscrowAccount,

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -26,6 +26,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	const observationPeriodTime = 20 * time.Second
 	const averageLedgerDuration = 5 * time.Second
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
+	const formationExpiry = 5 * time.Minute
 
 	asset := txnbuild.NativeAsset{}
 	// native asset has no asset limit
@@ -54,6 +55,7 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
 		Asset:                      asset,
+		ExpiresAt:                  time.Now().Add(formationExpiry),
 	})
 	require.NoError(t, err)
 	assert.Len(t, open.CloseSignatures, 1)
@@ -304,6 +306,7 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 	const observationPeriodTime = 20 * time.Second
 	const averageLedgerDuration = 5 * time.Second
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
+	const formationExpiry = 5 * time.Minute
 
 	asset, distributor := initAsset(t, client, "ABDC")
 	initiator, responder := initAccounts(t, AssetParam{
@@ -324,6 +327,7 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
 		Asset:                      asset,
+		ExpiresAt:                  time.Now().Add(formationExpiry),
 	})
 	require.NoError(t, err)
 	assert.Len(t, open.CloseSignatures, 1)
@@ -514,6 +518,7 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	const observationPeriodTime = 20 * time.Second
 	const averageLedgerDuration = 5 * time.Second
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
+	const formationExpiry = 5 * time.Minute
 
 	asset, distributor := initAsset(t, client, "ABDC")
 	initiator, responder := initAccounts(t, AssetParam{
@@ -534,6 +539,7 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
 		Asset:                      asset,
+		ExpiresAt:                  time.Now().Add(formationExpiry),
 	})
 
 	require.NoError(t, err)
@@ -726,6 +732,7 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 	const observationPeriodTime = 20 * time.Second
 	const averageLedgerDuration = 5 * time.Second
 	const observationPeriodLedgerGap = int64(observationPeriodTime / averageLedgerDuration)
+	const formationExpiry = 5 * time.Minute
 
 	asset, distributor := initAsset(t, client, "ABDC")
 	initiator, responder := initAccounts(t, AssetParam{
@@ -746,6 +753,7 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 		ObservationPeriodTime:      observationPeriodTime,
 		ObservationPeriodLedgerGap: observationPeriodLedgerGap,
 		Asset:                      asset,
+		ExpiresAt:                  time.Now().Add(formationExpiry),
 	})
 
 	require.NoError(t, err)

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -20,7 +20,7 @@ func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
 	return d.ObservationPeriodTime == d2.ObservationPeriodTime &&
 		d.ObservationPeriodLedgerGap == d2.ObservationPeriodLedgerGap &&
 		d.Asset == d2.Asset &&
-		d.ExpiresAt == d2.ExpiresAt
+		d.ExpiresAt.Equal(d2.ExpiresAt)
 }
 
 type OpenAgreement struct {

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -126,6 +126,11 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, authorized b
 		return m, authorized, fmt.Errorf("input open agreement details do not match the saved open agreement details")
 	}
 
+	// If the expiry of the agreement is past the max expiry the channel will accept, error.
+	if m.Details.ExpiresAt.After(time.Now().Add(c.maxOpenExpiry)) {
+		return m, authorized, fmt.Errorf("input open agreement expire too far into the future")
+	}
+
 	// at the end of this method, if no error, then save a new channel openAgreement. Use the
 	// channel's saved open agreement details if present, to prevent other party from changing.
 	defer func() {

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -13,10 +13,14 @@ type OpenAgreementDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	Asset                      Asset
+	ExpiresAt                  time.Time
 }
 
 func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
-	return d == d2
+	return d.ObservationPeriodTime == d2.ObservationPeriodTime &&
+		d.ObservationPeriodLedgerGap == d2.ObservationPeriodLedgerGap &&
+		d.Asset == d2.Asset &&
+		d.ExpiresAt == d2.ExpiresAt
 }
 
 type OpenAgreement struct {
@@ -35,6 +39,7 @@ type OpenParams struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	Asset                      Asset
+	ExpiresAt                  time.Time
 }
 
 func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *txnbuild.Transaction, err error) {
@@ -70,6 +75,7 @@ func (c *Channel) OpenTxs(d OpenAgreementDetails) (txClose, txDecl, formation *t
 		ResponderEscrow: c.responderEscrowAccount().Address,
 		StartSequence:   c.startingSequence,
 		Asset:           d.Asset,
+		ExpiresAt:       d.ExpiresAt,
 	})
 	return
 }

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
@@ -30,19 +31,22 @@ func TestProposeOpen_validAsset(t *testing.T) {
 
 	native := NativeAsset{}
 	_, err := sendingChannel.ProposeOpen(OpenParams{
-		Asset: native,
+		Asset:     native,
+		ExpiresAt: time.Now().Add(5 * time.Minute),
 	})
 	require.NoError(t, err)
 
 	invalidCredit := CreditAsset{}
 	_, err = sendingChannel.ProposeOpen(OpenParams{
-		Asset: invalidCredit,
+		Asset:     invalidCredit,
+		ExpiresAt: time.Now().Add(5 * time.Minute),
 	})
 	require.EqualError(t, err, `validation failed for *txnbuild.ChangeTrust operation: Field: Line, Error: asset code length must be between 1 and 12 characters`)
 
 	validCredit := CreditAsset{Code: "ABCD", Issuer: "GCSZIQEYTDI427C2XCCIWAGVHOIZVV2XKMRELUTUVKOODNZWSR2OLF6P"}
 	_, err = sendingChannel.ProposeOpen(OpenParams{
-		Asset: validCredit,
+		Asset:     validCredit,
+		ExpiresAt: time.Now().Add(5 * time.Minute),
 	})
 	require.NoError(t, err)
 }

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"time"
+
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
@@ -18,6 +20,7 @@ type EscrowAccount struct {
 
 type Channel struct {
 	networkPassphrase string
+	maxOpenExpiry     time.Duration
 
 	startingSequence int64
 	// TODO - leave execution out for now
@@ -38,6 +41,7 @@ type Channel struct {
 
 type Config struct {
 	NetworkPassphrase string
+	MaxOpenExpiry     time.Duration
 
 	Initiator bool
 
@@ -51,6 +55,7 @@ type Config struct {
 func NewChannel(c Config) *Channel {
 	channel := &Channel{
 		networkPassphrase:   c.NetworkPassphrase,
+		maxOpenExpiry:       c.MaxOpenExpiry,
 		initiator:           c.Initiator,
 		localEscrowAccount:  c.LocalEscrowAccount,
 		remoteEscrowAccount: c.RemoteEscrowAccount,

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -26,7 +26,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 			Sequence:  p.StartSequence,
 		},
 		BaseFee:    0,
-		Timebounds: txnbuild.NewTimebounds(0, p.ExpiresAt.Unix()),
+		Timebounds: txnbuild.NewTimebounds(0, p.ExpiresAt.UTC().Unix()),
 	}
 
 	// I sponsoring ledger entries on EI

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -2,6 +2,7 @@ package txbuild
 
 import (
 	"math"
+	"time"
 
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/keypair"
@@ -15,6 +16,7 @@ type FormationParams struct {
 	ResponderEscrow *keypair.FromAddress
 	StartSequence   int64
 	Asset           txnbuild.Asset
+	ExpiresAt       time.Time
 }
 
 func Formation(p FormationParams) (*txnbuild.Transaction, error) {
@@ -24,7 +26,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 			Sequence:  p.StartSequence,
 		},
 		BaseFee:    0,
-		Timebounds: txnbuild.NewTimeout(300),
+		Timebounds: txnbuild.NewTimebounds(0, p.ExpiresAt.Unix()),
 	}
 	tp.Operations = append(tp.Operations, &txnbuild.BeginSponsoringFutureReserves{SourceAccount: p.InitiatorSigner.Address(), SponsoredID: p.InitiatorEscrow.Address()})
 	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{

--- a/sdk/txbuild/integrationtests/integrationtests_test.go
+++ b/sdk/txbuild/integrationtests/integrationtests_test.go
@@ -210,6 +210,7 @@ func Test(t *testing.T) {
 			ResponderEscrow: responder.Escrow.FromAddress(),
 			StartSequence:   s,
 			Asset:           txnbuild.NativeAsset{},
+			ExpiresAt:       time.Now().Add(1 * time.Minute),
 		})
 		require.NoError(t, err)
 		f, err = f.Sign(networkPassphrase, initiator.KP, responder.KP)


### PR DESCRIPTION
### What
Make the formation transaction that gets built deterministic by changing the time bounds to be based on time.Now to be based on a fixed time the proposer chooses.

### Why
The formation transaction sets its time bounds relative to the now time, which requires both participants to have synchronized clocks at a resolution of 1 second and for the clients to generate the transaction at the exact moment. This is unlikely to happen. This behavior also makes it impossible to regenerate the formation transaction later.

I discovered this problem while working on #122. Two participants running separately were producing different open agreement transactions because the time bound maximum was set to different values in the formation transaction.

Close #150