### PR TITLE
sep: add discussion about risks with queueing payments

### DIFF
--- a/specifications/sep-payment-channel-mechanics.md
+++ b/specifications/sep-payment-channel-mechanics.md
@@ -691,7 +691,8 @@ remaining transactions.
 
 This protocol implicitly supports participants sending multiple payments to the
 other participant without the other participant confirming each payment
-immediately. This introduces some risk to the sending participant because the
+immediately. This introduces some risk to the sending participant if they
+queue multiple payments to the receiver without any replies, because the
 receiving participant can prevent the channel from being closed for
 approximately the observation period multiplied by the number of uncomfirmed
 payments. The receiving participant could do this by submitting each payment's

--- a/specifications/sep-payment-channel-mechanics.md
+++ b/specifications/sep-payment-channel-mechanics.md
@@ -687,6 +687,19 @@ could submit a subset of the transactions required by the process and the
 participant will not have any other capability to authorize and submit the
 remaining transactions.
 
+### Queueing Multiple Payments
+
+This protocol implicitly supports participants sending multiple payments to the
+other participant without the other participant confirming each payment
+immediately. This introduces some risk to the sending participant because the
+receiving participant can prevent the channel from being closed for
+approximately the observation period multiplied by the number of uncomfirmed
+payments. The receiving participant could do this by submitting each payment's
+declaration transaction in order and wait just less than the observation period
+between each submission. The sending participant would not be in possession of
+the most recent authorized declaration transaction and so could not jump ahead
+to that most recent payment.
+
 ## Limitations
 
 This protocol defines the mechanisms of the Stellar network's core protocol that


### PR DESCRIPTION
### What
Add discussion about the risks of queueing multiple payments by sending multiple payments to the other participant before they confirm each individually.

### Why
CAP-40 gives us a bonus benefit that participants can make multiple payments without waiting for the confirmation from teh receiver. Some future version of the protocol defined in the SEP could use that bonus and make it possible for participants to speed up and slow down independent of each other and be allowed to fall behind for a period or indefinitely. There is one side-effect and tradeoff to that though which is important to weigh with any implementation that uses it. I wanted to document it so that we didn't forget about it if we went all in on that approach in the future.