### PR TITLE
sdk/state: remove assets from places only needed for multi asset support

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -37,9 +37,9 @@ func (c *Channel) CloseTxs(d CloseAgreementDetails) (txDecl *txnbuild.Transactio
 		ResponderEscrow:            c.responderEscrowAccount().Address,
 		StartSequence:              c.startingSequence,
 		IterationNumber:            d.IterationNumber,
-		AmountToInitiator:          amountToInitiator(d.Balance.Amount),
-		AmountToResponder:          amountToResponder(d.Balance.Amount),
-		Asset:                      d.Balance.Asset.Asset(),
+		AmountToInitiator:          amountToInitiator(d.Balance),
+		AmountToResponder:          amountToResponder(d.Balance),
+		Asset:                      c.openAgreement.Details.Asset.Asset(),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -156,12 +156,12 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 			rBalanceCheck -= amount
 			iBalanceCheck += amount
 		}
-		t.Log("Current channel balances: I: ", sendingChannel.Balance().Amount/1_000_0000, "R: ", receivingChannel.Balance().Amount/1_000_0000)
+		t.Log("Current channel balances: I: ", sendingChannel.Balance()/1_000_0000, "R: ", receivingChannel.Balance()/1_000_0000)
 		t.Log("Current channel iteration numbers: I: ", sendingChannel.NextIterationNumber(), "R: ", receivingChannel.NextIterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, sends to other party
-		payment, err := sendingChannel.ProposePayment(state.Amount{Asset: state.NativeAsset, Amount: amount})
+		payment, err := sendingChannel.ProposePayment(amount)
 		require.NoError(t, err)
 
 		var authorized bool
@@ -422,12 +422,12 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 			rBalanceCheck -= amount
 			iBalanceCheck += amount
 		}
-		t.Log("Current channel balances: I: ", sendingChannel.Balance().Amount/1_000_0000, "R: ", receivingChannel.Balance().Amount/1_000_0000)
+		t.Log("Current channel balances: I: ", sendingChannel.Balance()/1_000_0000, "R: ", receivingChannel.Balance()/1_000_0000)
 		t.Log("Current channel iteration numbers: I: ", sendingChannel.NextIterationNumber(), "R: ", receivingChannel.NextIterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, sends to other party
-		payment, err := sendingChannel.ProposePayment(state.Amount{Asset: asset, Amount: amount})
+		payment, err := sendingChannel.ProposePayment(amount)
 		require.NoError(t, err)
 
 		var authorized bool
@@ -635,12 +635,12 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 			rBalanceCheck -= amount
 			iBalanceCheck += amount
 		}
-		t.Log("Current channel balances: I: ", sendingChannel.Balance().Amount/1_000_0000, "R: ", receivingChannel.Balance().Amount/1_000_0000)
+		t.Log("Current channel balances: I: ", sendingChannel.Balance()/1_000_0000, "R: ", receivingChannel.Balance()/1_000_0000)
 		t.Log("Current channel iteration numbers: I: ", sendingChannel.NextIterationNumber(), "R: ", receivingChannel.NextIterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, sends to other party
-		payment, err := sendingChannel.ProposePayment(state.Amount{Asset: asset, Amount: amount})
+		payment, err := sendingChannel.ProposePayment(amount)
 		require.NoError(t, err)
 
 		var authorized bool
@@ -849,12 +849,12 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 			rBalanceCheck -= amount
 			iBalanceCheck += amount
 		}
-		t.Log("Current channel balances: I: ", sendingChannel.Balance().Amount/1_000_0000, "R: ", receivingChannel.Balance().Amount/1_000_0000)
+		t.Log("Current channel balances: I: ", sendingChannel.Balance()/1_000_0000, "R: ", receivingChannel.Balance()/1_000_0000)
 		t.Log("Current channel iteration numbers: I: ", sendingChannel.NextIterationNumber(), "R: ", receivingChannel.NextIterationNumber())
 		t.Log("Proposal: ", i, paymentLog, amount/1_000_0000)
 
 		// Sender: creates new Payment, sends to other party
-		payment, err := sendingChannel.ProposePayment(state.Amount{Asset: asset, Amount: amount})
+		payment, err := sendingChannel.ProposePayment(amount)
 		require.NoError(t, err)
 
 		var authorized bool

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -224,7 +224,7 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, authorized b
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
 			IterationNumber:            1,
-			Balance:                    Amount{Asset: m.Details.Asset},
+			Balance:                    0,
 			ObservationPeriodTime:      m.Details.ObservationPeriodTime,
 			ObservationPeriodLedgerGap: m.Details.ObservationPeriodLedgerGap,
 		},

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -8,11 +8,6 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-type Amount struct {
-	Asset  Asset
-	Amount int64
-}
-
 type EscrowAccount struct {
 	Address        *keypair.FromAddress
 	SequenceNumber int64
@@ -74,7 +69,7 @@ func (c *Channel) NextIterationNumber() int64 {
 
 // Balance returns the amount owing from the initiator to the responder, if positive, or
 // the amount owing from the responder to the initiator, if negative.
-func (c *Channel) Balance() Amount {
+func (c *Channel) Balance() int64 {
 	return c.latestAuthorizedCloseAgreement.Details.Balance
 }
 

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -20,7 +20,7 @@ type CloseAgreementDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	IterationNumber            int64
-	Balance                    Amount
+	Balance                    int64
 }
 
 // CloseAgreement contains everything a participant needs to execute the close
@@ -35,25 +35,21 @@ func (ca CloseAgreement) isEmpty() bool {
 	return ca.Details == CloseAgreementDetails{} && len(ca.CloseSignatures) == 0 && len(ca.DeclarationSignatures) == 0
 }
 
-func (c *Channel) ProposePayment(amount Amount) (CloseAgreement, error) {
-	if amount.Amount <= 0 {
+func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
+	if amount <= 0 {
 		return CloseAgreement{}, errors.New("payment amount must be greater than 0")
-	}
-	if amount.Asset != c.latestAuthorizedCloseAgreement.Details.Balance.Asset {
-		return CloseAgreement{}, fmt.Errorf("payment asset type is invalid, got: %s want: %s",
-			amount.Asset, c.latestAuthorizedCloseAgreement.Details.Balance.Asset)
 	}
 	newBalance := int64(0)
 	if c.initiator {
-		newBalance = c.Balance().Amount + amount.Amount
+		newBalance = c.Balance() + amount
 	} else {
-		newBalance = c.Balance().Amount - amount.Amount
+		newBalance = c.Balance() - amount
 	}
 	d := CloseAgreementDetails{
 		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap,
 		IterationNumber:            c.NextIterationNumber(),
-		Balance:                    Amount{Asset: amount.Asset, Amount: newBalance},
+		Balance:                    newBalance,
 	}
 	_, txClose, err := c.CloseTxs(d)
 	if err != nil {
@@ -84,10 +80,6 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	}
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
 		return ca, authorized, errors.New("close agreement does not match the close agreement already in progress")
-	}
-	if ca.Details.Balance.Asset != c.latestAuthorizedCloseAgreement.Details.Balance.Asset {
-		return ca, authorized, fmt.Errorf("payment asset type is invalid, got: %s want: %s",
-			ca.Details.Balance.Asset, c.latestAuthorizedCloseAgreement.Details.Balance.Asset)
 	}
 
 	// If the agreement is signed by all participants at the end of this method,
@@ -133,8 +125,8 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 		return ca, authorized, fmt.Errorf("verifying close signed by local: %w", err)
 	}
 	if !signed {
-		if (c.initiator && ca.Details.Balance.Amount > c.latestAuthorizedCloseAgreement.Details.Balance.Amount) ||
-			(!c.initiator && ca.Details.Balance.Amount < c.latestAuthorizedCloseAgreement.Details.Balance.Amount) {
+		if (c.initiator && ca.Details.Balance > c.latestAuthorizedCloseAgreement.Details.Balance) ||
+			(!c.initiator && ca.Details.Balance < c.latestAuthorizedCloseAgreement.Details.Balance) {
 			return ca, authorized, fmt.Errorf("close agreement is a payment to the proposer")
 		}
 		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -108,21 +108,20 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentToRemote(t *testing.T) {
 
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
+	channel.openAgreement = OpenAgreement{
+		Details: OpenAgreementDetails{
+			Asset: NativeAsset,
+		},
+	}
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
-			Balance: Amount{
-				Asset:  NativeAsset,
-				Amount: 100, // Local (initiator) owes remote (responder) 100.
-			},
+			Balance: 100, // Local (initiator) owes remote (responder) 100.
 		},
 	}
 	ca := CloseAgreementDetails{
 		IterationNumber: 2,
-		Balance: Amount{
-			Asset:  NativeAsset,
-			Amount: 110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
-		},
+		Balance: 110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
 	}
 	_, txClose, err := channel.CloseTxs(ca)
 	require.NoError(t, err)
@@ -159,21 +158,20 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentToRemote(t *testing.T) {
 
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
+	channel.openAgreement = OpenAgreement{
+		Details: OpenAgreementDetails{
+			Asset: NativeAsset,
+		},
+	}
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
-			Balance: Amount{
-				Asset:  NativeAsset,
-				Amount: 100, // Remote (initiator) owes local (responder) 100.
-			},
+			Balance: 100, // Remote (initiator) owes local (responder) 100.
 		},
 	}
 	ca := CloseAgreementDetails{
 		IterationNumber: 2,
-		Balance: Amount{
-			Asset:  NativeAsset,
-			Amount: 90, // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
-		},
+		Balance: 90, // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
 	}
 	_, txClose, err := channel.CloseTxs(ca)
 	require.NoError(t, err)
@@ -215,13 +213,18 @@ func TestLastConfirmedPayment(t *testing.T) {
 	})
 
 	// latest close agreement should be set during open steps
-	sendingChannel.latestAuthorizedCloseAgreement.Details.Balance = Amount{Asset: NativeAsset}
-	receiverChannel.latestAuthorizedCloseAgreement.Details.Balance = Amount{Asset: NativeAsset}
+	sendingChannel.openAgreement = OpenAgreement{
+		Details: OpenAgreementDetails{
+			Asset: NativeAsset,
+		},
+	}
+	receiverChannel.openAgreement = OpenAgreement{
+		Details: OpenAgreementDetails{
+			Asset: NativeAsset,
+		},
+	}
 
-	ca, err := sendingChannel.ProposePayment(Amount{
-		Asset:  NativeAsset,
-		Amount: 200,
-	})
+	ca, err := sendingChannel.ProposePayment(200)
 	require.NoError(t, err)
 
 	ca, authorized, err := receiverChannel.ConfirmPayment(ca)
@@ -233,17 +236,14 @@ func TestLastConfirmedPayment(t *testing.T) {
 	caDifferent := CloseAgreement{
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
-			Balance: Amount{
-				Asset:  NativeAsset,
-				Amount: 400,
-			},
+			Balance: 400,
 		},
 		CloseSignatures: ca.CloseSignatures,
 	}
 	_, authorized, err = receiverChannel.ConfirmPayment(caDifferent)
 	assert.False(t, authorized)
 	require.EqualError(t, err, "close agreement does not match the close agreement already in progress")
-	assert.Equal(t, CloseAgreement{Details: CloseAgreementDetails{Balance: Amount{Asset: NativeAsset}}}, receiverChannel.LatestCloseAgreement())
+	assert.Equal(t, CloseAgreement{Details: CloseAgreementDetails{Balance: 0}}, receiverChannel.LatestCloseAgreement())
 
 	// Confirming a payment with same sequence number and same amount should pass
 	ca, authorized, err = sendingChannel.ConfirmPayment(ca)

--- a/sdk/state/update_test.go
+++ b/sdk/state/update_test.go
@@ -116,12 +116,12 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentToRemote(t *testing.T) {
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
-			Balance: 100, // Local (initiator) owes remote (responder) 100.
+			Balance:         100, // Local (initiator) owes remote (responder) 100.
 		},
 	}
 	ca := CloseAgreementDetails{
 		IterationNumber: 2,
-		Balance: 110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
+		Balance:         110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
 	}
 	_, txClose, err := channel.CloseTxs(ca)
 	require.NoError(t, err)
@@ -166,12 +166,12 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentToRemote(t *testing.T) {
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
-			Balance: 100, // Remote (initiator) owes local (responder) 100.
+			Balance:         100, // Remote (initiator) owes local (responder) 100.
 		},
 	}
 	ca := CloseAgreementDetails{
 		IterationNumber: 2,
-		Balance: 90, // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
+		Balance:         90, // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
 	}
 	_, txClose, err := channel.CloseTxs(ca)
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	caDifferent := CloseAgreement{
 		Details: CloseAgreementDetails{
 			IterationNumber: 1,
-			Balance: 400,
+			Balance:         400,
 		},
 		CloseSignatures: ca.CloseSignatures,
 	}


### PR DESCRIPTION
### What
Remove assets from `CloseAgreements` and some other places.

### Why

In #72 we rewound support for multiple assets and moved forward with single asset support only. `CloseAgreements` only need to include asset information if the channel is multi-asset. This simplifies several things. 

I realized this could be simplified when I worked on #155. In that change I needed to add a balance to `EscrowAccount`. It was going to be significantly harder to follow the existing pattern and include asset information in that object, so I didn't. I think it is worth bringing the same simplicity to close agreements and everywhere else.