### PR TITLE
sdk/state: remove old todo

### DIFF
--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -22,9 +22,6 @@ type Channel struct {
 
 	startingSequence int64
 
-	// TODO - leave execution out for now
-	// iterationNumberExecuted int64
-
 	initiator           bool
 	localEscrowAccount  *EscrowAccount
 	remoteEscrowAccount *EscrowAccount


### PR DESCRIPTION
### What
Remove old todo.

### Why
The todo comment has been there for a while but isn't something we're likely to do soon. It's something we'll need when we do #49 but we can address how that is implemented when and if we come to it.