### PR TITLE
sdk/state: export initiator from Channel

### DIFF
--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -61,6 +61,10 @@ func NewChannel(c Config) *Channel {
 	return channel
 }
 
+func (c *Channel) IsInitiator() bool {
+	return c.initiator
+}
+
 func (c *Channel) NextIterationNumber() int64 {
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() {
 		return c.latestUnauthorizedCloseAgreement.Details.IterationNumber


### PR DESCRIPTION
### What
Export the initiator variable from the Channel.

### Why
The caller already knows about it since they choose who the initiator is during config, and it is helpful in picking who should take the first action in some processes like the open process. We might remove this later on to hide the notion of initiator, but for now having it is useful.

Something I discovered working on #122.