### PR TITLE
sdk/state: store tx hashes in agreements

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -70,10 +70,10 @@ func (c *Channel) CloseTxs() (declTx *txnbuild.Transaction, closeTx *txnbuild.Tr
 	// Check that the transactions built match the transaction hashes in the
 	// close agreement.
 	if ca.TransactionHashes.Declaration != declTxHash {
-		// TODO
+		return nil, nil, fmt.Errorf("rebuilt declaration tx has unexpected hash: %v expected: %v", ca.TransactionHashes.Declaration, declTxHash)
 	}
 	if ca.TransactionHashes.Close != closeTxHash {
-		// TODO
+		return nil, nil, fmt.Errorf("rebuilt close tx has unexpected hash: %v expected: %v", ca.TransactionHashes.Close, closeTxHash)
 	}
 
 	// Add the declaration signatures to the declaration tx.

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -174,10 +174,10 @@ func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement
 	// Check that the transactions built match the transaction hashes in the
 	// close agreement.
 	if ca.TransactionHashes.Declaration != txDeclHash {
-		// TODO
+		return CloseAgreement{}, fmt.Errorf("unexpected declaration tx hash: %v expected: %v", ca.TransactionHashes.Declaration, txDeclHash)
 	}
 	if ca.TransactionHashes.Close != txCloseHash {
-		// TODO
+		return CloseAgreement{}, fmt.Errorf("unexpected close tx hash: %v expected: %v", ca.TransactionHashes.Close, txCloseHash)
 	}
 
 	// If remote has not signed the txs, error as is invalid.

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -18,7 +18,7 @@ import (
 // 6. If A or B declines or is not responsive at any step, A or B may submit the
 //    original close tx after the observation period.
 
-func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (txDeclHash [32]byte, txDecl *txnbuild.Transaction, txCloseHash [32]byte, txClose *txnbuild.Transaction, err error) {
+func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (txDeclHash TransactionHash, txDecl *txnbuild.Transaction, txCloseHash TransactionHash, txClose *txnbuild.Transaction, err error) {
 	txClose, err = txbuild.Close(txbuild.CloseParams{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: d.ObservationPeriodLedgerGap,
@@ -33,11 +33,11 @@ func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (t
 		Asset:                      oad.Asset.Asset(),
 	})
 	if err != nil {
-		return [32]byte{}, nil, [32]byte{}, nil, err
+		return TransactionHash{}, nil, TransactionHash{}, nil, err
 	}
 	txCloseHash, err = txClose.Hash(c.networkPassphrase)
 	if err != nil {
-		return [32]byte{}, nil, [32]byte{}, nil, err
+		return TransactionHash{}, nil, TransactionHash{}, nil, err
 	}
 	txDecl, err = txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
@@ -48,11 +48,11 @@ func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (t
 		CloseTxHash:             txCloseHash,
 	})
 	if err != nil {
-		return [32]byte{}, nil, [32]byte{}, nil, err
+		return TransactionHash{}, nil, TransactionHash{}, nil, err
 	}
 	txDeclHash, err = txDecl.Hash(c.networkPassphrase)
 	if err != nil {
-		return [32]byte{}, nil, [32]byte{}, nil, err
+		return TransactionHash{}, nil, TransactionHash{}, nil, err
 	}
 	return txDeclHash, txDecl, txCloseHash, txClose, nil
 }

--- a/sdk/state/close_test.go
+++ b/sdk/state/close_test.go
@@ -404,11 +404,11 @@ func TestChannel_ProposeAndConfirmCoordinatedClose_rejectIfUnexpectedTransaction
 	// Proposer rejects if unexpected declaration tx hash.
 	ca2Modified := ca
 	ca2Modified.TransactionHashes.Declaration = TransactionHash{}
-	_, err = receiverChannel.ConfirmClose(ca2Modified)
+	_, err = senderChannel.ConfirmClose(ca2Modified)
 	require.EqualError(t, err, "unexpected declaration tx hash: 0000000000000000000000000000000000000000000000000000000000000000 expected: "+ca2.TransactionHashes.Declaration.String())
 	ca2Modified = ca
 	ca2Modified.TransactionHashes.Close = TransactionHash{}
-	_, err = receiverChannel.ConfirmClose(ca2Modified)
+	_, err = senderChannel.ConfirmClose(ca2Modified)
 	require.EqualError(t, err, "unexpected close tx hash: 0000000000000000000000000000000000000000000000000000000000000000 expected: "+ca2.TransactionHashes.Close.String())
 
 	// Proposer accepts correct agreement.

--- a/sdk/state/hash.go
+++ b/sdk/state/hash.go
@@ -1,0 +1,35 @@
+package state
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+type TransactionHash [32]byte
+
+func (h TransactionHash) String() string {
+	return hex.EncodeToString(h[:])
+}
+
+func (h TransactionHash) MarshalText() ([]byte, error) {
+	text := [len(h) * 2]byte{}
+	n := hex.Encode(text[:], h[:])
+	if n != len(text) {
+		return nil, hex.ErrLength
+	}
+	return text[:], nil
+}
+
+func (h *TransactionHash) UnmarshalText(text []byte) error {
+	if hex.DecodedLen(len(text)) != len(h) {
+		return hex.ErrLength
+	}
+	n, err := hex.Decode(h[:], text)
+	if err != nil {
+		return fmt.Errorf("unmarshalling hash: %w", err)
+	}
+	if n != len(h) {
+		return hex.ErrLength
+	}
+	return nil
+}

--- a/sdk/state/hash_test.go
+++ b/sdk/state/hash_test.go
@@ -1,0 +1,74 @@
+package state
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHash_String(t *testing.T) {
+	h := TransactionHash{}
+	assert.Equal(
+		t,
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		h.String(),
+	)
+	h = TransactionHash{0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01}
+	assert.Equal(
+		t,
+		"0123456789012345678901234567890101234567890123456789012345678901",
+		h.String(),
+	)
+}
+
+func TestHash_MarshalText(t *testing.T) {
+	h := TransactionHash{}
+	b, err := h.MarshalText()
+	require.NoError(t, err)
+	wantB := []byte("0000000000000000000000000000000000000000000000000000000000000000")
+	assert.Equal(t, wantB, b)
+
+	h = TransactionHash{0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01}
+	b, err = h.MarshalText()
+	require.NoError(t, err)
+	wantB = []byte("0123456789012345678901234567890101234567890123456789012345678901")
+	assert.Equal(t, wantB, b)
+}
+
+func TestHash_UnmarshalText(t *testing.T) {
+	// Zero.
+	s := "0000000000000000000000000000000000000000000000000000000000000000"
+	h := TransactionHash{}
+	err := h.UnmarshalText([]byte(s))
+	require.NoError(t, err)
+	wantH := TransactionHash{}
+	assert.Equal(t, wantH, h)
+
+	// Valid.
+	s = "0123456789012345678901234567890101234567890123456789012345678901"
+	h = TransactionHash{}
+	err = h.UnmarshalText([]byte(s))
+	require.NoError(t, err)
+	wantH = TransactionHash{0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01}
+	assert.Equal(t, wantH, h)
+
+	// Invalid: too long.
+	s = "01234567890123456789012345678901012345678901234567890123456789000"
+	h = TransactionHash{}
+	err = h.UnmarshalText([]byte(s))
+	require.ErrorIs(t, err, hex.ErrLength)
+
+	// Invalid: too short by one character / half a byte.
+	s = "012345678901234567890123456789010123456789012345678901234567890"
+	h = TransactionHash{}
+	err = h.UnmarshalText([]byte(s))
+	require.ErrorIs(t, err, hex.ErrLength)
+
+	// Invalid: too short by two characters / a byte.
+	s = "01234567890123456789012345678901012345678901234567890123456789"
+	h = TransactionHash{}
+	err = h.UnmarshalText([]byte(s))
+	require.ErrorIs(t, err, hex.ErrLength)
+}

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -81,7 +81,7 @@ func (c *Channel) ingestTxToUpdateUnauthorizedCloseAgreement(tx *txnbuild.Transa
 		return nil
 	}
 
-	declTx, closeTx, err := c.closeTxs(c.openAgreement.Details, ca.Details)
+	declTxHash, _, closeTxHash, _, err := c.closeTxs(c.openAgreement.Details, ca.Details)
 	if err != nil {
 		return fmt.Errorf("building txs for latest unauthorized close agreement: %w", err)
 	}
@@ -89,21 +89,12 @@ func (c *Channel) ingestTxToUpdateUnauthorizedCloseAgreement(tx *txnbuild.Transa
 	// Compare the hash of the tx with the hash of the declaration tx from the
 	// latest unauthorized close agreement. If they match, then the tx is the
 	// declaration tx.
-	declTxHash, err := declTx.Hash(c.networkPassphrase)
-	if err != nil {
-		return fmt.Errorf("hashing latest unauthorized declaration tx: %w", err)
-	}
 	txHash, err := tx.Hash(c.networkPassphrase)
 	if err != nil {
 		return fmt.Errorf("hashing tx: %w", err)
 	}
 	if txHash != declTxHash {
 		return nil
-	}
-
-	closeTxHash, err := closeTx.Hash(c.networkPassphrase)
-	if err != nil {
-		return fmt.Errorf("hashing latest unauthorized close tx: %w", err)
 	}
 
 	// Look for the signatures on the tx that are required to fully authorize

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -312,6 +312,10 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 			ProposingSigner:            m.Details.ProposingSigner,
 			ConfirmingSigner:           m.Details.ConfirmingSigner,
 		},
+		TransactionHashes: CloseAgreementTransactionHashes{
+			Declaration: m.TransactionHashes.Declaration,
+			Close:       m.TransactionHashes.Close,
+		},
 		ProposerSignatures: CloseAgreementSignatures{
 			Declaration: m.ProposerSignatures.Declaration,
 			Close:       m.ProposerSignatures.Close,
@@ -323,6 +327,7 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 	}
 	c.openAgreement = OpenAgreement{
 		Details:             m.Details,
+		TransactionHashes:   m.TransactionHashes,
 		ProposerSignatures:  m.ProposerSignatures,
 		ConfirmerSignatures: m.ConfirmerSignatures,
 	}

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -123,7 +123,7 @@ type OpenParams struct {
 	StartingSequence           int64
 }
 
-func (c *Channel) openTxs(d OpenAgreementDetails) (declHash [32]byte, decl *txnbuild.Transaction, closeHash [32]byte, close *txnbuild.Transaction, formationHash [32]byte, formation *txnbuild.Transaction, err error) {
+func (c *Channel) openTxs(d OpenAgreementDetails) (declHash TransactionHash, decl *txnbuild.Transaction, closeHash TransactionHash, close *txnbuild.Transaction, formationHash [32]byte, formation *txnbuild.Transaction, err error) {
 	cad := CloseAgreementDetails{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: d.ObservationPeriodLedgerGap,
@@ -152,6 +152,7 @@ func (c *Channel) openTxs(d OpenAgreementDetails) (declHash [32]byte, decl *txnb
 	})
 	if err != nil {
 		err = fmt.Errorf("building formation tx for open: %w", err)
+		return
 	}
 	formationHash, err = formation.Hash(c.networkPassphrase)
 	if err != nil {

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -308,13 +308,9 @@ func TestChannel_OpenTx(t *testing.T) {
 		},
 	}
 
-	declTx, closeTx, _, err := channel.openTxs(channel.openAgreement.Details)
+	declTxHash, _, closeTxHash, _, _, _, err := channel.openTxs(channel.openAgreement.Details)
 	require.NoError(t, err)
 	formationTx, err := channel.OpenTx()
-	require.NoError(t, err)
-	declTxHash, err := declTx.Hash(channel.networkPassphrase)
-	require.NoError(t, err)
-	closeTxHash, err := closeTx.Hash(channel.networkPassphrase)
 	require.NoError(t, err)
 	// TODO: Compare the non-signature parts of formationTx with the result of
 	// channel.openTx() when there is an practical way of doing that added to

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -238,10 +238,10 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	// Check that the transactions built match the transaction hashes in the
 	// close agreement.
 	if ca.TransactionHashes.Declaration != txDeclHash {
-		// TODO
+		return CloseAgreement{}, fmt.Errorf("unexpected declaration tx hash: %v expected: %v", ca.TransactionHashes.Declaration, txDeclHash)
 	}
 	if ca.TransactionHashes.Close != txCloseHash {
-		// TODO
+		return CloseAgreement{}, fmt.Errorf("unexpected close tx hash: %v expected: %v", ca.TransactionHashes.Close, txCloseHash)
 	}
 
 	// If remote has not signed the txs, error as is invalid.

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -281,7 +281,7 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 			},
 		}
 
-		txDecl, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		_, txDecl, _, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
@@ -385,7 +385,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	// A close agreement from the remote participant should be rejected if the
 	// observation period doesn't match the channels observation period.
 	{
-		txDecl, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		_, txDecl, _, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
@@ -496,7 +496,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
 	}
-	txDecl, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
+	_, txDecl, _, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
 	require.NoError(t, err)
 	txDecl, err = txDecl.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
@@ -597,7 +597,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 		ObservationPeriodLedgerGap: 10,
 	}
 
-	txDecl, txClose, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
+	_, txDecl, _, txClose, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
 	require.NoError(t, err)
 	txDecl, err = txDecl.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
@@ -698,7 +698,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
 	}
-	txDecl, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
+	_, txDecl, _, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
 	require.NoError(t, err)
 	txDecl, err = txDecl.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
@@ -811,7 +811,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
 	}
-	txDecl, txClose, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
+	_, txDecl, _, txClose, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
 	require.NoError(t, err)
 	txDecl, err = txDecl.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -281,7 +281,7 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 			},
 		}
 
-		_, txDecl, _, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		txDeclHash, txDecl, txCloseHash, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
@@ -300,6 +300,10 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 				ObservationPeriodLedgerGap: 1,
 				ProposingSigner:            remoteSigner.FromAddress(),
 				ConfirmingSigner:           localSigner.FromAddress(),
+			},
+			TransactionHashes: CloseAgreementTransactionHashes{
+				Declaration: txDeclHash,
+				Close:       txCloseHash,
 			},
 			ProposerSignatures: CloseAgreementSignatures{
 				Declaration: txDecl.Signatures()[0].Signature,
@@ -385,7 +389,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	// A close agreement from the remote participant should be rejected if the
 	// observation period doesn't match the channels observation period.
 	{
-		_, txDecl, _, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		txDeclHash, txDecl, txCloseHash, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
@@ -401,6 +405,10 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 				IterationNumber:            1,
 				ObservationPeriodTime:      0,
 				ObservationPeriodLedgerGap: 0,
+			},
+			TransactionHashes: CloseAgreementTransactionHashes{
+				Declaration: txDeclHash,
+				Close:       txCloseHash,
 			},
 			ProposerSignatures: CloseAgreementSignatures{
 				Declaration: txDecl.Signatures()[0].Signature,
@@ -496,7 +504,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
 	}
-	_, txDecl, _, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
+	txDeclHash, txDecl, txCloseHash, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
 	require.NoError(t, err)
 	txDecl, err = txDecl.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
@@ -504,6 +512,10 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	require.NoError(t, err)
 	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
+		TransactionHashes: CloseAgreementTransactionHashes{
+			Declaration: txDeclHash,
+			Close:       txCloseHash,
+		},
 		ProposerSignatures: CloseAgreementSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
@@ -597,7 +609,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 		ObservationPeriodLedgerGap: 10,
 	}
 
-	_, txDecl, _, txClose, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
+	txDeclHash, txDecl, txCloseHash, txClose, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
 	require.NoError(t, err)
 	txDecl, err = txDecl.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
@@ -605,6 +617,10 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	require.NoError(t, err)
 	_, err = responderChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
+		TransactionHashes: CloseAgreementTransactionHashes{
+			Declaration: txDeclHash,
+			Close:       txCloseHash,
+		},
 		ProposerSignatures: CloseAgreementSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
@@ -698,7 +714,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
 	}
-	_, txDecl, _, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
+	txDeclHash, txDecl, txCloseHash, txClose, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
 	require.NoError(t, err)
 	txDecl, err = txDecl.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
@@ -706,6 +722,10 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	require.NoError(t, err)
 	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
+		TransactionHashes: CloseAgreementTransactionHashes{
+			Declaration: txDeclHash,
+			Close:       txCloseHash,
+		},
 		ProposerSignatures: CloseAgreementSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
@@ -718,6 +738,10 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	initiatorChannel.UpdateRemoteEscrowAccountBalance(200)
 	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
+		TransactionHashes: CloseAgreementTransactionHashes{
+			Declaration: txDeclHash,
+			Close:       txCloseHash,
+		},
 		ProposerSignatures: CloseAgreementSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
@@ -811,7 +835,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
 	}
-	_, txDecl, _, txClose, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
+	txDeclHash, txDecl, txCloseHash, txClose, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
 	require.NoError(t, err)
 	txDecl, err = txDecl.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
@@ -819,6 +843,10 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	require.NoError(t, err)
 	_, err = responderChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
+		TransactionHashes: CloseAgreementTransactionHashes{
+			Declaration: txDeclHash,
+			Close:       txCloseHash,
+		},
 		ProposerSignatures: CloseAgreementSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
@@ -831,6 +859,10 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	responderChannel.UpdateRemoteEscrowAccountBalance(200)
 	_, err = responderChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
+		TransactionHashes: CloseAgreementTransactionHashes{
+			Declaration: txDeclHash,
+			Close:       txCloseHash,
+		},
 		ProposerSignatures: CloseAgreementSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
@@ -1103,12 +1135,25 @@ func TestLastConfirmedPayment(t *testing.T) {
 			ObservationPeriodTime:      10,
 			ObservationPeriodLedgerGap: 10,
 		},
+		TransactionHashes:   ca.TransactionHashes,
 		ProposerSignatures:  ca.ProposerSignatures,
 		ConfirmerSignatures: ca.ConfirmerSignatures,
 	}
 	_, err = sendingChannel.ConfirmPayment(caDifferent)
 	require.EqualError(t, err, "validating payment: close agreement does not match the close agreement already in progress")
 	assert.Equal(t, ca, sendingChannel.latestUnauthorizedCloseAgreement)
+
+	// Confirming a close agreement with details but different tx hashes should error
+	declTxHash, _, closeTxHash, _, err := sendingChannel.closeTxs(sendingChannel.openAgreement.Details, ca.Details)
+	require.NoError(t, err)
+	caDifferent = ca
+	caDifferent.TransactionHashes.Declaration = TransactionHash{}
+	_, err = sendingChannel.ConfirmPayment(caDifferent)
+	require.EqualError(t, err, "unexpected declaration tx hash: 0000000000000000000000000000000000000000000000000000000000000000 expected: "+declTxHash.String())
+	caDifferent = ca
+	caDifferent.TransactionHashes.Close = TransactionHash{}
+	_, err = sendingChannel.ConfirmPayment(caDifferent)
+	require.EqualError(t, err, "unexpected close tx hash: 0000000000000000000000000000000000000000000000000000000000000000 expected: "+closeTxHash.String())
 
 	// Confirming a payment with same sequence number and same amount should pass
 	caFinal, err := sendingChannel.ConfirmPayment(caResponse)

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -273,10 +273,18 @@ func amountToResponder(balance int64) int64 {
 	return 0
 }
 
-func signTx(tx *txnbuild.Transaction, networkPassphrase string, kp *keypair.Full) (xdr.Signature, error) {
+func hashTx(tx *txnbuild.Transaction, networkPassphrase string) ([32]byte, error) {
 	h, err := network.HashTransactionInEnvelope(tx.ToXDR(), networkPassphrase)
 	if err != nil {
-		return nil, fmt.Errorf("failed to hash transaction: %w", err)
+		return [32]byte{}, fmt.Errorf("hashing transaction: %w", err)
+	}
+	return h, nil
+}
+
+func signTx(tx *txnbuild.Transaction, networkPassphrase string, kp *keypair.Full) (xdr.Signature, error) {
+	h, err := hashTx(tx, networkPassphrase)
+	if err != nil {
+		return nil, fmt.Errorf("hashing transaction for signing: %w", err)
 	}
 	sig, err := kp.Sign(h[:])
 	if err != nil {

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -146,7 +146,7 @@ func (c *Channel) State() (State, error) {
 	}
 
 	// Get the sequence numbers for the latest close agreement transactions.
-	declTxAuthorized, closeTxAuthorized, err := c.closeTxs(c.openAgreement.Details, c.latestAuthorizedCloseAgreement.Details)
+	_, declTxAuthorized, _, closeTxAuthorized, err := c.closeTxs(c.openAgreement.Details, c.latestAuthorizedCloseAgreement.Details)
 	if err != nil {
 		return -1, fmt.Errorf("building declaration and close txs for latest authorized close agreement: %w", err)
 	}

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -273,18 +273,10 @@ func amountToResponder(balance int64) int64 {
 	return 0
 }
 
-func hashTx(tx *txnbuild.Transaction, networkPassphrase string) ([32]byte, error) {
+func signTx(tx *txnbuild.Transaction, networkPassphrase string, kp *keypair.Full) (xdr.Signature, error) {
 	h, err := network.HashTransactionInEnvelope(tx.ToXDR(), networkPassphrase)
 	if err != nil {
-		return [32]byte{}, fmt.Errorf("hashing transaction: %w", err)
-	}
-	return h, nil
-}
-
-func signTx(tx *txnbuild.Transaction, networkPassphrase string, kp *keypair.Full) (xdr.Signature, error) {
-	h, err := hashTx(tx, networkPassphrase)
-	if err != nil {
-		return nil, fmt.Errorf("hashing transaction for signing: %w", err)
+		return nil, fmt.Errorf("failed to hash transaction: %w", err)
 	}
 	sig, err := kp.Sign(h[:])
 	if err != nil {


### PR DESCRIPTION
### What
Store tx hashes in the open and close agreements, and validate that they match built transactions when rebuilding txs, or confirming agreements.

### Why
To add some resilience to tx building so that it is immediately clear if an update causes txs to build different. To improve debugging if two participants interacting appear to have incorrect signatures due to txs being built differently.

I started adding this while working on storing txs (#199). Much of the code relies on verifying signatures to detect an issue with transaction building, which is fine and functional, but it is difficult to tell when transaction building is the cause of verification failure rather than incorrect signatures.

This is a bit off the planned path for #199, but is related to it.