### PR TITLE
sdk/state: prevent proposing payment that over commits

### DIFF
--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -82,6 +82,10 @@ func (c *Channel) LatestCloseAgreement() CloseAgreement {
 	return c.latestAuthorizedCloseAgreement
 }
 
+func (c *Channel) UpdateLocalEscrowAccountBalance(balance int64) {
+	c.localEscrowAccount.Balance = balance
+}
+
 func (c *Channel) UpdateRemoteEscrowAccountBalance(balance int64) {
 	c.remoteEscrowAccount.Balance = balance
 }
@@ -140,6 +144,13 @@ func (c *Channel) amountToLocal(balance int64) int64 {
 		return amountToInitiator(balance)
 	}
 	return amountToResponder(balance)
+}
+
+func (c *Channel) amountToRemote(balance int64) int64 {
+	if c.initiator {
+		return amountToResponder(balance)
+	}
+	return amountToInitiator(balance)
 }
 
 func amountToInitiator(balance int64) int64 {

--- a/sdk/state/update.go
+++ b/sdk/state/update.go
@@ -45,6 +45,10 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 	} else {
 		newBalance = c.Balance() - amount
 	}
+	if c.amountToRemote(newBalance) > c.localEscrowAccount.Balance {
+		return CloseAgreement{}, fmt.Errorf("amount over commits: %w", ErrUnderfunded)
+	}
+
 	d := CloseAgreementDetails{
 		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap,


### PR DESCRIPTION
### What

Prevent a participant from proposing a payment that would exceed the balance they supplied to the payment channel.

### Why

@acharb pointed out (https://github.com/stellar/experimental-payment-channels/pull/155#discussion_r667233215) that allowing a participant to propose a payment too large could break the payment channel for both participants because the payment in the closing transaction would fail with insufficient funds. This isn't good for either participant. It also makes little sense to allow a payment to be proposed if a sensible other participant will reject it, which they should.

Close #157