### PR TITLE
sdk/state: validate balances and handle deposits and balance changes

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -7,5 +7,7 @@ replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20
 require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stellar/go v0.0.0-00010101000000-000000000000
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/objx v0.3.0 // indirect
+	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -154,9 +154,14 @@ github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/g
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
+github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tyler-smith/go-bip39 v0.0.0-20180618194314-52158e4697b8/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
@@ -254,5 +259,8 @@ gopkg.in/tylerb/graceful.v1 v1.2.13/go.mod h1:yBhekWvR20ACXVObSSdD3u6S9DeSylanL2
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -47,20 +47,6 @@ func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transactio
 	return txDecl, txClose, nil
 }
 
-func amountToInitiator(balance int64) int64 {
-	if balance < 0 {
-		return balance * -1
-	}
-	return 0
-}
-
-func amountToResponder(balance int64) int64 {
-	if balance > 0 {
-		return balance
-	}
-	return 0
-}
-
 // ProposeClose proposes that the latest authorized close agreement be submitted
 // without waiting the observation period. This should be used when participants
 // are in agreement on the final close state, but would like to submit earlier

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -127,6 +127,10 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 	t.Log("Iteration", i, "Declarations:", txSeqs(declarationTxs))
 	t.Log("Iteration", i, "Closes:", txSeqs(closeTxs))
 
+	// Update balances known for each other.
+	initiatorChannel.UpdateRemoteEscrowAccountBalance(responder.Contribution)
+	responderChannel.UpdateRemoteEscrowAccountBalance(initiator.Contribution)
+
 	// Perform a number of iterations, much like two participants may.
 	// Exchange signed C_i and D_i for each
 	t.Log("Subsequent agreements...")
@@ -394,6 +398,10 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Update balances known for each other.
+	initiatorChannel.UpdateRemoteEscrowAccountBalance(responder.Contribution)
+	responderChannel.UpdateRemoteEscrowAccountBalance(initiator.Contribution)
+
 	// Perform a number of iterations, much like two participants may.
 	// Exchange signed C_i and D_i for each
 	t.Log("Subsequent agreements...")
@@ -606,6 +614,10 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 		_, err = client.SubmitFeeBumpTransaction(fbtx)
 		require.NoError(t, err)
 	}
+
+	// Update balances known for each other.
+	initiatorChannel.UpdateRemoteEscrowAccountBalance(responder.Contribution)
+	responderChannel.UpdateRemoteEscrowAccountBalance(initiator.Contribution)
 
 	// Perform a number of iterations, much like two participants may.
 	// Exchange signed C_i and D_i for each
@@ -820,6 +832,10 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 		_, err = client.SubmitFeeBumpTransaction(fbtx)
 		require.NoError(t, err)
 	}
+
+	// Update balances known for each other.
+	initiatorChannel.UpdateRemoteEscrowAccountBalance(responder.Contribution)
+	responderChannel.UpdateRemoteEscrowAccountBalance(initiator.Contribution)
 
 	// Perform a number of iterations, much like two participants may.
 	// Exchange signed C_i and D_i for each

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -16,6 +16,7 @@ type Amount struct {
 type EscrowAccount struct {
 	Address        *keypair.FromAddress
 	SequenceNumber int64
+	Balance        int64
 }
 
 type Channel struct {
@@ -86,6 +87,14 @@ func (c *Channel) LatestCloseAgreement() CloseAgreement {
 	return c.latestAuthorizedCloseAgreement
 }
 
+func (c *Channel) UpdateLocalEscrowAccountBalance(balance int64) {
+	c.localEscrowAccount.Balance = balance
+}
+
+func (c *Channel) UpdateRemoteEscrowAccountBalance(balance int64) {
+	c.remoteEscrowAccount.Balance = balance
+}
+
 func (c *Channel) initiatorEscrowAccount() *EscrowAccount {
 	if c.initiator {
 		return c.localEscrowAccount
@@ -133,6 +142,27 @@ func (c *Channel) verifySigned(tx *txnbuild.Transaction, sigs []xdr.DecoratedSig
 		}
 	}
 	return false, nil
+}
+
+func (c *Channel) amountToLocal(balance int64) int64 {
+	if c.initiator {
+		return amountToInitiator(balance)
+	}
+	return amountToResponder(balance)
+}
+
+func amountToInitiator(balance int64) int64 {
+	if balance < 0 {
+		return balance * -1
+	}
+	return 0
+}
+
+func amountToResponder(balance int64) int64 {
+	if balance > 0 {
+		return balance
+	}
+	return 0
 }
 
 func appendNewSignatures(oldSignatures []xdr.DecoratedSignature, newSignatures []xdr.DecoratedSignature) []xdr.DecoratedSignature {

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -82,10 +82,6 @@ func (c *Channel) LatestCloseAgreement() CloseAgreement {
 	return c.latestAuthorizedCloseAgreement
 }
 
-func (c *Channel) UpdateLocalEscrowAccountBalance(balance int64) {
-	c.localEscrowAccount.Balance = balance
-}
-
 func (c *Channel) UpdateRemoteEscrowAccountBalance(balance int64) {
 	c.remoteEscrowAccount.Balance = balance
 }

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -131,7 +131,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 			(!c.initiator && ca.Details.Balance < c.latestAuthorizedCloseAgreement.Details.Balance) {
 			return ca, authorized, fmt.Errorf("close agreement is a payment to the proposer")
 		}
-		if c.amountToLocal(ca.Details.Balance.Amount) > c.remoteEscrowAccount.Balance {
+		if c.amountToLocal(ca.Details.Balance) > c.remoteEscrowAccount.Balance {
 			return ca, authorized, fmt.Errorf("close agreement over commits: %w", ErrUnderfunded)
 		}
 		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -186,16 +186,142 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentToRemote(t *testing.T) {
 	require.EqualError(t, err, "close agreement is a payment to the proposer")
 }
 
+func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *testing.T) {
+	localSigner := keypair.MustRandom()
+	remoteSigner := keypair.MustRandom()
+	localEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(101),
+		Balance:        100,
+	}
+	remoteEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(202),
+		Balance:        100,
+	}
+
+	// Given a channel with observation periods set to 1, that is already open.
+	channel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           true,
+		LocalSigner:         localSigner,
+		RemoteSigner:        remoteSigner.FromAddress(),
+		LocalEscrowAccount:  localEscrowAccount,
+		RemoteEscrowAccount: remoteEscrowAccount,
+	})
+
+	// A close agreement from the remote participant should be rejected if the
+	// payment changes the balance in the favor of the remote.
+	channel.latestAuthorizedCloseAgreement = CloseAgreement{
+		Details: CloseAgreementDetails{
+			IterationNumber: 1,
+			Balance: Amount{
+				Asset:  NativeAsset,
+				Amount: -60, // Remote (responder) owes local (initiator) 60.
+			},
+		},
+	}
+	ca := CloseAgreementDetails{
+		IterationNumber: 2,
+		Balance: Amount{
+			Asset:  NativeAsset,
+			Amount: -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
+		},
+	}
+	_, txClose, err := channel.CloseTxs(ca)
+	require.NoError(t, err)
+	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
+	require.NoError(t, err)
+	_, _, err = channel.ConfirmPayment(CloseAgreement{
+		Details:         ca,
+		CloseSignatures: txClose.Signatures(),
+	})
+	assert.EqualError(t, err, "close agreement over commits: account is underfunded to make payment")
+	assert.ErrorIs(t, err, ErrUnderfunded)
+
+	// The same close payment should pass if the balance has been updated.
+	channel.UpdateRemoteEscrowAccountBalance(200)
+	_, _, err = channel.ConfirmPayment(CloseAgreement{
+		Details:         ca,
+		CloseSignatures: txClose.Signatures(),
+	})
+	assert.NoError(t, err)
+}
+
+func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *testing.T) {
+	localSigner := keypair.MustRandom()
+	remoteSigner := keypair.MustRandom()
+	localEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(101),
+		Balance:        100,
+	}
+	remoteEscrowAccount := &EscrowAccount{
+		Address:        keypair.MustRandom().FromAddress(),
+		SequenceNumber: int64(202),
+		Balance:        100,
+	}
+
+	// Given a channel with observation periods set to 1, that is already open.
+	channel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           false,
+		LocalSigner:         localSigner,
+		RemoteSigner:        remoteSigner.FromAddress(),
+		LocalEscrowAccount:  localEscrowAccount,
+		RemoteEscrowAccount: remoteEscrowAccount,
+	})
+
+	// A close agreement from the remote participant should be rejected if the
+	// payment changes the balance in the favor of the remote.
+	channel.latestAuthorizedCloseAgreement = CloseAgreement{
+		Details: CloseAgreementDetails{
+			IterationNumber: 1,
+			Balance: Amount{
+				Asset:  NativeAsset,
+				Amount: 60, // Remote (initiator) owes local (responder) 60.
+			},
+		},
+	}
+	ca := CloseAgreementDetails{
+		IterationNumber: 2,
+		Balance: Amount{
+			Asset:  NativeAsset,
+			Amount: 110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
+		},
+	}
+	_, txClose, err := channel.CloseTxs(ca)
+	require.NoError(t, err)
+	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
+	require.NoError(t, err)
+	_, _, err = channel.ConfirmPayment(CloseAgreement{
+		Details:         ca,
+		CloseSignatures: txClose.Signatures(),
+	})
+	assert.EqualError(t, err, "close agreement over commits: account is underfunded to make payment")
+	assert.ErrorIs(t, err, ErrUnderfunded)
+
+	// The same close payment should pass if the balance has been updated.
+	channel.UpdateRemoteEscrowAccountBalance(200)
+	_, _, err = channel.ConfirmPayment(CloseAgreement{
+		Details:         ca,
+		CloseSignatures: txClose.Signatures(),
+	})
+	assert.NoError(t, err)
+}
+
 func TestLastConfirmedPayment(t *testing.T) {
 	localSigner := keypair.MustRandom()
 	remoteSigner := keypair.MustRandom()
 	localEscrowAccount := &EscrowAccount{
 		Address:        keypair.MustRandom().FromAddress(),
 		SequenceNumber: int64(101),
+		Balance:        1000,
 	}
 	remoteEscrowAccount := &EscrowAccount{
 		Address:        keypair.MustRandom().FromAddress(),
 		SequenceNumber: int64(202),
+		Balance:        1000,
 	}
 	sendingChannel := NewChannel(Config{
 		NetworkPassphrase:   network.TestNetworkPassphrase,

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -213,18 +213,12 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
-			Balance: Amount{
-				Asset:  NativeAsset,
-				Amount: -60, // Remote (responder) owes local (initiator) 60.
-			},
+			Balance:         -60, // Remote (responder) owes local (initiator) 60.
 		},
 	}
 	ca := CloseAgreementDetails{
 		IterationNumber: 2,
-		Balance: Amount{
-			Asset:  NativeAsset,
-			Amount: -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
-		},
+		Balance:         -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
 	}
 	_, txClose, err := channel.CloseTxs(ca)
 	require.NoError(t, err)
@@ -275,18 +269,12 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
-			Balance: Amount{
-				Asset:  NativeAsset,
-				Amount: 60, // Remote (initiator) owes local (responder) 60.
-			},
+			Balance:         60, // Remote (initiator) owes local (responder) 60.
 		},
 	}
 	ca := CloseAgreementDetails{
 		IterationNumber: 2,
-		Balance: Amount{
-			Asset:  NativeAsset,
-			Amount: 110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
-		},
+		Balance:         110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
 	}
 	_, txClose, err := channel.CloseTxs(ca)
 	require.NoError(t, err)


### PR DESCRIPTION
### What

When receiving a proposed new close agreement/payment, error with `ErrUnderfunded` if the close agreement over commits the payer. Support updating the known balances of escrow accounts so the payment can be confirmed if on network the balance has been increased.

### Why

The state machine does not validate that a proposed close agreement will be satisfied by the balance of the paying participant's balance. This is a problem because the payer could over commit, breaking the channel. The receiver in a payment shouldn't accept a close agreement if it can't be satisfied by the current balances in the escrow accounts.

It's possible for participants to deposit more of an asset into their escrow account, so it should also be possible 
to update the known balances inside the channel when that happens. Deposits can happen at anytime without a participants involvement so the flow must support a way to move forward if a participant proposes a payment that based on stale knowledge is invalid, but would be valid with updated knowledge. The ConfirmPayment function returns an `ErrUnderfunded` error so that a caller can respond to that specific situation by checking the balance of the payers escrow account on network, updating it locally, and trying again.

Close #48
