### PR TITLE
sdk/state: reject payment if a coordinated close already accepted

### DIFF
--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -115,12 +115,14 @@ func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 		c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
 		return fmt.Errorf("cannot propose payment after proposing a coordinated close")
 	}
+
 	// If a coordinated close has been accepted already, error.
 	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
 		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
 		return fmt.Errorf("cannot confirm payment after an accepted coordinated close")
 	}
 
+	// If the new close agreement details are incorrect, error.
 	if ca.Details.IterationNumber != c.NextIterationNumber() {
 		return fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
 	}

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -115,7 +115,7 @@ func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && !ca.Details.Equal(c.latestUnauthorizedCloseAgreement.Details) {
 		return fmt.Errorf("close agreement does not match the close agreement already in progress")
 	}
-	if ca.Details.ConfirmingSigner != nil && ca.Details.ConfirmingSigner.Address() != c.localSigner.Address() &&
+	if ca.Details.ConfirmingSigner.Address() != c.localSigner.Address() &&
 		ca.Details.ConfirmingSigner.Address() != c.remoteSigner.Address() {
 		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ca.Details.ConfirmingSigner.Address())
 	}

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -56,7 +56,7 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 	}
 
 	// If a coordinated close has been accepted already, error.
-	if c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
+	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
 		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
 		return CloseAgreement{}, errors.New("cannot propose payment after an accepted coordinated close")
 	}
@@ -119,7 +119,7 @@ func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 		ca.Details.ConfirmingSigner.Address() != c.remoteSigner.Address() {
 		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ca.Details.ConfirmingSigner.Address())
 	}
-	if c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
+	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
 		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
 		return fmt.Errorf("cannot confirm payment after an accepted coordinated close")
 	}

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -110,15 +110,15 @@ var ErrUnderfunded = fmt.Errorf("account is underfunded to make payment")
 // there are additional verifications ConfirmPayment performs that are based
 // on the state of the close agreement signatures.
 func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
-	// If a coordinated close has been accepted already, error.
-	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
-		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
-		return fmt.Errorf("cannot confirm payment after an accepted coordinated close")
-	}
 	// If a coordinated close has been proposed by this channel already, error.
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
 		c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
 		return fmt.Errorf("cannot propose payment after proposing a coordinated close")
+	}
+	// If a coordinated close has been accepted already, error.
+	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
+		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
+		return fmt.Errorf("cannot confirm payment after an accepted coordinated close")
 	}
 
 	if ca.Details.IterationNumber != c.NextIterationNumber() {
@@ -135,7 +135,6 @@ func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 		ca.Details.ConfirmingSigner.Address() != c.remoteSigner.Address() {
 		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ca.Details.ConfirmingSigner.Address())
 	}
-
 	return nil
 }
 

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -52,13 +51,19 @@ func (ca CloseAgreement) Equal(ca2 CloseAgreement) bool {
 
 func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 	if amount <= 0 {
-		return CloseAgreement{}, errors.New("payment amount must be greater than 0")
+		return CloseAgreement{}, fmt.Errorf("payment amount must be greater than 0")
 	}
 
 	// If a coordinated close has been accepted already, error.
 	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
 		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
-		return CloseAgreement{}, errors.New("cannot propose payment after an accepted coordinated close")
+		return CloseAgreement{}, fmt.Errorf("cannot propose payment after an accepted coordinated close")
+	}
+
+	// If a coordinated close has been proposed by this channel already, error.
+	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
+		c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
+		return CloseAgreement{}, fmt.Errorf("cannot propose payment after proposing a coordinated close")
 	}
 
 	newBalance := int64(0)
@@ -105,6 +110,17 @@ var ErrUnderfunded = fmt.Errorf("account is underfunded to make payment")
 // there are additional verifications ConfirmPayment performs that are based
 // on the state of the close agreement signatures.
 func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
+	// If a coordinated close has been accepted already, error.
+	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
+		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
+		return fmt.Errorf("cannot confirm payment after an accepted coordinated close")
+	}
+	// If a coordinated close has been proposed by this channel already, error.
+	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
+		c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
+		return fmt.Errorf("cannot propose payment after proposing a coordinated close")
+	}
+
 	if ca.Details.IterationNumber != c.NextIterationNumber() {
 		return fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
 	}
@@ -119,10 +135,7 @@ func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 		ca.Details.ConfirmingSigner.Address() != c.remoteSigner.Address() {
 		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ca.Details.ConfirmingSigner.Address())
 	}
-	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
-		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
-		return fmt.Errorf("cannot confirm payment after an accepted coordinated close")
-	}
+
 	return nil
 }
 

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -381,14 +381,18 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	}
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
-			IterationNumber: 1,
-			Balance:         100, // Local (initiator) owes remote (responder) 100.
+			IterationNumber:            1,
+			Balance:                    100, // Local (initiator) owes remote (responder) 100.
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
 		},
 	}
 	ca := CloseAgreementDetails{
-		IterationNumber:  2,
-		Balance:          110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
-		ConfirmingSigner: localSigner.FromAddress(),
+		IterationNumber:            2,
+		Balance:                    110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
+		ConfirmingSigner:           localSigner.FromAddress(),
+		ObservationPeriodTime:      10,
+		ObservationPeriodLedgerGap: 10,
 	}
 	txDecl, txClose, err := channel.closeTxs(channel.openAgreement.Details, ca)
 	require.NoError(t, err)
@@ -435,14 +439,18 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	}
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
-			IterationNumber: 1,
-			Balance:         100, // Remote (initiator) owes local (responder) 100.
+			IterationNumber:            1,
+			Balance:                    100, // Remote (initiator) owes local (responder) 100.
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
 		},
 	}
 	ca := CloseAgreementDetails{
-		IterationNumber:  2,
-		Balance:          90, // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
-		ConfirmingSigner: localSigner.FromAddress(),
+		IterationNumber:            2,
+		Balance:                    90, // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
+		ConfirmingSigner:           localSigner.FromAddress(),
+		ObservationPeriodTime:      10,
+		ObservationPeriodLedgerGap: 10,
 	}
 	txDecl, txClose, err := channel.closeTxs(channel.openAgreement.Details, ca)
 	require.NoError(t, err)
@@ -486,14 +494,18 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	// payment changes the balance in the favor of the remote.
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
-			IterationNumber: 1,
-			Balance:         -60, // Remote (responder) owes local (initiator) 60.
+			IterationNumber:            1,
+			Balance:                    -60, // Remote (responder) owes local (initiator) 60.
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
 		},
 	}
 	ca := CloseAgreementDetails{
-		IterationNumber:  2,
-		Balance:          -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
-		ConfirmingSigner: localSigner.FromAddress(),
+		IterationNumber:            2,
+		Balance:                    -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
+		ConfirmingSigner:           localSigner.FromAddress(),
+		ObservationPeriodTime:      10,
+		ObservationPeriodLedgerGap: 10,
 	}
 	txDecl, txClose, err := channel.closeTxs(channel.openAgreement.Details, ca)
 	require.NoError(t, err)
@@ -547,14 +559,18 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	// payment changes the balance in the favor of the remote.
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
-			IterationNumber: 1,
-			Balance:         60, // Remote (initiator) owes local (responder) 60.
+			IterationNumber:            1,
+			Balance:                    60, // Remote (initiator) owes local (responder) 60.
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
 		},
 	}
 	ca := CloseAgreementDetails{
-		IterationNumber:  2,
-		Balance:          110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
-		ConfirmingSigner: localSigner.FromAddress(),
+		IterationNumber:            2,
+		Balance:                    110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
+		ConfirmingSigner:           localSigner.FromAddress(),
+		ObservationPeriodTime:      10,
+		ObservationPeriodLedgerGap: 10,
 	}
 	txDecl, txClose, err := channel.closeTxs(channel.openAgreement.Details, ca)
 	require.NoError(t, err)
@@ -608,8 +624,10 @@ func TestChannel_ConfirmPayment_initiatorCannotProposePaymentThatIsUnderfunded(t
 	// payment changes the balance in the favor of the remote.
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
-			IterationNumber: 1,
-			Balance:         60, // Local (initiator) owes remote (responder) 60.
+			IterationNumber:            1,
+			Balance:                    60, // Local (initiator) owes remote (responder) 60.
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
 		},
 	}
 	_, err := channel.ProposePayment(110)
@@ -650,8 +668,10 @@ func TestChannel_ConfirmPayment_responderCannotProposePaymentThatIsUnderfunded(t
 	// payment changes the balance in the favor of the remote.
 	channel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Details: CloseAgreementDetails{
-			IterationNumber: 1,
-			Balance:         -60, // Local (responder) owes remote (initiator) 60.
+			IterationNumber:            1,
+			Balance:                    -60, // Local (responder) owes remote (initiator) 60.
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
 		},
 	}
 	_, err := channel.ProposePayment(110)

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -894,14 +894,14 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfAfterCoordinatedClose(t *testi
 	_, err = senderChannel.ConfirmClose(ca)
 	require.NoError(t, err)
 
-	// After a confirmed coordinated close proposing a payment should error
+	// After a confirmed coordinated close proposing a payment should error.
 	_, err = senderChannel.ProposePayment(10)
 	require.EqualError(t, err, "cannot propose payment after an accepted coordinated close")
 
 	_, err = receiverChannel.ProposePayment(10)
 	require.EqualError(t, err, "cannot propose payment after an accepted coordinated close")
 
-	// After a confirmed coordinated close confirming a payment should error
+	// After a confirmed coordinated close confirming a payment should error.
 	p := CloseAgreement{
 		Details: CloseAgreementDetails{
 			ObservationPeriodTime:      0,

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -714,15 +714,21 @@ func TestLastConfirmedPayment(t *testing.T) {
 		RemoteEscrowAccount: localEscrowAccount,
 	})
 
-	// latest close agreement should be set during open steps
-	sendingChannel.openAgreement = OpenAgreement{
-		Details: OpenAgreementDetails{
-			Asset: NativeAsset,
+	// // latest close agreement should be set during open steps
+	sendingChannel.latestAuthorizedCloseAgreement = CloseAgreement{
+		Details: CloseAgreementDetails{
+			IterationNumber:            1,
+			Balance:                    0,
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
 		},
 	}
-	receiverChannel.openAgreement = OpenAgreement{
-		Details: OpenAgreementDetails{
-			Asset: NativeAsset,
+	receiverChannel.latestAuthorizedCloseAgreement = CloseAgreement{
+		Details: CloseAgreementDetails{
+			IterationNumber:            1,
+			Balance:                    0,
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
 		},
 	}
 
@@ -737,8 +743,10 @@ func TestLastConfirmedPayment(t *testing.T) {
 	// Confirming a close agreement with same sequence number but different Amount should error
 	caDifferent := CloseAgreement{
 		Details: CloseAgreementDetails{
-			IterationNumber: 1,
-			Balance:         400,
+			IterationNumber:            2,
+			Balance:                    400,
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
 		},
 		DeclarationSignatures: ca.DeclarationSignatures,
 		CloseSignatures:       ca.CloseSignatures,
@@ -829,6 +837,23 @@ func TestChannel_ConfirmPayment_checkForExtraSignatures(t *testing.T) {
 		LocalEscrowAccount:  remoteEscrowAccount,
 		RemoteEscrowAccount: localEscrowAccount,
 	})
+
+	senderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
+		Details: CloseAgreementDetails{
+			IterationNumber:            1,
+			Balance:                    0,
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
+		},
+	}
+	receiverChannel.latestAuthorizedCloseAgreement = CloseAgreement{
+		Details: CloseAgreementDetails{
+			IterationNumber:            1,
+			Balance:                    0,
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
+		},
+	}
 
 	ca, err := senderChannel.ProposePayment(10)
 	require.NoError(t, err)


### PR DESCRIPTION
**WHAT**
in ProposePayment and ConfirmPayment check to see if there's an accepted coordinated close , and if so don't allow new payments

**WHY**
with a fully signed coordinated close a participant could submit a C_i/D_i near instantly, which invalidates later payments

closes https://github.com/stellar/experimental-payment-channels/issues/107