### PR TITLE
sdk/state: add some helpful funcs

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -5,6 +5,7 @@ go 1.16
 replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20210528222607-c2e3ef441a5d
 
 require (
+	github.com/google/go-cmp v0.2.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stellar/go v0.0.0-00010101000000-000000000000
 	github.com/stretchr/objx v0.3.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -46,6 +46,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-querystring v0.0.0-20160401233042-9235644dd9e5 h1:oERTZ1buOUYlpmKaqlO5fYmz8cZ1rYu5DieJzF4ZVmU=
 github.com/google/go-querystring v0.0.0-20160401233042-9235644dd9e5/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -152,13 +153,11 @@ github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiF
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
 github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
@@ -31,7 +32,13 @@ type OpenAgreement struct {
 }
 
 func (oa OpenAgreement) isEmpty() bool {
-	return oa.Details.Equal(OpenAgreementDetails{})
+	return oa.Equal(OpenAgreement{})
+}
+
+func (oa OpenAgreement) Equal(oa2 OpenAgreement) bool {
+	// TODO: Replace cmp.Equal with a hand written equals.
+	type OA OpenAgreement
+	return cmp.Equal(OA(oa), OA(oa2))
 }
 
 // OpenParams are the parameters selected by the participant proposing an open channel.

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -1,13 +1,130 @@
 package state
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestOpenAgreement_Equal(t *testing.T) {
+	testCases := []struct {
+		oa1       OpenAgreement
+		oa2       OpenAgreement
+		wantEqual bool
+	}{
+		{OpenAgreement{}, OpenAgreement{}, true},
+		{
+			OpenAgreement{
+				Details: OpenAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					Asset:                      "native",
+					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
+				},
+			},
+			OpenAgreement{
+				Details: OpenAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					Asset:                      "native",
+					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
+				},
+			},
+			true,
+		},
+		{
+			OpenAgreement{
+				Details: OpenAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					Asset:                      "native",
+					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
+				},
+			},
+			OpenAgreement{},
+			false,
+		},
+		{
+			OpenAgreement{
+				Details: OpenAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					Asset:                      "native",
+					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			OpenAgreement{
+				Details: OpenAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					Asset:                      "native",
+					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			true,
+		},
+		{
+			OpenAgreement{
+				Details: OpenAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					Asset:                      "native",
+					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			OpenAgreement{},
+			false,
+		},
+		{
+			OpenAgreement{
+				Details: OpenAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					Asset:                      "native",
+					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			OpenAgreement{},
+			false,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			equal := tc.oa1.Equal(tc.oa2)
+			assert.Equal(t, tc.wantEqual, equal)
+		})
+	}
+}
 
 func TestProposeOpen_validAsset(t *testing.T) {
 	localSigner := keypair.MustRandom()

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stellar/go/xdr"
 )
 
@@ -32,7 +33,13 @@ type CloseAgreement struct {
 }
 
 func (ca CloseAgreement) isEmpty() bool {
-	return ca.Details == CloseAgreementDetails{} && len(ca.CloseSignatures) == 0 && len(ca.DeclarationSignatures) == 0
+	return ca.Equal(CloseAgreement{})
+}
+
+func (ca CloseAgreement) Equal(ca2 CloseAgreement) bool {
+	// TODO: Replace cmp.Equal with a hand written equals.
+	type CA CloseAgreement
+	return cmp.Equal(CA(ca), CA(ca2))
 }
 
 func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -2,7 +2,9 @@ package state
 
 import (
 	"math/rand"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
@@ -10,6 +12,120 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCloseAgreement_Equal(t *testing.T) {
+	testCases := []struct {
+		ca1       CloseAgreement
+		ca2       CloseAgreement
+		wantEqual bool
+	}{
+		{CloseAgreement{}, CloseAgreement{}, true},
+		{
+			CloseAgreement{
+				Details: CloseAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					IterationNumber:            3,
+					Balance:                    100,
+				},
+			},
+			CloseAgreement{
+				Details: CloseAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					IterationNumber:            3,
+					Balance:                    100,
+				},
+			},
+			true,
+		},
+		{
+			CloseAgreement{
+				Details: CloseAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					IterationNumber:            3,
+					Balance:                    100,
+				},
+			},
+			CloseAgreement{},
+			false,
+		},
+		{
+			CloseAgreement{
+				Details: CloseAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					IterationNumber:            3,
+					Balance:                    100,
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			CloseAgreement{
+				Details: CloseAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					IterationNumber:            3,
+					Balance:                    100,
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			true,
+		},
+		{
+			CloseAgreement{
+				Details: CloseAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					IterationNumber:            3,
+					Balance:                    100,
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			CloseAgreement{},
+			false,
+		},
+		{
+			CloseAgreement{
+				Details: CloseAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					IterationNumber:            3,
+					Balance:                    100,
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			CloseAgreement{},
+			false,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			equal := tc.ca1.Equal(tc.ca2)
+			assert.Equal(t, tc.wantEqual, equal)
+		})
+	}
+}
 
 func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) {
 	localSigner := keypair.MustRandom()

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -90,12 +90,12 @@ func (c *Channel) UpdateRemoteEscrowAccountBalance(balance int64) {
 	c.remoteEscrowAccount.Balance = balance
 }
 
-func (c *Channel) LocalEscrowAccountBalance() int64 {
-	return c.localEscrowAccount.Balance
+func (c *Channel) LocalEscrowAccount() EscrowAccount {
+	return *c.localEscrowAccount
 }
 
-func (c *Channel) RemoteEscrowAccountBalance() int64 {
-	return c.remoteEscrowAccount.Balance
+func (c *Channel) RemoteEscrowAccount() EscrowAccount {
+	return *c.remoteEscrowAccount
 }
 
 func (c *Channel) initiatorEscrowAccount() *EscrowAccount {


### PR DESCRIPTION
### What
Add some functions that I've found helpful:
 - Equal functions on agreements.
 - Functions to get the escrow account objects from the channel.

### Why
It's helpful for the user to be able to compare agreements to know if an agreement they have is the same as a new agreement.

It's helpful to be able to access the full state of the escrow account as known by the channel, and not just the balance that we expose now.

I discovered this while working on #122.

Close #175 

### Known Limitations
I shortcutted writing the equals methods by using the cmp.Equal package. We should really write a proper equals package that doesn't use reflection under the surface, but this should be sufficient for now.