### PR TITLE
sdk/state: reorder funcs

### DIFF
--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -10,6 +10,32 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+type Config struct {
+	NetworkPassphrase string
+	MaxOpenExpiry     time.Duration
+
+	Initiator bool
+
+	LocalEscrowAccount  *EscrowAccount
+	RemoteEscrowAccount *EscrowAccount
+
+	LocalSigner  *keypair.Full
+	RemoteSigner *keypair.FromAddress
+}
+
+func NewChannel(c Config) *Channel {
+	channel := &Channel{
+		networkPassphrase:   c.NetworkPassphrase,
+		maxOpenExpiry:       c.MaxOpenExpiry,
+		initiator:           c.Initiator,
+		localEscrowAccount:  c.LocalEscrowAccount,
+		remoteEscrowAccount: c.RemoteEscrowAccount,
+		localSigner:         c.LocalSigner,
+		remoteSigner:        c.RemoteSigner,
+	}
+	return channel
+}
+
 type EscrowAccount struct {
 	Address        *keypair.FromAddress
 	SequenceNumber int64
@@ -86,32 +112,6 @@ func (c *Channel) State() (State, error) {
 
 func (c *Channel) setInitiatorEscrowAccountSequence(seqNum int64) {
 	c.initiatorEscrowAccount().SequenceNumber = seqNum
-}
-
-type Config struct {
-	NetworkPassphrase string
-	MaxOpenExpiry     time.Duration
-
-	Initiator bool
-
-	LocalEscrowAccount  *EscrowAccount
-	RemoteEscrowAccount *EscrowAccount
-
-	LocalSigner  *keypair.Full
-	RemoteSigner *keypair.FromAddress
-}
-
-func NewChannel(c Config) *Channel {
-	channel := &Channel{
-		networkPassphrase:   c.NetworkPassphrase,
-		maxOpenExpiry:       c.MaxOpenExpiry,
-		initiator:           c.Initiator,
-		localEscrowAccount:  c.LocalEscrowAccount,
-		remoteEscrowAccount: c.RemoteEscrowAccount,
-		localSigner:         c.LocalSigner,
-		remoteSigner:        c.RemoteSigner,
-	}
-	return channel
 }
 
 func (c *Channel) IsInitiator() bool {


### PR DESCRIPTION
### What
Move the `Config` and `NewChannel` type and function above the `Channel` type.

### Why
The type and function are the entry point to using the `Channel`, but they're buried below some other types and functions. Moving them to the top makes them easier to discover and matches how the same pattern in the `sdk/agent` package.

