### PR TITLE
sdk/state: use keypair Equal in more places

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -140,8 +140,7 @@ func (c *Channel) validateClose(ca CloseAgreement) error {
 	if ca.Details.ObservationPeriodLedgerGap != 0 {
 		return fmt.Errorf("close agreement observation period ledger gap is not zero")
 	}
-	if ca.Details.ConfirmingSigner != nil && ca.Details.ConfirmingSigner.Address() != c.localSigner.Address() &&
-		ca.Details.ConfirmingSigner.Address() != c.remoteSigner.Address() {
+	if !ca.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) && !ca.Details.ConfirmingSigner.Equal(c.remoteSigner) {
 		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ca.Details.ConfirmingSigner.Address())
 	}
 	return nil

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -133,8 +133,7 @@ func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && !ca.Details.Equal(c.latestUnauthorizedCloseAgreement.Details) {
 		return fmt.Errorf("close agreement does not match the close agreement already in progress")
 	}
-	if ca.Details.ConfirmingSigner != nil && ca.Details.ConfirmingSigner.Address() != c.localSigner.Address() &&
-		ca.Details.ConfirmingSigner.Address() != c.remoteSigner.Address() {
+	if !ca.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) && !ca.Details.ConfirmingSigner.Equal(c.remoteSigner) {
 		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ca.Details.ConfirmingSigner.Address())
 	}
 	return nil


### PR DESCRIPTION
### What
Use keypair.Equal in more places rather than do manual comparisons.

### Why
I updated how we compare keypairs in some places in #205 and missed these other two places.

Note that the keypair.Equal function safely handles the case when the left-hand-side or right-hand-side are nil, so there is no need for the nil checks anymore either.