### PR TITLE
sep: change title

### DIFF
--- a/specifications/sep-payment-channel-mechanics.md
+++ b/specifications/sep-payment-channel-mechanics.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: ????
-Title: Payment Channel Transactions
+Title: Payment Channel Mechanics
 Author: David Mazières <@standford-scs>, Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
@@ -14,8 +14,8 @@ Version: 0.4.0
 
 ## Summary
 
-This protocol defines the Stellar transactions that two participants use to
-open and close a payment channel.
+This protocol defines the mechanics that two participants use to open and close
+a payment channel.
 
 ## Dependencies
 


### PR DESCRIPTION
### What
Change the title of the SEP to refer to the mechanics of the payment channel rather than transactions.

### Why
The SEP contains a specification of the transactions and the basic mechanics required to form and maintain a payment channel safely, so it defines more than just the transactions. For this reason I wanted to drop the `transactions` from the title. However, the SEP doesn't define much about how coordination should occur and so it is not a sufficient SEP in its current form to be considered a specification of the entire payment channel. The scope of the SEP is really the bare minimum mechanics which can sit under a variety of applications.