### PR TITLE
sdk/state: check ConfirmingSigner isn't nil

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -134,7 +134,7 @@ func (c *Channel) validateClose(ca CloseAgreement) error {
 	if ca.Details.ObservationPeriodLedgerGap != 0 {
 		return fmt.Errorf("close agreement observation period ledger gap is not zero")
 	}
-	if ca.Details.ConfirmingSigner.Address() != c.localSigner.Address() &&
+	if ca.Details.ConfirmingSigner != nil && ca.Details.ConfirmingSigner.Address() != c.localSigner.Address() &&
 		ca.Details.ConfirmingSigner.Address() != c.remoteSigner.Address() {
 		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ca.Details.ConfirmingSigner.Address())
 	}

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -107,7 +107,7 @@ func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && !ca.Details.Equal(c.latestUnauthorizedCloseAgreement.Details) {
 		return fmt.Errorf("close agreement does not match the close agreement already in progress")
 	}
-	if ca.Details.ConfirmingSigner.Address() != c.localSigner.Address() &&
+	if ca.Details.ConfirmingSigner != nil && ca.Details.ConfirmingSigner.Address() != c.localSigner.Address() &&
 		ca.Details.ConfirmingSigner.Address() != c.remoteSigner.Address() {
 		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ca.Details.ConfirmingSigner.Address())
 	}


### PR DESCRIPTION
**WHAT**
in close and payment check that the given close agreement doesn't have a nil `ConfirmingSigner` before checking it

**WHY**
otherwise the check throws a runtime error if the other party gives you a close agreement with an empty `ConfirmingSigner`

ran into this while working on https://github.com/stellar/experimental-payment-channels/pull/197