### PR TITLE
sdk/state: simplify some equal funcs using new stellar/go funcs

### DIFF
--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -24,9 +24,7 @@ func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
 		d.ObservationPeriodLedgerGap == d2.ObservationPeriodLedgerGap &&
 		d.Asset == d2.Asset &&
 		d.ExpiresAt.Equal(d2.ExpiresAt) &&
-		((d.ConfirmingSigner == nil && d2.ConfirmingSigner == nil) ||
-			(d.ConfirmingSigner != nil && d2.ConfirmingSigner != nil &&
-				d.ConfirmingSigner.Address() == d2.ConfirmingSigner.Address()))
+		d.ConfirmingSigner.Equal(d2.ConfirmingSigner)
 }
 
 type OpenAgreement struct {

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -28,7 +28,7 @@ type CloseAgreementDetails struct {
 func (d CloseAgreementDetails) Equal(d2 CloseAgreementDetails) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
 	type CAD CloseAgreementDetails
-	return cmp.Equal(CAD(d), CAD(d2), cmp.AllowUnexported(keypair.FromAddress{}))
+	return cmp.Equal(CAD(d), CAD(d2))
 }
 
 // CloseAgreement contains everything a participant needs to execute the close
@@ -46,7 +46,7 @@ func (ca CloseAgreement) isEmpty() bool {
 func (ca CloseAgreement) Equal(ca2 CloseAgreement) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
 	type CA CloseAgreement
-	return cmp.Equal(CA(ca), CA(ca2), cmp.AllowUnexported(keypair.FromAddress{}))
+	return cmp.Equal(CA(ca), CA(ca2))
 }
 
 func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {


### PR DESCRIPTION
### What
Use the new Equal funcs that were added to the keypair package in the stellar/go repo for comparing keypairs.

### Why
To simplify difficult to read code.