### PR TITLE
sdk/state: error if proposing or confirming a payment or close if channel is not open yet

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -87,6 +87,11 @@ func (c *Channel) CloseTxs() (declTx *txnbuild.Transaction, closeTx *txnbuild.Tr
 // are in agreement on the final close state, but would like to submit earlier
 // than the original observation time.
 func (c *Channel) ProposeClose() (CloseAgreement, error) {
+	// If the channel is not open yet, error.
+	if c.latestAuthorizedCloseAgreement.isEmpty() {
+		return CloseAgreement{}, fmt.Errorf("cannot propose a coordinated close before channel is opened")
+	}
+
 	d := c.latestAuthorizedCloseAgreement.Details
 	d.ObservationPeriodTime = 0
 	d.ObservationPeriodLedgerGap = 0
@@ -111,6 +116,10 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 }
 
 func (c *Channel) validateClose(ca CloseAgreement) error {
+	// If the channel is not open yet, error.
+	if c.latestAuthorizedCloseAgreement.isEmpty() {
+		return fmt.Errorf("cannot confirm a coordinated close before channel is opened")
+	}
 	if ca.Details.IterationNumber != c.latestAuthorizedCloseAgreement.Details.IterationNumber {
 		return fmt.Errorf("close agreement iteration number does not match saved latest authorized close agreement")
 	}

--- a/sdk/state/close_test.go
+++ b/sdk/state/close_test.go
@@ -162,5 +162,4 @@ func TestChannel_ProposeAndConfirmCoordinatedClose_rejectIfChannelNotOpen(t *tes
 	// Before open, confirming a coordinated close should error.
 	_, err = senderChannel.ConfirmClose(CloseAgreement{})
 	require.EqualError(t, err, "validating close agreement: cannot confirm a coordinated close before channel is opened")
-
 }

--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// functions to be used in the state_test integration tests
+// functions to be used in the sdk/state/integrationtests integration tests
 
 type AssetParam struct {
 	Asset       state.Asset

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -95,6 +95,11 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		return CloseAgreement{}, fmt.Errorf("payment amount must be greater than 0")
 	}
 
+	// If the channel is not open yet, error.
+	if c.latestAuthorizedCloseAgreement.isEmpty() {
+		return CloseAgreement{}, fmt.Errorf("cannot propose a payment before channel is opened")
+	}
+
 	// If a coordinated close has been accepted already, error.
 	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
 		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
@@ -147,6 +152,11 @@ var ErrUnderfunded = fmt.Errorf("account is underfunded to make payment")
 // there are additional verifications ConfirmPayment performs that are based
 // on the state of the close agreement signatures.
 func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
+	// If the channel is not open yet, error.
+	if c.latestAuthorizedCloseAgreement.isEmpty() {
+		return fmt.Errorf("cannot confirm a payment before channel is opened")
+	}
+
 	// If a coordinated close has been proposed by this channel already, error.
 	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
 		c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -750,7 +750,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 	assert.Equal(t, caFinal, caResponse)
 }
 
-func TestChannel_ProposeAndConfirmPayment_rejectIfAfterCoordinatedClose(t *testing.T) {
+func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 	localSigner := keypair.MustRandom()
 	remoteSigner := keypair.MustRandom()
 	localEscrowAccount := &EscrowAccount{
@@ -782,6 +782,14 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfAfterCoordinatedClose(t *testi
 		LocalEscrowAccount:  remoteEscrowAccount,
 		RemoteEscrowAccount: localEscrowAccount,
 	})
+
+	// Before open, proposing a payment should error.
+	_, err := senderChannel.ProposePayment(10)
+	require.EqualError(t, err, "cannot propose a payment before channel is opened")
+
+	// Before open, confirming a payment should error.
+	_, err = senderChannel.ConfirmPayment(CloseAgreement{})
+	require.EqualError(t, err, "validating payment: cannot confirm a payment before channel is opened")
 
 	// Open channel.
 	m, err := senderChannel.ProposeOpen(OpenParams{


### PR DESCRIPTION
**WHAT**
error if the channel is trying to propose or confirm a payment or close if the channel is not open yet

**WHY**
a channel shouldn't be able attempt to propose/confirm a payment or close if the channel is not open yet. Although the methods would fail, checking explicitly prevents unexpected behavior.


closes https://github.com/stellar/experimental-payment-channels/issues/186