### PR TITLE
sdk/agent: move channel creation into open process

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -292,11 +292,11 @@ func (a *Agent) handleHello(m msg.Message, send *msg.Encoder) error {
 
 	h := m.Hello
 
-	fmt.Fprintf(a.LogWriter, "other's escrow account: %v\n", h.EscrowAccount.Address())
 	a.otherEscrowAccount = &h.EscrowAccount
-
-	fmt.Fprintf(a.LogWriter, "other's signer: %v\n", h.Signer.Address())
 	a.otherEscrowAccountSigner = &h.Signer
+
+	fmt.Fprintf(a.LogWriter, "other's escrow account: %v\n", a.otherEscrowAccount.Address())
+	fmt.Fprintf(a.LogWriter, "other's signer: %v\n", a.otherEscrowAccountSigner.Address())
 
 	return nil
 }

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -79,11 +79,7 @@ func (a *Agent) hello() error {
 	return nil
 }
 
-func isInitiator(self, other *keypair.FromAddress) bool {
-	return self.Address() > other.Address()
-}
-
-func (a *Agent) initChannel() error {
+func (a *Agent) initChannel(initiator bool) error {
 	if a.channel != nil {
 		return fmt.Errorf("channel already created")
 	}
@@ -98,7 +94,7 @@ func (a *Agent) initChannel() error {
 	a.channel = state.NewChannel(state.Config{
 		NetworkPassphrase: a.NetworkPassphrase,
 		MaxOpenExpiry:     a.MaxOpenExpiry,
-		Initiator:         isInitiator(a.EscrowAccountKey, a.otherEscrowAccount),
+		Initiator:         initiator,
 		LocalEscrowAccount: &state.EscrowAccount{
 			Address:        a.EscrowAccountKey,
 			SequenceNumber: escrowAccountSeqNum,
@@ -122,7 +118,7 @@ func (a *Agent) Open() error {
 	if a.channel != nil {
 		return fmt.Errorf("channel already exists")
 	}
-	err := a.initChannel()
+	err := a.initChannel(true)
 	if err != nil {
 		return fmt.Errorf("init channel: %w", err)
 	}
@@ -306,7 +302,7 @@ func (a *Agent) handleHello(m msg.Message, send *msg.Encoder) error {
 }
 
 func (a *Agent) handleOpenRequest(m msg.Message, send *msg.Encoder) error {
-	err := a.initChannel()
+	err := a.initChannel(false)
 	if err != nil {
 		return fmt.Errorf("init channel: %w", err)
 	}


### PR DESCRIPTION
### What
Move the channel creation in the agent into the open process instead of happening as part of the hello process.

### Why
The agent creates the channel the moment the agent has the hello information from the other participant, but this is somewhat unnecessary, introduces stale data, and complicates the channel setup.

It is unnecessary because the agent doesn't need the channel until the open process begins.

Stale data may be introduced because at the moment the sequence number of the escrow accounts is needed to be known when initializing the channel, however it could have changed by the time the open starts and when the open starts is when it is required.

The channel setup is complicated when the channel is created early because channel creation records who the initiator is. This has required us to come up with a formula to choose the initiator and who the initiator is must be detached from who proposes the open. We can simply make the initiator the person proposing the open if the initialization of the channel occurs during the open. You could argue that we should set the initiator during the first call to Open in the Channel type, but that has a side-effect that the initiator isn't a constant value for the lifetime of the Channel value and the type is simpler if we can say many of the config fields are constants.

