### PR TITLE
sdk/state: enforce only one close agreement open at a time

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -90,6 +90,7 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 	// If an unfinished unauthorized agreement exists, error.
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() {
 		return CloseAgreement{}, fmt.Errorf("cannot propose coordinated close while an unfinished payment exists")
+	}
 
 	// If the channel is not open yet, error.
 	if c.latestAuthorizedCloseAgreement.isEmpty() {

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -87,6 +87,11 @@ func (c *Channel) CloseTxs() (declTx *txnbuild.Transaction, closeTx *txnbuild.Tr
 // are in agreement on the final close state, but would like to submit earlier
 // than the original observation time.
 func (c *Channel) ProposeClose() (CloseAgreement, error) {
+	// If an unfinished unauthorized agreement exists, error.
+	if !c.latestUnauthorizedCloseAgreement.isEmpty() {
+		return CloseAgreement{}, fmt.Errorf("cannot propose coordinated close while an unfinished payment exists")
+	}
+
 	d := c.latestAuthorizedCloseAgreement.Details
 	d.ObservationPeriodTime = 0
 	d.ObservationPeriodLedgerGap = 0

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -107,6 +107,11 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		return CloseAgreement{}, fmt.Errorf("cannot propose payment after proposing a coordinated close")
 	}
 
+	// If an unfinished unauthorized agreement exists, error.
+	if !c.latestUnauthorizedCloseAgreement.isEmpty() {
+		return CloseAgreement{}, fmt.Errorf("cannot start a new payment while an unfinished one exists")
+	}
+
 	newBalance := int64(0)
 	if c.initiator {
 		newBalance = c.Balance() + amount

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -907,6 +907,8 @@ func TestChannel_enforceOnlyOneCloseAgreementAllowed(t *testing.T) {
 	_, err = senderChannel.ProposePayment(10)
 	require.NoError(t, err)
 
+	ucaOriginal := senderChannel.latestUnauthorizedCloseAgreement
+
 	// sender should not be able to propose a second payment until the first is finished
 	_, err = senderChannel.ProposePayment(20)
 	require.EqualError(t, err, "cannot start a new payment while an unfinished one exists")
@@ -917,4 +919,7 @@ func TestChannel_enforceOnlyOneCloseAgreementAllowed(t *testing.T) {
 
 	// sender should still have the original close agreement
 	require.Equal(t, senderChannel.latestAuthorizedCloseAgreement, caOriginal)
+
+	// sender should still have the latestUnauthorizedCloseAgreement
+	require.Equal(t, senderChannel.latestUnauthorizedCloseAgreement, ucaOriginal)
 }

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -901,6 +901,8 @@ func TestChannel_enforceOnlyOneCloseAgreementAllowed(t *testing.T) {
 	_, err = senderChannel.ConfirmOpen(m)
 	require.NoError(t, err)
 
+	caOriginal := senderChannel.latestAuthorizedCloseAgreement
+
 	// sender proposes payment
 	_, err = senderChannel.ProposePayment(10)
 	require.NoError(t, err)
@@ -912,4 +914,7 @@ func TestChannel_enforceOnlyOneCloseAgreementAllowed(t *testing.T) {
 	// sender should not be able to propose coordinated close while unfinished payment exists
 	_, err = senderChannel.ProposeClose()
 	require.EqualError(t, err, "cannot propose coordinated close while an unfinished payment exists")
+
+	// sender should still have the original close agreement
+	require.Equal(t, senderChannel.latestAuthorizedCloseAgreement, caOriginal)
 }


### PR DESCRIPTION
**WHAT**
enforce that only one unauthorized close agreement can exist at a time

**WHY**
currently this edge case exists:
```
A proposes {ca1}
B confirms {ca1}, but doesn't send sigs back to A
A proposes {ca2}, B submits ca1, and A can't finish ca1 because proposing cleared the latest unauthorized
```
by enforcing that A cant propose a {ca2}, which clears its {ca1}, it prevents this edge case and protects A.

closes https://github.com/stellar/experimental-payment-channels/issues/103


note:
- if A wants to close the channel after {ca1}, A would need to do an uncoordinated close, as this change prevents them from proposing a coordinated close which would also clear its unfinished {ca1}.

