### PR TITLE
sep: fix typo

### DIFF
--- a/specifications/sep-payment-channel-transactions.md
+++ b/specifications/sep-payment-channel-transactions.md
@@ -173,7 +173,7 @@ without any payment.
 
 Participants should check the state of the other participant's escrow account
 after the formation transaction is submitted to ensure the state is as
-expected.Participants may wish to reduce their exposure to griefing by making
+expected. Participants may wish to reduce their exposure to griefing by making
 deposits of initial contributions after formation. See [Security](#Security).
 
 It is critical that signatures for F are exchanged after C_i and D_i because F


### PR DESCRIPTION
### What
Add a space between sentences.

### Why
@acharb pointed out this typo in https://github.com/stellar/experimental-payment-channels/pull/162#discussion_r675081613 but the PR was auto-merged before it could be fixed.