### PR TITLE
sdk/agent: fix reconnect

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -359,7 +359,7 @@ func (a *Agent) DeclareClose() error {
 		CloseRequest: &ca,
 	})
 	if err != nil {
-		return fmt.Errorf("error: sending the close proposal: %w\n", err)
+		return fmt.Errorf("error: sending the close proposal: %w", err)
 	}
 
 	return nil
@@ -398,11 +398,11 @@ func (a *Agent) receive() error {
 	m := msg.Message{}
 	err := recv.Decode(&m)
 	if err != nil {
-		return fmt.Errorf("reading and decoding: %v\n", err)
+		return fmt.Errorf("reading and decoding: %v", err)
 	}
 	err = a.handle(m, send)
 	if err != nil {
-		return fmt.Errorf("handling message: %v\n", err)
+		return fmt.Errorf("handling message: %v", err)
 	}
 	return nil
 }
@@ -451,13 +451,16 @@ func (a *Agent) handleHello(m msg.Message, send *msg.Encoder) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if a.channel != nil {
-		return fmt.Errorf("extra hello received when channel already setup")
-	}
-
 	defer a.snapshot()
 
 	h := m.Hello
+
+	if a.otherEscrowAccount != nil && !a.otherEscrowAccount.Equal(&h.EscrowAccount) {
+		return fmt.Errorf("hello received with unexpected escrow account: %s expected: %s", h.EscrowAccount.Address(), a.otherEscrowAccount.Address())
+	}
+	if a.otherEscrowAccountSigner != nil && !a.otherEscrowAccountSigner.Equal(&h.Signer) {
+		return fmt.Errorf("hello received with unexpected signer: %s expected: %s", h.Signer.Address(), a.otherEscrowAccountSigner.Address())
+	}
 
 	a.otherEscrowAccount = &h.EscrowAccount
 	a.otherEscrowAccountSigner = &h.Signer

--- a/sdk/agent/agent_test.go
+++ b/sdk/agent/agent_test.go
@@ -231,6 +231,22 @@ func TestAgent_openPaymentClose(t *testing.T) {
 		assert.IsType(t, ErrorEvent{}, remoteEvent)
 	}
 
+	// Extra hellos with wrong data raise an error.
+	incorrectSigner := keypair.MustRandom()
+	localAgent.escrowAccountSigner = incorrectSigner
+	err = localAgent.hello()
+	require.NoError(t, err)
+	err = remoteAgent.receive()
+	require.EqualError(t, err, "handling message: handling message 100: hello received with unexpected signer: "+incorrectSigner.Address()+" expected: "+localSigner.Address())
+	localAgent.escrowAccountSigner = localSigner
+
+	// Expect error event.
+	{
+		remoteEvent, ok := <-remoteEvents
+		require.True(t, ok)
+		assert.IsType(t, ErrorEvent{}, remoteEvent)
+	}
+
 	// Open the channel.
 	err = localAgent.Open()
 	require.NoError(t, err)

--- a/sdk/agent/agent_test.go
+++ b/sdk/agent/agent_test.go
@@ -201,6 +201,36 @@ func TestAgent_openPaymentClose(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, remoteEvent, ConnectedEvent{})
 	}
+
+	// Extra hellos are allowed and have no consequence.
+	err = localAgent.hello()
+	require.NoError(t, err)
+	err = remoteAgent.receive()
+	require.NoError(t, err)
+
+	// Expect connected event.
+	{
+		remoteEvent, ok := <-remoteEvents
+		require.True(t, ok)
+		assert.Equal(t, remoteEvent, ConnectedEvent{})
+	}
+
+	// Extra hellos with wrong data raise an error.
+	incorrectEscrow := keypair.MustRandom().FromAddress()
+	localAgent.escrowAccountKey = incorrectEscrow
+	err = localAgent.hello()
+	require.NoError(t, err)
+	err = remoteAgent.receive()
+	require.EqualError(t, err, "handling message: handling message 100: hello received with unexpected escrow account: "+incorrectEscrow.Address()+" expected: "+localEscrow.Address())
+	localAgent.escrowAccountKey = localEscrow
+
+	// Expect error event.
+	{
+		remoteEvent, ok := <-remoteEvents
+		require.True(t, ok)
+		assert.IsType(t, ErrorEvent{}, remoteEvent)
+	}
+
 	// Open the channel.
 	err = localAgent.Open()
 	require.NoError(t, err)


### PR DESCRIPTION
### What
Change the hello message handling so that multiple hellos are allowed as long as they contain the same data.

### Why
When restoring a channel using a snapshot the hello messages will be exchanged again for the new setup. The agent considers that an error. That should be allowed.