### PR TITLE
sdk/state: fix test

### DIFF
--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -110,11 +110,24 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				CloseSignatures: []xdr.DecoratedSignature{
 					{
 						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			OpenAgreement{
+				Details: OpenAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					Asset:                      "native",
+					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
 						Signature: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
 					},
 				},
 			},
-			OpenAgreement{},
 			false,
 		},
 	}

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -111,11 +111,24 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				CloseSignatures: []xdr.DecoratedSignature{
 					{
 						Hint:      [4]byte{0, 1, 2, 3},
+						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+					},
+				},
+			},
+			CloseAgreement{
+				Details: CloseAgreementDetails{
+					ObservationPeriodTime:      time.Minute,
+					ObservationPeriodLedgerGap: 2,
+					IterationNumber:            3,
+					Balance:                    100,
+				},
+				CloseSignatures: []xdr.DecoratedSignature{
+					{
+						Hint:      [4]byte{0, 1, 2, 3},
 						Signature: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
 					},
 				},
 			},
-			CloseAgreement{},
 			false,
 		},
 	}


### PR DESCRIPTION
### What
Add a test case for open and close agreement equality functions that check if the signatures are different the function returns false.

### Why
@acharb pointed out that the tests were not actually testing that case because of a mistake in the last test cases. 

https://github.com/stellar/experimental-payment-channels/pull/177/files#r671552880

Close #175