### PR TITLE
sdk/agent: exit early if eof

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -397,6 +397,9 @@ func (a *Agent) receive() error {
 	send := msg.NewEncoder(io.MultiWriter(a.conn, a.logWriter))
 	m := msg.Message{}
 	err := recv.Decode(&m)
+	if err == io.EOF {
+		return err
+	}
 	if err != nil {
 		return fmt.Errorf("reading and decoding: %v\n", err)
 	}
@@ -410,6 +413,10 @@ func (a *Agent) receive() error {
 func (a *Agent) receiveLoop() {
 	for {
 		err := a.receive()
+		if err == io.EOF {
+			fmt.Fprintln(a.logWriter, "error receiving: EOF, stopping receiving")
+			break
+		}
 		if err != nil {
 			fmt.Fprintf(a.logWriter, "error receiving: %v\n", err)
 		}


### PR DESCRIPTION
### What
Exit the agent's receive loop early if EOF reached on agent's connection.

### Why
If an EOF error is seen there's no point attempting to read the connection again as that is an indication the connection is closed. In the example app this is clear because when one side disconnects the agent continuously logs the EOF error.

### Known Limitations
I'm not adding a test for this change because the test would need to block on the receive loop on a timeout waiting to see if it stops. It'd be brittle and not deliver a ton of value.