### PR TITLE
sdk/state: refactor signatures

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -54,7 +54,7 @@ func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (t
 }
 
 // CloseTxs builds the declaration and close transactions used for closing the
-// channel using the latest close agreement. The transaction are signed and
+// channel using the latest close agreement. The transactions are signed and
 // ready to submit.
 func (c *Channel) CloseTxs() (declTx *txnbuild.Transaction, closeTx *txnbuild.Transaction, err error) {
 	ca := c.latestAuthorizedCloseAgreement

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -57,40 +57,27 @@ func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (t
 // channel using the latest close agreement. The transaction are signed and
 // ready to submit.
 func (c *Channel) CloseTxs() (declTx *txnbuild.Transaction, closeTx *txnbuild.Transaction, err error) {
-	closeAgreement := c.latestAuthorizedCloseAgreement
-	declTx, closeTx, err = c.closeTxs(c.openAgreement.Details, closeAgreement.Details)
+	ca := c.latestAuthorizedCloseAgreement
+	declTx, closeTx, err = c.closeTxs(c.openAgreement.Details, ca.Details)
 	if err != nil {
 		return nil, nil, fmt.Errorf("building declaration and close txs for latest close agreement: %w", err)
 	}
 
-	declTx, err = declTx.AddSignatureDecorated(closeAgreement.DeclarationSignatures...)
-	if err != nil {
-		return nil, nil, fmt.Errorf("attaching signatures to declaration tx for latest close agreement: %w", err)
-	}
-	for _, s := range closeAgreement.CloseSignatures {
-		var signed bool
-		signed, err = c.verifySigned(closeTx, []xdr.DecoratedSignature{s}, closeAgreement.Details.ConfirmingSigner)
-		if err != nil {
-			return nil, nil, fmt.Errorf("finding signatures of confirming signer of close tx for declaration tx for latest close agreement: %w", err)
-		}
-		if signed {
-			var closeTxHash [32]byte
-			closeTxHash, err = closeTx.Hash(c.networkPassphrase)
-			if err != nil {
-				return nil, nil, fmt.Errorf("hashing close tx for including payload sig in declaration tx: %w", err)
-			}
-			payloadSig := xdr.NewDecoratedSignatureForPayload(s.Signature, s.Hint, closeTxHash[:])
-			declTx, err = declTx.AddSignatureDecorated(payloadSig)
-			if err != nil {
-				return nil, nil, fmt.Errorf("attaching signatures to declaration tx for latest close agreement: %w", err)
-			}
-		}
-	}
+	// Add the declaration signatures to the declaration tx.
+	declTx, _ = declTx.AddSignatureDecorated(xdr.NewDecoratedSignature(ca.ProposerSignatures.Declaration, ca.Details.ProposingSigner.Hint()))
+	declTx, _ = declTx.AddSignatureDecorated(xdr.NewDecoratedSignature(ca.ConfirmerSignatures.Declaration, ca.Details.ConfirmingSigner.Hint()))
 
-	closeTx, err = closeTx.AddSignatureDecorated(closeAgreement.CloseSignatures...)
+	// Add the close signature provided by the confirming signer that is
+	// required to be an extra signer on the declaration tx to the formation tx.
+	closeTxHash, err := closeTx.Hash(c.networkPassphrase)
 	if err != nil {
-		return nil, nil, fmt.Errorf("attaching signatures to close tx for latest close agreement: %w", err)
+		return nil, nil, fmt.Errorf("hashing close tx for including payload sig in declaration tx: %w", err)
 	}
+	declTx, _ = declTx.AddSignatureDecorated(xdr.NewDecoratedSignatureForPayload(ca.ConfirmerSignatures.Close, ca.Details.ConfirmingSigner.Hint(), closeTxHash[:]))
+
+	// Add the close signatures to the close tx.
+	closeTx, _ = closeTx.AddSignatureDecorated(xdr.NewDecoratedSignature(ca.ProposerSignatures.Close, ca.Details.ProposingSigner.Hint()))
+	closeTx, _ = closeTx.AddSignatureDecorated(xdr.NewDecoratedSignature(ca.ConfirmerSignatures.Close, ca.Details.ConfirmingSigner.Hint()))
 
 	return
 }
@@ -109,20 +96,15 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("making declaration and close transactions: %w", err)
 	}
-	txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
+	sigs, err := signCloseAgreementTxs(txDecl, txClose, c.networkPassphrase, c.localSigner)
 	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("signing declaration transaction: %w", err)
-	}
-	txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
-	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("signing close transaction: %w", err)
+		return CloseAgreement{}, fmt.Errorf("signing open agreement with local: %w", err)
 	}
 
 	// Store the close agreement while participants iterate on signatures.
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{
-		Details:               d,
-		CloseSignatures:       txClose.Signatures(),
-		DeclarationSignatures: txDecl.Signatures(),
+		Details: d,
+		ProposerSignatures: sigs,
 	}
 	return c.latestUnauthorizedCloseAgreement, nil
 }
@@ -161,59 +143,36 @@ func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement
 		return CloseAgreement{}, fmt.Errorf("making close transactions: %w", err)
 	}
 
-	// If remote has not signed, error as is invalid.
-	signed, err := c.verifySigned(txClose, ca.CloseSignatures, c.remoteSigner)
+	// If remote has not signed the txs, error as is invalid.
+	remoteSigs := ca.SignaturesFor(c.remoteSigner)
+	if remoteSigs == nil {
+		return CloseAgreement{}, fmt.Errorf("remote is not a signer")
+	}
+	err = remoteSigs.Verify(txDecl, txClose, c.networkPassphrase, c.remoteSigner)
 	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("verifying close signature with remote: %w", err)
-	}
-	if !signed {
-		return CloseAgreement{}, fmt.Errorf("verifying close: not signed by remote")
-	}
-	signed, err = c.verifySigned(txDecl, ca.DeclarationSignatures, c.remoteSigner)
-	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("verifying declaration signed by remote: %w", err)
-	}
-	if !signed {
-		return CloseAgreement{}, fmt.Errorf("verifying declaration signed by remote: not signed by remote")
+		return CloseAgreement{}, fmt.Errorf("not signed by remote: %w", err)
 	}
 
-	// If local has not signed, sign.
-	signed, err = c.verifySigned(txClose, ca.CloseSignatures, c.localSigner)
+	// If local has not signed close, check that the payment is not to the proposer, then sign.
+	localSigs := ca.SignaturesFor(c.localSigner.FromAddress())
+	if localSigs == nil {
+		return CloseAgreement{}, fmt.Errorf("local is not a signer")
+	}
+	err = localSigs.Verify(txDecl, txClose, c.networkPassphrase, c.localSigner.FromAddress())
 	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("verifying close signature with local: %w", err)
-	}
-	if !signed {
-		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
-		if err != nil {
-			return CloseAgreement{}, fmt.Errorf("signing close transaction: %w", err)
+		// If the local is not the confirmer, do not sign, because being the
+		// proposer they should have signed earlier.
+		if !ca.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) {
+			return CloseAgreement{}, fmt.Errorf("not signed by local: %w", err)
 		}
-		ca.CloseSignatures = append(ca.CloseSignatures, txClose.Signatures()...)
-	}
-	signed, err = c.verifySigned(txDecl, ca.DeclarationSignatures, c.localSigner)
-	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("verifying declaration signature with local: %w", err)
-	}
-	if !signed {
-		txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
+		ca.ConfirmerSignatures, err = signCloseAgreementTxs(txDecl, txClose, c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return CloseAgreement{}, fmt.Errorf("signing declaration transaction: %w", err)
+			return CloseAgreement{}, fmt.Errorf("local signing: %w", err)
 		}
-		ca.DeclarationSignatures = append(ca.DeclarationSignatures, txDecl.Signatures()...)
-	}
-
-	// If the agreement has extra signatures, error.
-	if len(ca.DeclarationSignatures) > 2 || len(ca.CloseSignatures) > 2 {
-		return CloseAgreement{}, fmt.Errorf("close agreement has too many signatures,"+
-			" has declaration: %d, close: %d, max of 2 allowed for each",
-			len(ca.DeclarationSignatures), len(ca.CloseSignatures))
 	}
 
 	// The new close agreement is valid and authorized, store and promote it.
-	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details:               ca.Details,
-		CloseSignatures:       ca.CloseSignatures,
-		DeclarationSignatures: ca.DeclarationSignatures,
-	}
+	c.latestAuthorizedCloseAgreement = ca
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}
 	return c.latestAuthorizedCloseAgreement, nil
 }

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -90,6 +90,7 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 	d := c.latestAuthorizedCloseAgreement.Details
 	d.ObservationPeriodTime = 0
 	d.ObservationPeriodLedgerGap = 0
+	d.ProposingSigner = c.localSigner.FromAddress()
 	d.ConfirmingSigner = c.remoteSigner
 
 	txDecl, txClose, err := c.closeTxs(c.openAgreement.Details, d)

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -104,7 +104,7 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 
 	// Store the close agreement while participants iterate on signatures.
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{
-		Details: d,
+		Details:            d,
 		ProposerSignatures: sigs,
 	}
 	return c.latestUnauthorizedCloseAgreement, nil

--- a/sdk/state/close_test.go
+++ b/sdk/state/close_test.go
@@ -45,60 +45,33 @@ func TestChannel_CloseTx(t *testing.T) {
 			ObservationPeriodLedgerGap: 2,
 			IterationNumber:            3,
 			Balance:                    4,
+			ProposingSigner:            localSigner.FromAddress(),
 			ConfirmingSigner:           remoteSigner.FromAddress(),
 		},
-		DeclarationSignatures: []xdr.DecoratedSignature{{Hint: [4]byte{0, 0, 0, 0}, Signature: []byte{0}}},
-		CloseSignatures:       []xdr.DecoratedSignature{{Hint: [4]byte{1, 1, 1, 1}, Signature: []byte{1}}},
+		ProposerSignatures: CloseAgreementSignatures{
+			Declaration: xdr.Signature{0},
+			Close:       xdr.Signature{1},
+		},
+		ConfirmerSignatures: CloseAgreementSignatures{
+			Declaration: xdr.Signature{2},
+			Close:       xdr.Signature{3},
+		},
 	}
 
 	declTx, closeTx, err := channel.CloseTxs()
 	require.NoError(t, err)
+	closeTxHash, err := closeTx.Hash(channel.networkPassphrase)
+	require.NoError(t, err)
 	// TODO: Compare the non-signature parts of the txs with the result of
 	// channel.closeTxs() when there is an practical way of doing that added to
 	// txnbuild.
-	assert.Equal(t, []xdr.DecoratedSignature{{Hint: [4]byte{0, 0, 0, 0}, Signature: []byte{0}}}, declTx.Signatures())
-	assert.Equal(t, []xdr.DecoratedSignature{{Hint: [4]byte{1, 1, 1, 1}, Signature: []byte{1}}}, closeTx.Signatures())
-}
-
-func TestChannel_ConfirmClose_checksForExtraSignatures(t *testing.T) {
-	localSigner := keypair.MustRandom()
-	remoteSigner := keypair.MustRandom()
-	localEscrowAccount := &EscrowAccount{
-		Address:        keypair.MustRandom().FromAddress(),
-		SequenceNumber: int64(101),
-	}
-	remoteEscrowAccount := &EscrowAccount{
-		Address:        keypair.MustRandom().FromAddress(),
-		SequenceNumber: int64(202),
-	}
-
-	senderChannel := NewChannel(Config{
-		NetworkPassphrase:   network.TestNetworkPassphrase,
-		Initiator:           true,
-		LocalSigner:         localSigner,
-		RemoteSigner:        remoteSigner.FromAddress(),
-		LocalEscrowAccount:  localEscrowAccount,
-		RemoteEscrowAccount: remoteEscrowAccount,
-	})
-	responderChannel := NewChannel(Config{
-		NetworkPassphrase:   network.TestNetworkPassphrase,
-		Initiator:           false,
-		LocalSigner:         remoteSigner,
-		RemoteSigner:        localSigner.FromAddress(),
-		LocalEscrowAccount:  remoteEscrowAccount,
-		RemoteEscrowAccount: localEscrowAccount,
-	})
-
-	ca, err := senderChannel.ProposeClose()
-	require.NoError(t, err)
-
-	// Adding extra signature should cause error
-	ca.CloseSignatures = append(ca.CloseSignatures, xdr.DecoratedSignature{Signature: randomByteArray(t, 10)})
-	_, err = responderChannel.ConfirmClose(ca)
-	require.EqualError(t, err, "close agreement has too many signatures, has declaration: 2, close: 3, max of 2 allowed for each")
-
-	// Remove extra signature, now should succeed
-	ca.CloseSignatures = ca.CloseSignatures[0:1]
-	_, err = responderChannel.ConfirmClose(ca)
-	require.NoError(t, err)
+	assert.ElementsMatch(t, []xdr.DecoratedSignature{
+		{Hint: localSigner.Hint(), Signature: []byte{0}},
+		{Hint: remoteSigner.Hint(), Signature: []byte{2}},
+		xdr.NewDecoratedSignatureForPayload([]byte{3}, remoteSigner.Hint(), closeTxHash[:]),
+	}, declTx.Signatures())
+	assert.ElementsMatch(t, []xdr.DecoratedSignature{
+		{Hint: localSigner.Hint(), Signature: []byte{1}},
+		{Hint: remoteSigner.Hint(), Signature: []byte{3}},
+	}, closeTx.Signatures())
 }

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -58,23 +58,30 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 		ExpiresAt:                  time.Now().Add(formationExpiry),
 	})
 	require.NoError(t, err)
-	assert.Len(t, open.CloseSignatures, 1)
-	assert.Len(t, open.DeclarationSignatures, 1)
-	assert.Len(t, open.FormationSignatures, 1)
+	assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+	assert.NotEmpty(t, open.ProposerSignatures.Close)
+	assert.NotEmpty(t, open.ProposerSignatures.Formation)
+	assert.Empty(t, open.ConfirmerSignatures)
 	{
 		// R signs, R is done
 		open, err = responderChannel.ConfirmOpen(open)
 		require.NoError(t, err)
-		assert.Len(t, open.CloseSignatures, 2)
-		assert.Len(t, open.DeclarationSignatures, 2)
-		assert.Len(t, open.FormationSignatures, 2)
+		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
 
 		// I receives the signatures, I is done
 		open, err = initiatorChannel.ConfirmOpen(open)
 		require.NoError(t, err)
-		assert.Len(t, open.CloseSignatures, 2)
-		assert.Len(t, open.DeclarationSignatures, 2)
-		assert.Len(t, open.FormationSignatures, 2)
+		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
 	}
 
 	{
@@ -291,23 +298,30 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 		ExpiresAt:                  time.Now().Add(formationExpiry),
 	})
 	require.NoError(t, err)
-	assert.Len(t, open.CloseSignatures, 1)
-	assert.Len(t, open.DeclarationSignatures, 1)
-	assert.Len(t, open.FormationSignatures, 1)
+	assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+	assert.NotEmpty(t, open.ProposerSignatures.Close)
+	assert.NotEmpty(t, open.ProposerSignatures.Formation)
+	assert.Empty(t, open.ConfirmerSignatures)
 	{
 		// R signs, R is done
 		open, err = responderChannel.ConfirmOpen(open)
 		require.NoError(t, err)
-		assert.Len(t, open.CloseSignatures, 2)
-		assert.Len(t, open.DeclarationSignatures, 2)
-		assert.Len(t, open.FormationSignatures, 2)
+		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
 
 		// I stores the signatures, I is done.
 		open, err = initiatorChannel.ConfirmOpen(open)
 		require.NoError(t, err)
-		assert.Len(t, open.CloseSignatures, 2)
-		assert.Len(t, open.DeclarationSignatures, 2)
-		assert.Len(t, open.FormationSignatures, 2)
+		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
 	}
 
 	{
@@ -464,23 +478,31 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Len(t, open.CloseSignatures, 1)
-	assert.Len(t, open.DeclarationSignatures, 1)
-	assert.Len(t, open.FormationSignatures, 1)
+	assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+	assert.NotEmpty(t, open.ProposerSignatures.Close)
+	assert.NotEmpty(t, open.ProposerSignatures.Formation)
+	assert.Empty(t, open.ConfirmerSignatures)
+
 	{
 		// R signs txClose and txDecl
 		open, err = responderChannel.ConfirmOpen(open)
 		require.NoError(t, err)
-		assert.Len(t, open.CloseSignatures, 2)
-		assert.Len(t, open.DeclarationSignatures, 2)
-		assert.Len(t, open.FormationSignatures, 2)
+		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
 
 		// I receives the signatures, I is done
 		open, err = initiatorChannel.ConfirmOpen(open)
 		require.NoError(t, err)
-		assert.Len(t, open.CloseSignatures, 2)
-		assert.Len(t, open.DeclarationSignatures, 2)
-		assert.Len(t, open.FormationSignatures, 2)
+		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
 	}
 
 	{
@@ -638,23 +660,30 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 	})
 
 	require.NoError(t, err)
-	assert.Len(t, open.CloseSignatures, 1)
-	assert.Len(t, open.DeclarationSignatures, 1)
-	assert.Len(t, open.FormationSignatures, 1)
+	assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+	assert.NotEmpty(t, open.ProposerSignatures.Close)
+	assert.NotEmpty(t, open.ProposerSignatures.Formation)
+	assert.Empty(t, open.ConfirmerSignatures)
 	{
 		// R signs
 		open, err = responderChannel.ConfirmOpen(open)
 		require.NoError(t, err)
-		assert.Len(t, open.CloseSignatures, 2)
-		assert.Len(t, open.DeclarationSignatures, 2)
-		assert.Len(t, open.FormationSignatures, 2)
+		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
 
 		// I receives the signatures, I is done
 		open, err = initiatorChannel.ConfirmOpen(open)
 		require.NoError(t, err)
-		assert.Len(t, open.CloseSignatures, 2)
-		assert.Len(t, open.DeclarationSignatures, 2)
-		assert.Len(t, open.FormationSignatures, 2)
+		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
 	}
 
 	{

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -16,6 +16,7 @@ type OpenAgreementDetails struct {
 	ObservationPeriodLedgerGap int64
 	Asset                      Asset
 	ExpiresAt                  time.Time
+	ProposingSigner            *keypair.FromAddress
 	ConfirmingSigner           *keypair.FromAddress
 }
 
@@ -24,14 +25,52 @@ func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
 		d.ObservationPeriodLedgerGap == d2.ObservationPeriodLedgerGap &&
 		d.Asset == d2.Asset &&
 		d.ExpiresAt.Equal(d2.ExpiresAt) &&
+		d.ProposingSigner.Equal(d2.ProposingSigner) &&
 		d.ConfirmingSigner.Equal(d2.ConfirmingSigner)
 }
 
+type OpenAgreementSignatures struct {
+	Close       xdr.Signature
+	Declaration xdr.Signature
+	Formation   xdr.Signature
+}
+
+func signOpenAgreementTxs(decl, close, formation *txnbuild.Transaction, networkPassphrase string, signer *keypair.Full) (s OpenAgreementSignatures, err error) {
+	s.Declaration, err = signTx(decl, networkPassphrase, signer)
+	if err != nil {
+		return OpenAgreementSignatures{}, fmt.Errorf("signing declaration: %w", err)
+	}
+	s.Close, err = signTx(close, networkPassphrase, signer)
+	if err != nil {
+		return OpenAgreementSignatures{}, fmt.Errorf("signing close: %w", err)
+	}
+	s.Formation, err = signTx(formation, networkPassphrase, signer)
+	if err != nil {
+		return OpenAgreementSignatures{}, fmt.Errorf("signing formation: %w", err)
+	}
+	return s, nil
+}
+
+func (s OpenAgreementSignatures) Verify(decl, close, formation *txnbuild.Transaction, networkPassphrase string, signer *keypair.FromAddress) error {
+	err := verifySigned(decl, networkPassphrase, signer, s.Declaration)
+	if err != nil {
+		return fmt.Errorf("verifying declaration signed: %w", err)
+	}
+	err = verifySigned(close, networkPassphrase, signer, s.Close)
+	if err != nil {
+		return fmt.Errorf("verifying close signed: %w", err)
+	}
+	err = verifySigned(formation, networkPassphrase, signer, s.Formation)
+	if err != nil {
+		return fmt.Errorf("verifying formation signed: %w", err)
+	}
+	return nil
+}
+
 type OpenAgreement struct {
-	Details               OpenAgreementDetails
-	CloseSignatures       []xdr.DecoratedSignature
-	DeclarationSignatures []xdr.DecoratedSignature
-	FormationSignatures   []xdr.DecoratedSignature
+	Details             OpenAgreementDetails
+	ProposerSignatures  OpenAgreementSignatures
+	ConfirmerSignatures OpenAgreementSignatures
 }
 
 func (oa OpenAgreement) isEmpty() bool {
@@ -42,6 +81,16 @@ func (oa OpenAgreement) Equal(oa2 OpenAgreement) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
 	type OA OpenAgreement
 	return cmp.Equal(OA(oa), OA(oa2))
+}
+
+func (oa OpenAgreement) SignaturesFor(signer *keypair.FromAddress) *OpenAgreementSignatures {
+	if oa.Details.ProposingSigner.Equal(signer) {
+		return &oa.ProposerSignatures
+	}
+	if oa.Details.ConfirmingSigner.Equal(signer) {
+		return &oa.ConfirmerSignatures
+	}
+	return nil
 }
 
 // OpenParams are the parameters selected by the participant proposing an open channel.
@@ -100,58 +149,32 @@ func (c *Channel) openTxs(d OpenAgreementDetails) (decl, close, formation *txnbu
 // transaction is signed and ready to submit. ProposeOpen and ConfirmOpen must
 // be used prior to prepare an open agreement with the other participant.
 func (c *Channel) OpenTx() (formationTx *txnbuild.Transaction, err error) {
-	openAgreement := c.openAgreement
-	declTx, closeTx, formationTx, err := c.openTxs(openAgreement.Details)
+	oa := c.openAgreement
+	declTx, closeTx, formationTx, err := c.openTxs(oa.Details)
 	if err != nil {
 		return nil, fmt.Errorf("building txs for for open agreement: %w", err)
 	}
+
 	// Add the formation signatures to the formation tx.
-	formationTx, err = formationTx.AddSignatureDecorated(openAgreement.FormationSignatures...)
-	if err != nil {
-		return nil, fmt.Errorf("attaching signatures to formation tx for latest close agreement: %w", err)
-	}
+	formationTx, _ = formationTx.AddSignatureDecorated(xdr.NewDecoratedSignature(oa.ProposerSignatures.Formation, oa.Details.ProposingSigner.Hint()))
+	formationTx, _ = formationTx.AddSignatureDecorated(xdr.NewDecoratedSignature(oa.ConfirmerSignatures.Formation, oa.Details.ConfirmingSigner.Hint()))
+
 	// Add the declaration signature provided by the confirming signer that is
 	// required to be an extra signer on the formation tx to the formation tx.
-	for _, s := range openAgreement.DeclarationSignatures {
-		var signed bool
-		signed, err = c.verifySigned(declTx, []xdr.DecoratedSignature{s}, openAgreement.Details.ConfirmingSigner)
-		if err != nil {
-			return nil, fmt.Errorf("finding signatures of confirming signer of declaration tx for formation tx: %w", err)
-		}
-		if signed {
-			var declTxHash [32]byte
-			declTxHash, err = declTx.Hash(c.networkPassphrase)
-			if err != nil {
-				return nil, fmt.Errorf("hashing declaration tx for including payload sig in formation tx: %w", err)
-			}
-			payloadSig := xdr.NewDecoratedSignatureForPayload(s.Signature, s.Hint, declTxHash[:])
-			formationTx, err = formationTx.AddSignatureDecorated(payloadSig)
-			if err != nil {
-				return nil, fmt.Errorf("attaching signatures to formation tx for open agreement: %w", err)
-			}
-		}
+	declTxHash, err := declTx.Hash(c.networkPassphrase)
+	if err != nil {
+		return nil, fmt.Errorf("hashing declaration tx for including payload sig in formation tx: %w", err)
 	}
+	formationTx, _ = formationTx.AddSignatureDecorated(xdr.NewDecoratedSignatureForPayload(oa.ConfirmerSignatures.Declaration, oa.Details.ConfirmingSigner.Hint(), declTxHash[:]))
+
 	// Add the close signature provided by the confirming signer that is
 	// required to be an extra signer on the formation tx to the formation tx.
-	for _, s := range openAgreement.CloseSignatures {
-		var signed bool
-		signed, err = c.verifySigned(closeTx, []xdr.DecoratedSignature{s}, openAgreement.Details.ConfirmingSigner)
-		if err != nil {
-			return nil, fmt.Errorf("finding signatures of confirming signer of close tx for formation tx: %w", err)
-		}
-		if signed {
-			var closeTxHash [32]byte
-			closeTxHash, err = closeTx.Hash(c.networkPassphrase)
-			if err != nil {
-				return nil, fmt.Errorf("hashing close tx for including payload sig in formation tx: %w", err)
-			}
-			payloadSig := xdr.NewDecoratedSignatureForPayload(s.Signature, s.Hint, closeTxHash[:])
-			formationTx, err = formationTx.AddSignatureDecorated(payloadSig)
-			if err != nil {
-				return nil, fmt.Errorf("attaching signatures to formation tx for open agreement: %w", err)
-			}
-		}
+	closeTxHash, err := closeTx.Hash(c.networkPassphrase)
+	if err != nil {
+		return nil, fmt.Errorf("hashing close tx for including payload sig in formation tx: %w", err)
 	}
+	formationTx, _ = formationTx.AddSignatureDecorated(xdr.NewDecoratedSignatureForPayload(oa.ConfirmerSignatures.Close, oa.Details.ConfirmingSigner.Hint(), closeTxHash[:]))
+
 	return
 }
 
@@ -165,6 +188,7 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 		ObservationPeriodLedgerGap: p.ObservationPeriodLedgerGap,
 		Asset:                      p.Asset,
 		ExpiresAt:                  p.ExpiresAt,
+		ProposingSigner:            c.localSigner.FromAddress(),
 		ConfirmingSigner:           c.remoteSigner,
 	}
 
@@ -172,23 +196,13 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 	if err != nil {
 		return OpenAgreement{}, err
 	}
-	txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
+	sigs, err := signOpenAgreementTxs(txDecl, txClose, txFormation, c.networkPassphrase, c.localSigner)
 	if err != nil {
-		return OpenAgreement{}, err
-	}
-	txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
-	if err != nil {
-		return OpenAgreement{}, err
-	}
-	txFormation, err = txFormation.Sign(c.networkPassphrase, c.localSigner)
-	if err != nil {
-		return OpenAgreement{}, err
+		return OpenAgreement{}, fmt.Errorf("signing open agreement with local: %w", err)
 	}
 	open := OpenAgreement{
-		Details:               d,
-		CloseSignatures:       txClose.Signatures(),
-		DeclarationSignatures: txDecl.Signatures(),
-		FormationSignatures:   txFormation.Signatures(),
+		Details:            d,
+		ProposerSignatures: sigs,
 	}
 	c.openAgreement = open
 	return open, nil
@@ -226,68 +240,31 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 	}
 
 	// If remote has not signed the txs, error as is invalid.
-	signed, err := c.verifySigned(txClose, m.CloseSignatures, c.remoteSigner)
+	remoteSigs := m.SignaturesFor(c.remoteSigner)
+	if remoteSigs == nil {
+		return OpenAgreement{}, fmt.Errorf("remote is not a signer")
+	}
+	err = remoteSigs.Verify(txDecl, txClose, formation, c.networkPassphrase, c.remoteSigner)
 	if err != nil {
-		return OpenAgreement{}, fmt.Errorf("verifying close signed by remote: %w", err)
-	}
-	if !signed {
-		return OpenAgreement{}, fmt.Errorf("verifying close signed by remote: not signed by remote")
-	}
-	signed, err = c.verifySigned(txDecl, m.DeclarationSignatures, c.remoteSigner)
-	if err != nil {
-		return OpenAgreement{}, fmt.Errorf("verifying declaration with remote: %w", err)
-	}
-	if !signed {
-		return OpenAgreement{}, fmt.Errorf("verifying declaration signed by remote: not signed by remote")
-	}
-	signed, err = c.verifySigned(formation, m.FormationSignatures, c.remoteSigner)
-	if err != nil {
-		return OpenAgreement{}, fmt.Errorf("verifying formation with remote: %w", err)
-	}
-	if !signed {
-		return OpenAgreement{}, fmt.Errorf("verifying formation signed by remote: not signed by remote")
+		return OpenAgreement{}, fmt.Errorf("not signed by remote: %w", err)
 	}
 
 	// If local has not signed the txs, sign them.
-	signed, err = c.verifySigned(txClose, m.CloseSignatures, c.localSigner)
+	localSigs := m.SignaturesFor(c.localSigner.FromAddress())
+	if localSigs == nil {
+		return OpenAgreement{}, fmt.Errorf("remote is not a signer")
+	}
+	err = localSigs.Verify(txDecl, txClose, formation, c.networkPassphrase, c.localSigner.FromAddress())
 	if err != nil {
-		return OpenAgreement{}, fmt.Errorf("verifying close signed by local: %w", err)
-	}
-	if !signed {
-		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
-		if err != nil {
-			return OpenAgreement{}, fmt.Errorf("signing close with local: %w", err)
+		// If the local is not the confirmer, do not sign, because being the
+		// proposer they should have signed earlier.
+		if !m.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) {
+			return OpenAgreement{}, fmt.Errorf("not signed by local: %w", err)
 		}
-		m.CloseSignatures = append(m.CloseSignatures, txClose.Signatures()...)
-	}
-	signed, err = c.verifySigned(txDecl, m.DeclarationSignatures, c.localSigner)
-	if err != nil {
-		return OpenAgreement{}, fmt.Errorf("verifying declaration with local: %w", err)
-	}
-	if !signed {
-		txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
+		m.ConfirmerSignatures, err = signOpenAgreementTxs(txDecl, txClose, formation, c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return OpenAgreement{}, fmt.Errorf("signing declaration with local: decl %w", err)
+			return OpenAgreement{}, fmt.Errorf("local signing: %w", err)
 		}
-		m.DeclarationSignatures = append(m.DeclarationSignatures, txDecl.Signatures()...)
-	}
-	signed, err = c.verifySigned(formation, m.FormationSignatures, c.localSigner)
-	if err != nil {
-		return OpenAgreement{}, fmt.Errorf("verifying formation with local: %w", err)
-	}
-	if !signed {
-		formation, err = formation.Sign(c.networkPassphrase, c.localSigner)
-		if err != nil {
-			return OpenAgreement{}, fmt.Errorf("signing formation with local: %w", err)
-		}
-		m.FormationSignatures = append(m.FormationSignatures, formation.Signatures()...)
-	}
-
-	// If an agreement ever surpasses 2 signatures per tx, error.
-	if len(m.DeclarationSignatures) > 2 || len(m.CloseSignatures) > 2 || len(m.FormationSignatures) > 2 {
-		return OpenAgreement{}, fmt.Errorf("input open agreement has too many signatures,"+
-			" has declaration: %d, close: %d, formation: %d, max of 2 allowed for each",
-			len(m.DeclarationSignatures), len(m.CloseSignatures), len(m.FormationSignatures))
 	}
 
 	// All signatures are present that would be required to submit all
@@ -298,16 +275,22 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 			Balance:                    0,
 			ObservationPeriodTime:      m.Details.ObservationPeriodTime,
 			ObservationPeriodLedgerGap: m.Details.ObservationPeriodLedgerGap,
+			ProposingSigner:            m.Details.ProposingSigner,
 			ConfirmingSigner:           m.Details.ConfirmingSigner,
 		},
-		CloseSignatures:       appendNewSignatures(c.openAgreement.CloseSignatures, m.CloseSignatures),
-		DeclarationSignatures: appendNewSignatures(c.openAgreement.DeclarationSignatures, m.DeclarationSignatures),
+		ProposerSignatures: CloseAgreementSignatures{
+			Declaration: m.ProposerSignatures.Declaration,
+			Close:       m.ProposerSignatures.Close,
+		},
+		ConfirmerSignatures: CloseAgreementSignatures{
+			Declaration: m.ConfirmerSignatures.Declaration,
+			Close:       m.ConfirmerSignatures.Close,
+		},
 	}
 	c.openAgreement = OpenAgreement{
-		Details:               m.Details,
-		CloseSignatures:       appendNewSignatures(c.openAgreement.CloseSignatures, m.CloseSignatures),
-		DeclarationSignatures: appendNewSignatures(c.openAgreement.DeclarationSignatures, m.DeclarationSignatures),
-		FormationSignatures:   appendNewSignatures(c.openAgreement.FormationSignatures, m.FormationSignatures),
+		Details:             m.Details,
+		ProposerSignatures:  m.ProposerSignatures,
+		ConfirmerSignatures: m.ConfirmerSignatures,
 	}
 	return c.openAgreement, nil
 }

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -330,8 +330,9 @@ func TestChannel_OpenTx(t *testing.T) {
 		},
 	}
 
-	declTx, closeTx, formationTx, err := channel.openTxs(channel.openAgreement.Details)
-	formationTx, err = channel.OpenTx()
+	declTx, closeTx, _, err := channel.openTxs(channel.openAgreement.Details)
+	require.NoError(t, err)
+	formationTx, err := channel.OpenTx()
 	require.NoError(t, err)
 	declTxHash, err := declTx.Hash(channel.networkPassphrase)
 	require.NoError(t, err)

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -135,7 +135,7 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 	}
 
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{
-		Details: d,
+		Details:            d,
 		ProposerSignatures: sigs,
 	}
 	return c.latestUnauthorizedCloseAgreement, nil

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 )
 
@@ -22,6 +23,7 @@ type CloseAgreementDetails struct {
 	ObservationPeriodLedgerGap int64
 	IterationNumber            int64
 	Balance                    int64
+	ProposingSigner            *keypair.FromAddress
 	ConfirmingSigner           *keypair.FromAddress
 }
 
@@ -31,12 +33,41 @@ func (d CloseAgreementDetails) Equal(d2 CloseAgreementDetails) bool {
 	return cmp.Equal(CAD(d), CAD(d2))
 }
 
+type CloseAgreementSignatures struct {
+	Close       xdr.Signature
+	Declaration xdr.Signature
+}
+
+func signCloseAgreementTxs(decl, close *txnbuild.Transaction, networkPassphrase string, signer *keypair.Full) (s CloseAgreementSignatures, err error) {
+	s.Declaration, err = signTx(decl, networkPassphrase, signer)
+	if err != nil {
+		return CloseAgreementSignatures{}, fmt.Errorf("signing declaration: %w", err)
+	}
+	s.Close, err = signTx(close, networkPassphrase, signer)
+	if err != nil {
+		return CloseAgreementSignatures{}, fmt.Errorf("signing close: %w", err)
+	}
+	return s, nil
+}
+
+func (s CloseAgreementSignatures) Verify(decl, close *txnbuild.Transaction, networkPassphrase string, signer *keypair.FromAddress) error {
+	err := verifySigned(decl, networkPassphrase, signer, s.Declaration)
+	if err != nil {
+		return fmt.Errorf("verifying declaration signed: %w", err)
+	}
+	err = verifySigned(close, networkPassphrase, signer, s.Close)
+	if err != nil {
+		return fmt.Errorf("verifying close signed: %w", err)
+	}
+	return nil
+}
+
 // CloseAgreement contains everything a participant needs to execute the close
 // agreement on the Stellar network.
 type CloseAgreement struct {
-	Details               CloseAgreementDetails
-	CloseSignatures       []xdr.DecoratedSignature
-	DeclarationSignatures []xdr.DecoratedSignature
+	Details             CloseAgreementDetails
+	ProposerSignatures  CloseAgreementSignatures
+	ConfirmerSignatures CloseAgreementSignatures
 }
 
 func (ca CloseAgreement) isEmpty() bool {
@@ -47,6 +78,16 @@ func (ca CloseAgreement) Equal(ca2 CloseAgreement) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
 	type CA CloseAgreement
 	return cmp.Equal(CA(ca), CA(ca2))
+}
+
+func (ca CloseAgreement) SignaturesFor(signer *keypair.FromAddress) *CloseAgreementSignatures {
+	if ca.Details.ProposingSigner.Equal(signer) {
+		return &ca.ProposerSignatures
+	}
+	if ca.Details.ConfirmingSigner.Equal(signer) {
+		return &ca.ConfirmerSignatures
+	}
+	return nil
 }
 
 func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
@@ -81,25 +122,21 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap,
 		IterationNumber:            c.NextIterationNumber(),
 		Balance:                    newBalance,
+		ProposingSigner:            c.localSigner.FromAddress(),
 		ConfirmingSigner:           c.remoteSigner,
 	}
 	txDecl, txClose, err := c.closeTxs(c.openAgreement.Details, d)
 	if err != nil {
 		return CloseAgreement{}, err
 	}
-	txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
+	sigs, err := signCloseAgreementTxs(txDecl, txClose, c.networkPassphrase, c.localSigner)
 	if err != nil {
-		return CloseAgreement{}, err
-	}
-	txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
-	if err != nil {
-		return CloseAgreement{}, err
+		return CloseAgreement{}, fmt.Errorf("signing open agreement with local: %w", err)
 	}
 
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{
-		Details:               d,
-		CloseSignatures:       txClose.Signatures(),
-		DeclarationSignatures: txDecl.Signatures(),
+		Details: d,
+		ProposerSignatures: sigs,
 	}
 	return c.latestUnauthorizedCloseAgreement, nil
 }
@@ -155,68 +192,46 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	}
 
 	// If remote has not signed the txs, error as is invalid.
-	signed, err := c.verifySigned(txClose, ca.CloseSignatures, c.remoteSigner)
+	remoteSigs := ca.SignaturesFor(c.remoteSigner)
+	if remoteSigs == nil {
+		return CloseAgreement{}, fmt.Errorf("remote is not a signer")
+	}
+	err = remoteSigs.Verify(txDecl, txClose, c.networkPassphrase, c.remoteSigner)
 	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("verifying close signed by remote: %w", err)
-	}
-	if !signed {
-		return CloseAgreement{}, fmt.Errorf("verifying close signed by remote: not signed by remote")
-	}
-	signed, err = c.verifySigned(txDecl, ca.DeclarationSignatures, c.remoteSigner)
-	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("verifying declaration signed by remote: %w", err)
-	}
-	if !signed {
-		return CloseAgreement{}, fmt.Errorf("verifying declaration signed by remote: not signed by remote")
+		return CloseAgreement{}, fmt.Errorf("not signed by remote: %w", err)
 	}
 
 	// If local has not signed close, check that the payment is not to the proposer, then sign.
-	signed, err = c.verifySigned(txClose, ca.CloseSignatures, c.localSigner)
-	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("verifying close signed by local: %w", err)
+	localSigs := ca.SignaturesFor(c.localSigner.FromAddress())
+	if localSigs == nil {
+		return CloseAgreement{}, fmt.Errorf("local is not a signer")
 	}
-	if !signed {
+	err = localSigs.Verify(txDecl, txClose, c.networkPassphrase, c.localSigner.FromAddress())
+	if err != nil {
+		// If the local is not the confirmer, do not sign, because being the
+		// proposer they should have signed earlier.
+		if !ca.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) {
+			return CloseAgreement{}, fmt.Errorf("not signed by local: %w", err)
+		}
+		// If the payment is to the proposer, error, because the payment channel
+		// only supports pushing money to the other participant not pulling.
 		if (c.initiator && ca.Details.Balance > c.latestAuthorizedCloseAgreement.Details.Balance) ||
 			(!c.initiator && ca.Details.Balance < c.latestAuthorizedCloseAgreement.Details.Balance) {
 			return CloseAgreement{}, fmt.Errorf("close agreement is a payment to the proposer")
 		}
+		// If the payment over extends the proposers ability to pay, error.
 		if c.amountToLocal(ca.Details.Balance) > c.remoteEscrowAccount.Balance {
 			return CloseAgreement{}, fmt.Errorf("close agreement over commits: %w", ErrUnderfunded)
 		}
-		txClose, err = txClose.Sign(c.networkPassphrase, c.localSigner)
+		ca.ConfirmerSignatures, err = signCloseAgreementTxs(txDecl, txClose, c.networkPassphrase, c.localSigner)
 		if err != nil {
-			return CloseAgreement{}, fmt.Errorf("signing close with local: %w", err)
+			return CloseAgreement{}, fmt.Errorf("local signing: %w", err)
 		}
-		ca.CloseSignatures = append(ca.CloseSignatures, txClose.Signatures()...)
-	}
-
-	// If local has not signed declaration, sign it.
-	signed, err = c.verifySigned(txDecl, ca.DeclarationSignatures, c.localSigner)
-	if err != nil {
-		return CloseAgreement{}, fmt.Errorf("verifying declaration signed by local: %w", err)
-	}
-	if !signed {
-		txDecl, err = txDecl.Sign(c.networkPassphrase, c.localSigner)
-		if err != nil {
-			return CloseAgreement{}, err
-		}
-		ca.DeclarationSignatures = append(ca.DeclarationSignatures, txDecl.Signatures()...)
-	}
-
-	// If an agreement ever surpasses 2 signatures per tx, error.
-	if len(ca.DeclarationSignatures) > 2 || len(ca.CloseSignatures) > 2 {
-		return CloseAgreement{}, fmt.Errorf("close agreement has too many signatures,"+
-			" has declaration: %d, close: %d, max of 2 allowed for each",
-			len(ca.DeclarationSignatures), len(ca.CloseSignatures))
 	}
 
 	// All signatures are present that would be required to submit all
 	// transactions in the payment.
-	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details:               ca.Details,
-		CloseSignatures:       appendNewSignatures(c.latestUnauthorizedCloseAgreement.CloseSignatures, ca.CloseSignatures),
-		DeclarationSignatures: appendNewSignatures(c.latestUnauthorizedCloseAgreement.DeclarationSignatures, ca.DeclarationSignatures),
-	}
+	c.latestAuthorizedCloseAgreement = ca
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}
 
 	return c.latestAuthorizedCloseAgreement, nil

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
-	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,11 +58,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
@@ -73,11 +69,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			true,
@@ -90,11 +83,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{},
@@ -108,11 +98,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
@@ -122,11 +109,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			false,
@@ -140,11 +124,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
@@ -155,11 +136,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			true,
@@ -173,11 +151,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
@@ -188,11 +163,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GDJ5SXSKKFXINP7TN4J4T4JAXL4VZL7UMIAGZWQTYSKHSNHLSPVOAXRY"),
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			false,
@@ -206,11 +178,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
@@ -221,11 +190,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Balance:                    100,
 					ConfirmingSigner:           nil,
 				},
-				CloseSignatures: []xdr.DecoratedSignature{
-					{
-						Hint:      [4]byte{0, 1, 2, 3},
-						Signature: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-					},
+				ProposerSignatures: CloseAgreementSignatures{
+					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			false,
@@ -274,6 +240,7 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 			IterationNumber:            1,
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
+			ProposingSigner:            remoteSigner.FromAddress(),
 			ConfirmingSigner:           localSigner.FromAddress(),
 		})
 		require.NoError(t, err)
@@ -286,10 +253,13 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 				IterationNumber:            1,
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
+				ProposingSigner:            remoteSigner.FromAddress(),
 				ConfirmingSigner:           localSigner.FromAddress(),
 			},
-			DeclarationSignatures: txDecl.Signatures(),
-			CloseSignatures:       txClose.Signatures(),
+			ProposerSignatures: CloseAgreementSignatures{
+				Declaration: txDecl.Signatures()[0].Signature,
+				Close:       txClose.Signatures()[0].Signature,
+			},
 		})
 		require.NoError(t, err)
 	}
@@ -343,8 +313,10 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 				ObservationPeriodTime:      0,
 				ObservationPeriodLedgerGap: 0,
 			},
-			DeclarationSignatures: txDecl.Signatures(),
-			CloseSignatures:       txClose.Signatures(),
+			ProposerSignatures: CloseAgreementSignatures{
+				Declaration: txDecl.Signatures()[0].Signature,
+				Close:       txClose.Signatures()[0].Signature,
+			},
 		})
 		require.EqualError(t, err, "validating payment: invalid payment observation period: different than channel state")
 	}
@@ -390,6 +362,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
+		ProposingSigner:            remoteSigner.FromAddress(),
 		ConfirmingSigner:           localSigner.FromAddress(),
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
@@ -401,9 +374,11 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
 	_, err = channel.ConfirmPayment(CloseAgreement{
-		Details:               ca,
-		DeclarationSignatures: txDecl.Signatures(),
-		CloseSignatures:       txClose.Signatures(),
+		Details: ca,
+		ProposerSignatures: CloseAgreementSignatures{
+			Declaration: txDecl.Signatures()[0].Signature,
+			Close:       txClose.Signatures()[0].Signature,
+		},
 	})
 	require.EqualError(t, err, "close agreement is a payment to the proposer")
 }
@@ -448,6 +423,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    90, // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
+		ProposingSigner:            remoteSigner.FromAddress(),
 		ConfirmingSigner:           localSigner.FromAddress(),
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
@@ -459,9 +435,11 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
 	_, err = channel.ConfirmPayment(CloseAgreement{
-		Details:               ca,
-		DeclarationSignatures: txDecl.Signatures(),
-		CloseSignatures:       txClose.Signatures(),
+		Details: ca,
+		ProposerSignatures: CloseAgreementSignatures{
+			Declaration: txDecl.Signatures()[0].Signature,
+			Close:       txClose.Signatures()[0].Signature,
+		},
 	})
 	require.EqualError(t, err, "close agreement is a payment to the proposer")
 }
@@ -503,6 +481,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
+		ProposingSigner:            remoteSigner.FromAddress(),
 		ConfirmingSigner:           localSigner.FromAddress(),
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
@@ -514,9 +493,11 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
 	_, err = channel.ConfirmPayment(CloseAgreement{
-		Details:               ca,
-		DeclarationSignatures: txDecl.Signatures(),
-		CloseSignatures:       txClose.Signatures(),
+		Details: ca,
+		ProposerSignatures: CloseAgreementSignatures{
+			Declaration: txDecl.Signatures()[0].Signature,
+			Close:       txClose.Signatures()[0].Signature,
+		},
 	})
 	assert.EqualError(t, err, "close agreement over commits: account is underfunded to make payment")
 	assert.ErrorIs(t, err, ErrUnderfunded)
@@ -524,9 +505,11 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	// The same close payment should pass if the balance has been updated.
 	channel.UpdateRemoteEscrowAccountBalance(200)
 	_, err = channel.ConfirmPayment(CloseAgreement{
-		Details:               ca,
-		DeclarationSignatures: txDecl.Signatures(),
-		CloseSignatures:       txClose.Signatures(),
+		Details: ca,
+		ProposerSignatures: CloseAgreementSignatures{
+			Declaration: txDecl.Signatures()[0].Signature,
+			Close:       txClose.Signatures()[0].Signature,
+		},
 	})
 	assert.NoError(t, err)
 }
@@ -568,6 +551,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
+		ProposingSigner:            remoteSigner.FromAddress(),
 		ConfirmingSigner:           localSigner.FromAddress(),
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
@@ -579,9 +563,11 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
 	_, err = channel.ConfirmPayment(CloseAgreement{
-		Details:               ca,
-		DeclarationSignatures: txDecl.Signatures(),
-		CloseSignatures:       txClose.Signatures(),
+		Details: ca,
+		ProposerSignatures: CloseAgreementSignatures{
+			Declaration: txDecl.Signatures()[0].Signature,
+			Close:       txClose.Signatures()[0].Signature,
+		},
 	})
 	assert.EqualError(t, err, "close agreement over commits: account is underfunded to make payment")
 	assert.ErrorIs(t, err, ErrUnderfunded)
@@ -589,9 +575,11 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	// The same close payment should pass if the balance has been updated.
 	channel.UpdateRemoteEscrowAccountBalance(200)
 	_, err = channel.ConfirmPayment(CloseAgreement{
-		Details:               ca,
-		DeclarationSignatures: txDecl.Signatures(),
-		CloseSignatures:       txClose.Signatures(),
+		Details: ca,
+		ProposerSignatures: CloseAgreementSignatures{
+			Declaration: txDecl.Signatures()[0].Signature,
+			Close:       txClose.Signatures()[0].Signature,
+		},
 	})
 	assert.NoError(t, err)
 }
@@ -748,8 +736,8 @@ func TestLastConfirmedPayment(t *testing.T) {
 			ObservationPeriodTime:      10,
 			ObservationPeriodLedgerGap: 10,
 		},
-		DeclarationSignatures: ca.DeclarationSignatures,
-		CloseSignatures:       ca.CloseSignatures,
+		ProposerSignatures:  ca.ProposerSignatures,
+		ConfirmerSignatures: ca.ConfirmerSignatures,
 	}
 	_, err = sendingChannel.ConfirmPayment(caDifferent)
 	require.EqualError(t, err, "validating payment: close agreement does not match the close agreement already in progress")
@@ -763,120 +751,11 @@ func TestLastConfirmedPayment(t *testing.T) {
 	assert.Equal(t, caFinal, caResponse)
 }
 
-func TestAppendNewSignature(t *testing.T) {
-	closeSignatures := []xdr.DecoratedSignature{
-		{Signature: randomByteArray(t, 10)},
-		{Signature: randomByteArray(t, 10)},
-	}
-
-	closeSignaturesToAppend := []xdr.DecoratedSignature{
-		closeSignatures[0], // A duplicate signature is included.
-		{Signature: randomByteArray(t, 10)},
-	}
-
-	newCloseSignatures := appendNewSignatures(closeSignatures, closeSignaturesToAppend)
-
-	// Check that the final slice of signatures does not contain the duplicate.
-	assert.ElementsMatch(
-		t,
-		newCloseSignatures,
-		[]xdr.DecoratedSignature{
-			closeSignatures[0],
-			closeSignatures[1],
-			closeSignaturesToAppend[1],
-		},
-	)
-
-	// Check existing signatures are not lost.
-	newCloseSignatures = appendNewSignatures(closeSignatures, []xdr.DecoratedSignature{})
-
-	assert.ElementsMatch(
-		t,
-		newCloseSignatures,
-		[]xdr.DecoratedSignature{
-			closeSignatures[0],
-			closeSignatures[1],
-		},
-	)
-}
-
 func randomByteArray(t *testing.T, length int) []byte {
 	arr := make([]byte, length)
 	_, err := rand.Read(arr)
 	require.NoError(t, err)
 	return arr
-}
-
-func TestChannel_ConfirmPayment_checkForExtraSignatures(t *testing.T) {
-	localSigner := keypair.MustRandom()
-	remoteSigner := keypair.MustRandom()
-	localEscrowAccount := &EscrowAccount{
-		Address:        keypair.MustRandom().FromAddress(),
-		SequenceNumber: int64(101),
-		Balance:        int64(100),
-	}
-	remoteEscrowAccount := &EscrowAccount{
-		Address:        keypair.MustRandom().FromAddress(),
-		SequenceNumber: int64(202),
-		Balance:        int64(100),
-	}
-
-	senderChannel := NewChannel(Config{
-		NetworkPassphrase:   network.TestNetworkPassphrase,
-		Initiator:           true,
-		LocalSigner:         localSigner,
-		RemoteSigner:        remoteSigner.FromAddress(),
-		LocalEscrowAccount:  localEscrowAccount,
-		RemoteEscrowAccount: remoteEscrowAccount,
-	})
-	receiverChannel := NewChannel(Config{
-		NetworkPassphrase:   network.TestNetworkPassphrase,
-		Initiator:           false,
-		LocalSigner:         remoteSigner,
-		RemoteSigner:        localSigner.FromAddress(),
-		LocalEscrowAccount:  remoteEscrowAccount,
-		RemoteEscrowAccount: localEscrowAccount,
-	})
-
-	senderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
-			IterationNumber:            1,
-			Balance:                    0,
-			ObservationPeriodTime:      10,
-			ObservationPeriodLedgerGap: 10,
-		},
-	}
-	receiverChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
-			IterationNumber:            1,
-			Balance:                    0,
-			ObservationPeriodTime:      10,
-			ObservationPeriodLedgerGap: 10,
-		},
-	}
-
-	ca, err := senderChannel.ProposePayment(10)
-	require.NoError(t, err)
-
-	// Adding extra signature should cause error when receiver confirms
-	ca.CloseSignatures = append(ca.CloseSignatures, xdr.DecoratedSignature{Signature: randomByteArray(t, 10)})
-	_, err = receiverChannel.ConfirmPayment(ca)
-	require.EqualError(t, err, "close agreement has too many signatures, has declaration: 2, close: 3, max of 2 allowed for each")
-
-	// Remove extra signature, now should succeed
-	ca.CloseSignatures = ca.CloseSignatures[0:1]
-	ca, err = receiverChannel.ConfirmPayment(ca)
-	require.NoError(t, err)
-
-	// Adding extra signature should cause error when sender confirms
-	ca.DeclarationSignatures = append(ca.DeclarationSignatures, xdr.DecoratedSignature{Signature: randomByteArray(t, 10)})
-	_, err = senderChannel.ConfirmPayment(ca)
-	require.EqualError(t, err, "close agreement has too many signatures, has declaration: 3, close: 2, max of 2 allowed for each")
-
-	// Remove extra signature, now should succeed
-	ca.DeclarationSignatures = ca.DeclarationSignatures[0:2]
-	_, err = senderChannel.ConfirmPayment(ca)
-	require.NoError(t, err)
 }
 
 func TestChannel_ProposeAndConfirmPayment_rejectIfAfterCoordinatedClose(t *testing.T) {

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"math/rand"
 	"strconv"
 	"testing"
 	"time"
@@ -749,13 +748,6 @@ func TestLastConfirmedPayment(t *testing.T) {
 	assert.Equal(t, CloseAgreement{}, sendingChannel.latestUnauthorizedCloseAgreement)
 	assert.Equal(t, caFinal, sendingChannel.latestAuthorizedCloseAgreement)
 	assert.Equal(t, caFinal, caResponse)
-}
-
-func randomByteArray(t *testing.T, length int) []byte {
-	arr := make([]byte, length)
-	_, err := rand.Read(arr)
-	require.NoError(t, err)
-	return arr
 }
 
 func TestChannel_ProposeAndConfirmPayment_rejectIfAfterCoordinatedClose(t *testing.T) {


### PR DESCRIPTION
### What
Refactor how signatures are stored:
- Store the raw signature and not a decorated signature, not storing the hint.
- Store signatures in fields named for their purpose, rather than in a slice.
- Verify and sign in a single block, rather than piece meal.

### Why
Signatures were stored as decorated signature lists because early on it made it simple to add those signatures to a transaction at a later point. That optimization has made it painful to make several changes over the last few weeks, the worst being the implementation of CAP-40 (#190, #189).

The only benefit we got from storing decorated signatures was to speed up looking up signatures in each slice, because we frequently need to only verify a single signature for a single signer. Besides the fact it is unnecessary for us to be optimizing things like that this early in the project, we don't need the signatures stored in a slice, and therefore don't need the optimization. Storing signatures in a field specific for its use simplifies some of our code because we no longer need to go searching for specific signatures.

Decorated signatures are also inconvenient because in reality we can't just append them as they are anymore. Depending on where the signature is being used we must construct decorated signatures differently. This is because the hint of a payload signer is different to that of a regular signer, even for the same signature.

We also won't use decorated signatures when we implement recovery from disclosed signatures on Horizon, because Horizon doesn't public the decorated portion.

The change to sign in a single block is not particularly meaningful, it is just easier to write the signing and verification that way during the refactor.

Unfortunately this change is fundamental, touching many components, and I could not find an elegant way to isolate portions of the change that would be practical in isolation. I tried removing hints without. Thankfully many of the tests, including integration tests, did not need significant changes as they operate at a higher level, which provides some confidence that the change is sound.

Close #201 