### PR TITLE
sdk/state: make integration test horizon url configurable

### DIFF
--- a/sdk/state/integrationtests/main_test.go
+++ b/sdk/state/integrationtests/main_test.go
@@ -10,7 +10,13 @@ import (
 	"github.com/stellar/go/clients/horizonclient"
 )
 
-const horizonURL = "http://localhost:8000"
+var horizonURL = func() string {
+	url := os.Getenv("INTEGRATION_TESTS_HORIZON_URL")
+	if url == "" {
+		url = "http://localhost:8000"
+	}
+	return url
+}()
 
 var (
 	networkPassphrase string


### PR DESCRIPTION
### What
Make the Horizon URL that is used for integration tests configurable.

### Why
A lot of the time, including on CI, the URL being `localhost:8000` works fine. For those of us who use Docker and are hosting the quickstart image's port on the host port on Mac, we need it to be set to `host.docker.internal:8000`. Using an environment variable is a simple low effort solution to make it configurable.