### PR TITLE
sdk/state: move validation code to own methods

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -74,17 +74,29 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
-// ConfirmClose agrees to a close agreement to be submitted without waiting the
-// observation period. The agreement will always be accepted if it is identical
-// to the latest authorized close agreement, and it is signed by the participant
-// proposing the close.
-func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement, authorized bool, err error) {
+func (c *Channel) validateClose(ca CloseAgreement) error {
 	latestWithoutObservation := c.latestAuthorizedCloseAgreement.Details
 	latestWithoutObservation.ObservationPeriodTime = 0
 	latestWithoutObservation.ObservationPeriodLedgerGap = 0
 
 	if ca.Details != latestWithoutObservation {
-		return CloseAgreement{}, authorized, fmt.Errorf("close agreement details do not match saved latest authorized close agreement")
+		return fmt.Errorf("close agreement details do not match saved latest authorized close agreement")
+	}
+	if len(ca.DeclarationSignatures) > 2 || len(ca.CloseSignatures) > 2 {
+		return fmt.Errorf("close agreement has too many signatures, has declaration: %d, close: %d, max of 2 allowed for each",
+			len(ca.DeclarationSignatures), len(ca.CloseSignatures))
+	}
+	return nil
+}
+
+// ConfirmClose agrees to a close agreement to be submitted without waiting the
+// observation period. The agreement will always be accepted if it is identical
+// to the latest authorized close agreement, and it is signed by the participant
+// proposing the close.
+func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement, authorized bool, err error) {
+	err = c.validateClose(ca)
+	if err != nil {
+		return CloseAgreement{}, authorized, fmt.Errorf("validating close agreement: %w", err)
 	}
 
 	_, txClose, err := c.CloseTxs(ca.Details)

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -82,10 +82,6 @@ func (c *Channel) validateClose(ca CloseAgreement) error {
 	if ca.Details != latestWithoutObservation {
 		return fmt.Errorf("close agreement details do not match saved latest authorized close agreement")
 	}
-	if len(ca.DeclarationSignatures) > 2 || len(ca.CloseSignatures) > 2 {
-		return fmt.Errorf("close agreement has too many signatures, has declaration: %d, close: %d, max of 2 allowed for each",
-			len(ca.DeclarationSignatures), len(ca.CloseSignatures))
-	}
 	return nil
 }
 

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -144,7 +144,7 @@ func (c *Channel) validateOpen(m OpenAgreement) error {
 func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, authorized bool, err error) {
 	err = c.validateOpen(m)
 	if err != nil {
-		return m, authorized, fmt.Errorf("validating open agreement failed: %w", err)
+		return m, authorized, fmt.Errorf("validating open agreement: %w", err)
 	}
 
 	// at the end of this method, if no error, then save a new channel openAgreement. Use the

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -121,12 +121,6 @@ func (c *Channel) validateOpen(m OpenAgreement) error {
 		return fmt.Errorf("input open agreement expire too far into the future")
 	}
 
-	// If the open agreement has extra signatures, error.
-	if len(m.DeclarationSignatures) > 2 || len(m.CloseSignatures) > 2 || len(m.FormationSignatures) > 2 {
-		return fmt.Errorf("input open agreement has too many signatures, has declaration: %d,"+
-			" close: %d, formation: %d, max of 2 allowed for each",
-			len(m.DeclarationSignatures), len(m.CloseSignatures), len(m.FormationSignatures))
-	}
 	return nil
 }
 

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -110,6 +110,26 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 	return open, nil
 }
 
+func (c *Channel) validateOpen(m OpenAgreement) error {
+	// If the open agreement details don't match the open agreement in progress, error.
+	if !c.openAgreement.isEmpty() && !m.Details.Equal(c.openAgreement.Details) {
+		return fmt.Errorf("input open agreement details do not match the saved open agreement details")
+	}
+
+	// If the expiry of the agreement is past the max expiry the channel will accept, error.
+	if m.Details.ExpiresAt.After(time.Now().Add(c.maxOpenExpiry)) {
+		return fmt.Errorf("input open agreement expire too far into the future")
+	}
+
+	// If the open agreement has extra signatures, error.
+	if len(m.DeclarationSignatures) > 2 || len(m.CloseSignatures) > 2 || len(m.FormationSignatures) > 2 {
+		return fmt.Errorf("input open agreement has too many signatures, has declaration: %d,"+
+			" close: %d, formation: %d, max of 2 allowed for each",
+			len(m.DeclarationSignatures), len(m.CloseSignatures), len(m.FormationSignatures))
+	}
+	return nil
+}
+
 // ConfirmOpen confirms an open that was proposed. It is called by both
 // participants as they both participate in the open process.
 //
@@ -128,14 +148,9 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 // If after confirming the open has all the signatures it needs to be fully and
 // completely signed, fully signed will be true, otherwise it will be false.
 func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, authorized bool, err error) {
-	// If the open agreement details don't match the open agreement in progress, error.
-	if !c.openAgreement.isEmpty() && !m.Details.Equal(c.openAgreement.Details) {
-		return m, authorized, fmt.Errorf("input open agreement details do not match the saved open agreement details")
-	}
-
-	// If the expiry of the agreement is past the max expiry the channel will accept, error.
-	if m.Details.ExpiresAt.After(time.Now().Add(c.maxOpenExpiry)) {
-		return m, authorized, fmt.Errorf("input open agreement expire too far into the future")
+	err = c.validateOpen(m)
+	if err != nil {
+		return m, authorized, fmt.Errorf("validating open agreement failed: %w", err)
 	}
 
 	// at the end of this method, if no error, then save a new channel openAgreement. Use the

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -222,8 +222,7 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		// invalid ObservationPeriodTime
 		d := oa
 		d.ObservationPeriodTime = 0
-		_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: d})
-		require.False(t, authorized)
+		err := channel.validateOpen(OpenAgreement{Details: d})
 		require.EqualError(t, err, "input open agreement details do not match the saved open agreement details")
 	}
 
@@ -231,8 +230,7 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		// invalid different asset
 		d := oa
 		d.Asset = "ABC:GCDFU7RNY6HTYQKP7PYHBMXXKXZ4HET6LMJ5CDO7YL5NMYH4T2BSZCPZ"
-		_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: d})
-		require.False(t, authorized)
+		err := channel.validateOpen(OpenAgreement{Details: d})
 		require.EqualError(t, err, "input open agreement details do not match the saved open agreement details")
 	}
 }
@@ -259,12 +257,11 @@ func TestConfirmOpen_rejectsOpenAgreementsWithLongFormations(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 
-	_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: OpenAgreementDetails{
+	err := channel.validateOpen(OpenAgreement{Details: OpenAgreementDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
 		ExpiresAt:                  time.Now().Add(100 * time.Second),
 	}})
-	require.False(t, authorized)
 	require.EqualError(t, err, "input open agreement expire too far into the future")
 }

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -222,16 +222,18 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		// invalid ObservationPeriodTime
 		d := oa
 		d.ObservationPeriodTime = 0
-		err := channel.validateOpen(OpenAgreement{Details: d})
-		require.EqualError(t, err, "input open agreement details do not match the saved open agreement details")
+		_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: d})
+		require.False(t, authorized)
+		require.EqualError(t, err, "validating open agreement: input open agreement details do not match the saved open agreement details")
 	}
 
 	{
 		// invalid different asset
 		d := oa
 		d.Asset = "ABC:GCDFU7RNY6HTYQKP7PYHBMXXKXZ4HET6LMJ5CDO7YL5NMYH4T2BSZCPZ"
-		err := channel.validateOpen(OpenAgreement{Details: d})
-		require.EqualError(t, err, "input open agreement details do not match the saved open agreement details")
+		_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: d})
+		require.False(t, authorized)
+		require.EqualError(t, err, "validating open agreement: input open agreement details do not match the saved open agreement details")
 	}
 }
 
@@ -257,11 +259,12 @@ func TestConfirmOpen_rejectsOpenAgreementsWithLongFormations(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 
-	err := channel.validateOpen(OpenAgreement{Details: OpenAgreementDetails{
+	_, authorized, err := channel.ConfirmOpen(OpenAgreement{Details: OpenAgreementDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
 		ExpiresAt:                  time.Now().Add(100 * time.Second),
 	}})
-	require.EqualError(t, err, "input open agreement expire too far into the future")
+	require.False(t, authorized)
+	require.EqualError(t, err, "validating open agreement: input open agreement expire too far into the future")
 }

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -80,19 +80,30 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 
 var ErrUnderfunded = fmt.Errorf("account is underfunded to make payment")
 
+func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
+	if ca.Details.IterationNumber != c.NextIterationNumber() {
+		return fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
+	}
+	if ca.Details.ObservationPeriodTime != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime || ca.Details.ObservationPeriodLedgerGap != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap {
+		return fmt.Errorf("invalid payment observation period: different than channel state")
+	}
+	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
+		return fmt.Errorf("close agreement does not match the close agreement already in progress")
+	}
+	if len(ca.DeclarationSignatures) > 2 || len(ca.CloseSignatures) > 2 {
+		return fmt.Errorf("close agreement has too many signatures, has declaration: %d, close: %d, max of 2 allowed for each",
+			len(ca.DeclarationSignatures), len(ca.CloseSignatures))
+	}
+	return nil
+}
+
 // ConfirmPayment confirms a close agreement. The original proposer should only have to call this once, and the
 // receiver should call twice. First to sign the agreement and store signatures, second to just store the new signatures
 // from the other party's confirmation.
 func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreement, authorized bool, err error) {
-	// If the close agreement details don't match the close agreement in progress, error.
-	if ca.Details.IterationNumber != c.NextIterationNumber() {
-		return ca, authorized, fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
-	}
-	if ca.Details.ObservationPeriodTime != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime || ca.Details.ObservationPeriodLedgerGap != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap {
-		return ca, authorized, fmt.Errorf("invalid payment observation period: different than channel state")
-	}
-	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
-		return ca, authorized, errors.New("close agreement does not match the close agreement already in progress")
+	err = c.validatePayment(ca)
+	if err != nil {
+		return ca, authorized, fmt.Errorf("validating payment: %w", err)
 	}
 
 	// If the agreement is signed by all participants at the end of this method,

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -80,6 +80,9 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 
 var ErrUnderfunded = fmt.Errorf("account is underfunded to make payment")
 
+// validatePayment validates the close agreement given to the ConfirmPayment method. Note that
+// there are additional verifications ConfirmPayment performs that are based
+// on the state of the close agreement signatures.
 func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 	if ca.Details.IterationNumber != c.NextIterationNumber() {
 		return fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -90,10 +90,6 @@ func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details != ca.Details {
 		return fmt.Errorf("close agreement does not match the close agreement already in progress")
 	}
-	if len(ca.DeclarationSignatures) > 2 || len(ca.CloseSignatures) > 2 {
-		return fmt.Errorf("close agreement has too many signatures, has declaration: %d, close: %d, max of 2 allowed for each",
-			len(ca.DeclarationSignatures), len(ca.CloseSignatures))
-	}
 	return nil
 }
 

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -568,6 +568,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 		CloseSignatures: ca.CloseSignatures,
 	}
 	_, authorized, err = receiverChannel.ConfirmPayment(caDifferent)
+	assert.False(t, authorized)
 	require.EqualError(t, err, "validating payment: close agreement does not match the close agreement already in progress")
 	assert.Equal(t, CloseAgreement{Details: CloseAgreementDetails{Balance: 0}}, receiverChannel.LatestCloseAgreement())
 

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -209,7 +209,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 			},
 			CloseSignatures: txClose.Signatures(),
 		})
-		require.EqualError(t, err, "invalid payment observation period: different than channel state")
+		require.EqualError(t, err, "validating payment: invalid payment observation period: different than channel state")
 	}
 }
 
@@ -568,8 +568,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 		CloseSignatures: ca.CloseSignatures,
 	}
 	_, authorized, err = receiverChannel.ConfirmPayment(caDifferent)
-	assert.False(t, authorized)
-	require.EqualError(t, err, "close agreement does not match the close agreement already in progress")
+	require.EqualError(t, err, "validating payment: close agreement does not match the close agreement already in progress")
 	assert.Equal(t, CloseAgreement{Details: CloseAgreementDetails{Balance: 0}}, receiverChannel.LatestCloseAgreement())
 
 	// Confirming a payment with same sequence number and same amount should pass


### PR DESCRIPTION
**WHAT**
move `Confirm<open,payment,close>` validation code to their own `validate<open,payment,close>` methods

**WHY**
now that the validation code is growing it makes sense to move to their own methods. This helps with both readability and with unit testing that validation code

this refactoring made sense while working on: https://github.com/stellar/experimental-payment-channels/issues/142