### PR TITLE
sep, sdk/state: fix sponsorship operations during open

### DIFF
--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -26,6 +26,8 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		BaseFee:    0,
 		Timebounds: txnbuild.NewTimeout(300),
 	}
+
+	// I sponsoring ledger entries on EI
 	tp.Operations = append(tp.Operations, &txnbuild.BeginSponsoringFutureReserves{SourceAccount: p.InitiatorSigner.Address(), SponsoredID: p.InitiatorEscrow.Address()})
 	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
 		SourceAccount:   p.InitiatorEscrow.Address(),
@@ -33,11 +35,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		LowThreshold:    txnbuild.NewThreshold(2),
 		MediumThreshold: txnbuild.NewThreshold(2),
 		HighThreshold:   txnbuild.NewThreshold(2),
-		Signer:          &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
-	})
-	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
-		SourceAccount: p.InitiatorEscrow.Address(),
-		Signer:        &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
+		Signer:          &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
 	})
 	if !p.Asset.IsNative() {
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
@@ -47,6 +45,16 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		})
 	}
 	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.InitiatorEscrow.Address()})
+
+	// I sponsoring ledger entries on ER
+	tp.Operations = append(tp.Operations, &txnbuild.BeginSponsoringFutureReserves{SourceAccount: p.InitiatorSigner.Address(), SponsoredID: p.ResponderEscrow.Address()})
+	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
+		SourceAccount: p.ResponderEscrow.Address(),
+		Signer:        &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
+	})
+	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.ResponderEscrow.Address()})
+
+	// R sponsoring ledger entries on ER
 	tp.Operations = append(tp.Operations, &txnbuild.BeginSponsoringFutureReserves{SourceAccount: p.ResponderSigner.Address(), SponsoredID: p.ResponderEscrow.Address()})
 	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
 		SourceAccount:   p.ResponderEscrow.Address(),
@@ -54,11 +62,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		LowThreshold:    txnbuild.NewThreshold(2),
 		MediumThreshold: txnbuild.NewThreshold(2),
 		HighThreshold:   txnbuild.NewThreshold(2),
-		Signer:          &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
-	})
-	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
-		SourceAccount: p.ResponderEscrow.Address(),
-		Signer:        &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
+		Signer:          &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
 	})
 	if !p.Asset.IsNative() {
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
@@ -68,6 +72,15 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		})
 	}
 	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.ResponderEscrow.Address()})
+
+	// R sponsoring ledger entries on EI
+	tp.Operations = append(tp.Operations, &txnbuild.BeginSponsoringFutureReserves{SourceAccount: p.ResponderSigner.Address(), SponsoredID: p.InitiatorEscrow.Address()})
+	tp.Operations = append(tp.Operations, &txnbuild.SetOptions{
+		SourceAccount: p.InitiatorEscrow.Address(),
+		Signer:        &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
+	})
+	tp.Operations = append(tp.Operations, &txnbuild.EndSponsoringFutureReserves{SourceAccount: p.InitiatorEscrow.Address()})
+
 	tx, err := txnbuild.NewTransaction(tp)
 	if err != nil {
 		return nil, err

--- a/specifications/sep-payment-channel-transactions.md
+++ b/specifications/sep-payment-channel-transactions.md
@@ -186,22 +186,34 @@ multisig accounts. F has source account E, and sequence number set to s.
 
   F contains operations:
 
-  - Operations sponsored by I:
+  - Operations sponsored by I for EI:
     - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies
     participant I as a sponsor of future reserves.
     - One `CHANGE_TRUST` operation configuring trustlines on EI if the asset is not the native asset.
     - One `SET_OPTIONS` operation adjusting escrow account EI's thresholds such
     that I and R's signers must both sign.
-    - One or more `SET_OPTIONS` operations adding I and R's signers to ER.
+    - One or more `SET_OPTIONS` operations adding I signers to EI.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops I sponsoring
     future reserves of subsequent operations.
-  - Operations sponsored by R:
+  - Operations sponsored by I for ER:
+    - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies
+    participant I as a sponsor of future reserves.
+    - One or more `SET_OPTIONS` operations adding I signers to ER.
+    - One `END_SPONSORING_FUTURE_RESERVES` operation that stops I sponsoring
+    future reserves of subsequent operations.
+  - Operations sponsored by R for ER:
     - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies reserve
     account R as a sponsor of future reserves.
     - One `CHANGE_TRUST` operation configuring trustlines on ER if the asset is not the native asset.
     - One `SET_OPTIONS` operations adjusting escrow account ER's thresholds such
     that R and I's signers must both sign.
-    - One or more `SET_OPTIONS` operations adding I and R's signers to EI.
+    - One or more `SET_OPTIONS` operations adding R's signers to ER.
+    - One `END_SPONSORING_FUTURE_RESERVES` operation that stops R sponsoring
+    future reserves of subsequent operations.
+  - Operations sponsored by R for EI:
+    - One `BEGIN_SPONSORING_FUTURE_RESERVES` operation that specifies reserve
+    account R as a sponsor of future reserves.
+    - One or more `SET_OPTIONS` operations adding R's signers to EI.
     - One `END_SPONSORING_FUTURE_RESERVES` operation that stops R sponsoring
     future reserves of subsequent operations.
 


### PR DESCRIPTION
### What
Make the participants sponsor only their own signers.

### Why

The SEP states that the participants are only supposed to sponsor their own signers, but then the open process has them sponsoring each other signers. This has little impact on single signer setups, but cleaning this up makes it a bit more pure on ownership of the respective ledger entries.

Close #151 