### PR TITLE
sdk/state: remove unused code in test

### DIFF
--- a/sdk/state/ingest_test.go
+++ b/sdk/state/ingest_test.go
@@ -73,7 +73,6 @@ func TestChannel_IngestTx_updateUnauthorizedCloseAgreement(t *testing.T) {
 
 	// The initiator channel and responder channel should have the same close
 	// agreements.
-	initiatorChannel.Balance()
 	assert.Equal(t, int64(8), initiatorChannel.Balance())
 	assert.Equal(t, int64(8), responderChannel.Balance())
 	assert.Equal(t, initiatorChannel.LatestCloseAgreement(), responderChannel.LatestCloseAgreement())


### PR DESCRIPTION
### What
Remove line of code that's result is unused and has no effect.

### Why
@marcelosalloum reported it in #204 but the PR was auto-merged before it could be fixed.