### PR TITLE
sdk/state: rename CloseAgreement(.+) to Close$1

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -14,7 +14,7 @@ import (
 // transactions and still has them stored internally then it will return those
 // previously built transactions, otherwise the transactions will be built from
 // scratch.
-func (c *Channel) closeTxs(oad OpenDetails, d CloseDetails) (txs CloseTransactions, err error) {
+func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (txs CloseTransactions, err error) {
 	if c.openAgreement.Details.Equal(oad) {
 		if c.latestAuthorizedCloseAgreement.Details.Equal(d) {
 			return c.latestAuthorizedCloseTransactions, nil

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -14,13 +14,13 @@ import (
 // transactions and still has them stored internally then it will return those
 // previously built transactions, otherwise the transactions will be built from
 // scratch.
-func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (txs CloseAgreementTransactions, err error) {
+func (c *Channel) closeTxs(oad OpenDetails, d CloseDetails) (txs CloseTransactions, err error) {
 	if c.openAgreement.Details.Equal(oad) {
 		if c.latestAuthorizedCloseAgreement.Details.Equal(d) {
-			return c.latestAuthorizedCloseAgreementTransactions, nil
+			return c.latestAuthorizedCloseTransactions, nil
 		}
 		if c.latestUnauthorizedCloseAgreement.Details.Equal(d) {
-			return c.latestUnauthorizedCloseAgreementTransactions, nil
+			return c.latestUnauthorizedCloseTransactions, nil
 		}
 	}
 	txClose, err := txbuild.Close(txbuild.CloseParams{
@@ -37,11 +37,11 @@ func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (t
 		Asset:                      oad.Asset.Asset(),
 	})
 	if err != nil {
-		return CloseAgreementTransactions{}, err
+		return CloseTransactions{}, err
 	}
 	txCloseHash, err := txClose.Hash(c.networkPassphrase)
 	if err != nil {
-		return CloseAgreementTransactions{}, err
+		return CloseTransactions{}, err
 	}
 	txDecl, err := txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
@@ -52,13 +52,13 @@ func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (t
 		CloseTxHash:             txCloseHash,
 	})
 	if err != nil {
-		return CloseAgreementTransactions{}, err
+		return CloseTransactions{}, err
 	}
 	txDeclHash, err := txDecl.Hash(c.networkPassphrase)
 	if err != nil {
-		return CloseAgreementTransactions{}, err
+		return CloseTransactions{}, err
 	}
-	txs = CloseAgreementTransactions{
+	txs = CloseTransactions{
 		DeclarationHash: txDeclHash,
 		Declaration:     txDecl,
 		CloseHash:       txCloseHash,
@@ -130,7 +130,7 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 		Details:            d,
 		ProposerSignatures: sigs,
 	}
-	c.latestUnauthorizedCloseAgreementTransactions = txs
+	c.latestUnauthorizedCloseTransactions = txs
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
@@ -202,8 +202,8 @@ func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement
 
 	// The new close agreement is valid and authorized, store and promote it.
 	c.latestAuthorizedCloseAgreement = ca
-	c.latestAuthorizedCloseAgreementTransactions = txs
+	c.latestAuthorizedCloseTransactions = txs
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}
-	c.latestUnauthorizedCloseAgreementTransactions = CloseAgreementTransactions{}
+	c.latestUnauthorizedCloseTransactions = CloseTransactions{}
 	return c.latestAuthorizedCloseAgreement, nil
 }

--- a/sdk/state/close_test.go
+++ b/sdk/state/close_test.go
@@ -28,7 +28,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	oa := OpenAgreement{
-		Details: OpenDetails{
+		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
@@ -36,7 +36,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		},
 	}
 	ca := CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 2,
 			IterationNumber:            3,

--- a/sdk/state/close_test.go
+++ b/sdk/state/close_test.go
@@ -28,7 +28,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	oa := OpenAgreement{
-		Details: OpenAgreementDetails{
+		Details: OpenDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
@@ -36,7 +36,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		},
 	}
 	ca := CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 2,
 			IterationNumber:            3,
@@ -44,11 +44,11 @@ func TestChannel_CloseTx(t *testing.T) {
 			ProposingSigner:            localSigner.FromAddress(),
 			ConfirmingSigner:           remoteSigner.FromAddress(),
 		},
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: xdr.Signature{0},
 			Close:       xdr.Signature{1},
 		},
-		ConfirmerSignatures: CloseAgreementSignatures{
+		ConfirmerSignatures: CloseSignatures{
 			Declaration: xdr.Signature{2},
 			Close:       xdr.Signature{3},
 		},
@@ -57,7 +57,7 @@ func TestChannel_CloseTx(t *testing.T) {
 	require.NoError(t, err)
 	channel.openAgreement = oa
 	channel.latestAuthorizedCloseAgreement = ca
-	channel.latestAuthorizedCloseAgreementTransactions = txs
+	channel.latestAuthorizedCloseTransactions = txs
 	closeTxHash := txs.CloseHash
 
 	// TODO: Compare the non-signature parts of the txs with the result of
@@ -86,7 +86,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		Operations:    []txnbuild.Operation{&txnbuild.BumpSequence{}},
 	})
 	require.NoError(t, err)
-	channel.latestAuthorizedCloseAgreementTransactions = CloseAgreementTransactions{
+	channel.latestAuthorizedCloseTransactions = CloseTransactions{
 		Declaration: testTx,
 		Close:       testTx,
 	}
@@ -105,7 +105,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		Operations:    []txnbuild.Operation{&txnbuild.BumpSequence{}},
 	})
 	require.NoError(t, err)
-	channel.latestUnauthorizedCloseAgreementTransactions = CloseAgreementTransactions{
+	channel.latestUnauthorizedCloseTransactions = CloseTransactions{
 		Declaration: testTx,
 		Close:       testTx,
 	}

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-type OpenDetails struct {
+type OpenAgreementDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	Asset                      Asset
@@ -21,7 +21,7 @@ type OpenDetails struct {
 	ConfirmingSigner           *keypair.FromAddress
 }
 
-func (d OpenDetails) Equal(d2 OpenDetails) bool {
+func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
 	return d.ObservationPeriodTime == d2.ObservationPeriodTime &&
 		d.ObservationPeriodLedgerGap == d2.ObservationPeriodLedgerGap &&
 		d.Asset == d2.Asset &&
@@ -85,7 +85,7 @@ type OpenTransactions struct {
 }
 
 type OpenAgreement struct {
-	Details             OpenDetails
+	Details             OpenAgreementDetails
 	ProposerSignatures  OpenSignatures
 	ConfirmerSignatures OpenSignatures
 }
@@ -131,11 +131,11 @@ type OpenParams struct {
 // the channel has previous build the open transactions then it will return
 // those previously built transactions, otherwise the transactions will be built
 // from scratch.
-func (c *Channel) openTxs(d OpenDetails) (txs OpenTransactions, err error) {
+func (c *Channel) openTxs(d OpenAgreementDetails) (txs OpenTransactions, err error) {
 	if c.openAgreement.Details.Equal(d) {
 		return c.openTransactions, nil
 	}
-	cad := CloseDetails{
+	cad := CloseAgreementDetails{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: d.ObservationPeriodLedgerGap,
 		IterationNumber:            1,
@@ -217,7 +217,7 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 		return OpenAgreement{}, fmt.Errorf("cannot propose a new open if channel is already opened")
 	}
 
-	d := OpenDetails{
+	d := OpenAgreementDetails{
 		ObservationPeriodTime:      p.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: p.ObservationPeriodLedgerGap,
 		Asset:                      p.Asset,
@@ -309,7 +309,7 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 	// All signatures are present that would be required to submit all
 	// transactions in the open.
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    0,
 			ObservationPeriodTime:      m.Details.ObservationPeriodTime,

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-type OpenAgreementDetails struct {
+type OpenDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	Asset                      Asset
@@ -21,7 +21,7 @@ type OpenAgreementDetails struct {
 	ConfirmingSigner           *keypair.FromAddress
 }
 
-func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
+func (d OpenDetails) Equal(d2 OpenDetails) bool {
 	return d.ObservationPeriodTime == d2.ObservationPeriodTime &&
 		d.ObservationPeriodLedgerGap == d2.ObservationPeriodLedgerGap &&
 		d.Asset == d2.Asset &&
@@ -31,33 +31,33 @@ func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
 		d.ConfirmingSigner.Equal(d2.ConfirmingSigner)
 }
 
-type OpenAgreementSignatures struct {
+type OpenSignatures struct {
 	Close       xdr.Signature
 	Declaration xdr.Signature
 	Formation   xdr.Signature
 }
 
-func (oas OpenAgreementSignatures) isFull() bool {
+func (oas OpenSignatures) isFull() bool {
 	return len(oas.Close) > 0 && len(oas.Declaration) > 0 && len(oas.Formation) > 0
 }
 
-func signOpenAgreementTxs(txs OpenAgreementTransactions, networkPassphrase string, signer *keypair.Full) (s OpenAgreementSignatures, err error) {
+func signOpenAgreementTxs(txs OpenTransactions, networkPassphrase string, signer *keypair.Full) (s OpenSignatures, err error) {
 	s.Declaration, err = signTx(txs.Declaration, networkPassphrase, signer)
 	if err != nil {
-		return OpenAgreementSignatures{}, fmt.Errorf("signing declaration: %w", err)
+		return OpenSignatures{}, fmt.Errorf("signing declaration: %w", err)
 	}
 	s.Close, err = signTx(txs.Close, networkPassphrase, signer)
 	if err != nil {
-		return OpenAgreementSignatures{}, fmt.Errorf("signing close: %w", err)
+		return OpenSignatures{}, fmt.Errorf("signing close: %w", err)
 	}
 	s.Formation, err = signTx(txs.Formation, networkPassphrase, signer)
 	if err != nil {
-		return OpenAgreementSignatures{}, fmt.Errorf("signing formation: %w", err)
+		return OpenSignatures{}, fmt.Errorf("signing formation: %w", err)
 	}
 	return s, nil
 }
 
-func (s OpenAgreementSignatures) Verify(txs OpenAgreementTransactions, networkPassphrase string, signer *keypair.FromAddress) error {
+func (s OpenSignatures) Verify(txs OpenTransactions, networkPassphrase string, signer *keypair.FromAddress) error {
 	err := verifySigned(txs.Declaration, networkPassphrase, signer, s.Declaration)
 	if err != nil {
 		return fmt.Errorf("verifying declaration signed: %w", err)
@@ -73,9 +73,9 @@ func (s OpenAgreementSignatures) Verify(txs OpenAgreementTransactions, networkPa
 	return nil
 }
 
-// OpenAgreementTransactions contain all the transaction hashes and transactions
+// OpenTransactions contain all the transaction hashes and transactions
 // that make up the open agreement.
-type OpenAgreementTransactions struct {
+type OpenTransactions struct {
 	CloseHash       TransactionHash
 	Close           *txnbuild.Transaction
 	DeclarationHash TransactionHash
@@ -85,9 +85,9 @@ type OpenAgreementTransactions struct {
 }
 
 type OpenAgreement struct {
-	Details             OpenAgreementDetails
-	ProposerSignatures  OpenAgreementSignatures
-	ConfirmerSignatures OpenAgreementSignatures
+	Details             OpenDetails
+	ProposerSignatures  OpenSignatures
+	ConfirmerSignatures OpenSignatures
 }
 
 func (oa OpenAgreement) isEmpty() bool {
@@ -106,7 +106,7 @@ func (oa OpenAgreement) Equal(oa2 OpenAgreement) bool {
 	return cmp.Equal(OA(oa), OA(oa2))
 }
 
-func (oa OpenAgreement) SignaturesFor(signer *keypair.FromAddress) *OpenAgreementSignatures {
+func (oa OpenAgreement) SignaturesFor(signer *keypair.FromAddress) *OpenSignatures {
 	if oa.Details.ProposingSigner.Equal(signer) {
 		return &oa.ProposerSignatures
 	}
@@ -131,11 +131,11 @@ type OpenParams struct {
 // the channel has previous build the open transactions then it will return
 // those previously built transactions, otherwise the transactions will be built
 // from scratch.
-func (c *Channel) openTxs(d OpenAgreementDetails) (txs OpenAgreementTransactions, err error) {
+func (c *Channel) openTxs(d OpenDetails) (txs OpenTransactions, err error) {
 	if c.openAgreement.Details.Equal(d) {
 		return c.openAgreementTransactions, nil
 	}
-	cad := CloseAgreementDetails{
+	cad := CloseDetails{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: d.ObservationPeriodLedgerGap,
 		IterationNumber:            1,
@@ -171,7 +171,7 @@ func (c *Channel) openTxs(d OpenAgreementDetails) (txs OpenAgreementTransactions
 		return
 	}
 
-	txs = OpenAgreementTransactions{
+	txs = OpenTransactions{
 		DeclarationHash: closeTxs.DeclarationHash,
 		Declaration:     closeTxs.Declaration,
 		CloseHash:       closeTxs.CloseHash,
@@ -217,7 +217,7 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 		return OpenAgreement{}, fmt.Errorf("cannot propose a new open if channel is already opened")
 	}
 
-	d := OpenAgreementDetails{
+	d := OpenDetails{
 		ObservationPeriodTime:      p.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: p.ObservationPeriodLedgerGap,
 		Asset:                      p.Asset,
@@ -309,7 +309,7 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 	// All signatures are present that would be required to submit all
 	// transactions in the open.
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    0,
 			ObservationPeriodTime:      m.Details.ObservationPeriodTime,
@@ -317,16 +317,16 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 			ProposingSigner:            m.Details.ProposingSigner,
 			ConfirmingSigner:           m.Details.ConfirmingSigner,
 		},
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: m.ProposerSignatures.Declaration,
 			Close:       m.ProposerSignatures.Close,
 		},
-		ConfirmerSignatures: CloseAgreementSignatures{
+		ConfirmerSignatures: CloseSignatures{
 			Declaration: m.ConfirmerSignatures.Declaration,
 			Close:       m.ConfirmerSignatures.Close,
 		},
 	}
-	c.latestAuthorizedCloseAgreementTransactions = CloseAgreementTransactions{
+	c.latestAuthorizedCloseTransactions = CloseTransactions{
 		DeclarationHash: txs.DeclarationHash,
 		Declaration:     txs.Declaration,
 		CloseHash:       txs.CloseHash,

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -133,7 +133,7 @@ type OpenParams struct {
 // from scratch.
 func (c *Channel) openTxs(d OpenDetails) (txs OpenTransactions, err error) {
 	if c.openAgreement.Details.Equal(d) {
-		return c.openAgreementTransactions, nil
+		return c.openTransactions, nil
 	}
 	cad := CloseDetails{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
@@ -240,7 +240,7 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 		ProposerSignatures: sigs,
 	}
 	c.openAgreement = open
-	c.openAgreementTransactions = txs
+	c.openTransactions = txs
 	return open, nil
 }
 
@@ -337,6 +337,6 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 		ProposerSignatures:  m.ProposerSignatures,
 		ConfirmerSignatures: m.ConfirmerSignatures,
 	}
-	c.openAgreementTransactions = txs
+	c.openTransactions = txs
 	return c.openAgreement, nil
 }

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -24,7 +24,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		{OpenAgreement{}, OpenAgreement{}, true},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -33,7 +33,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -45,7 +45,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -58,7 +58,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -70,7 +70,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -85,7 +85,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -101,7 +101,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -113,7 +113,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -128,7 +128,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -140,7 +140,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -218,14 +218,14 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	channel.openAgreement = OpenAgreement{
-		Details: OpenDetails{
+		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
 		},
 	}
 
-	oa := OpenDetails{
+	oa := OpenAgreementDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -264,7 +264,7 @@ func TestConfirmOpen_rejectsOpenAgreementsWithLongFormations(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 
-	_, err := channel.ConfirmOpen(OpenAgreement{Details: OpenDetails{
+	_, err := channel.ConfirmOpen(OpenAgreement{Details: OpenAgreementDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -288,7 +288,7 @@ func TestChannel_OpenTx(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	oa := OpenAgreement{
-		Details: OpenDetails{
+		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -310,7 +310,7 @@ func TestChannel_OpenTx(t *testing.T) {
 	txs, err := channel.openTxs(oa.Details)
 	require.NoError(t, err)
 	channel.openAgreement = oa
-	channel.openAgreementTransactions = txs
+	channel.openTransactions = txs
 	declTxHash := txs.DeclarationHash
 	closeTxHash := txs.CloseHash
 
@@ -337,7 +337,7 @@ func TestChannel_OpenTx(t *testing.T) {
 		Operations:    []txnbuild.Operation{&txnbuild.BumpSequence{}},
 	})
 	require.NoError(t, err)
-	channel.openAgreementTransactions = OpenTransactions{
+	channel.openTransactions = OpenTransactions{
 		Formation: testTx,
 	}
 	formationTx, err = channel.OpenTx()

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -24,7 +24,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		{OpenAgreement{}, OpenAgreement{}, true},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -33,7 +33,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -45,7 +45,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -58,26 +58,26 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -85,14 +85,14 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -101,26 +101,26 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -128,26 +128,26 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           keypair.MustRandom().FromAddress(),
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -218,14 +218,14 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	channel.openAgreement = OpenAgreement{
-		Details: OpenAgreementDetails{
+		Details: OpenDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
 		},
 	}
 
-	oa := OpenAgreementDetails{
+	oa := OpenDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -264,7 +264,7 @@ func TestConfirmOpen_rejectsOpenAgreementsWithLongFormations(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 
-	_, err := channel.ConfirmOpen(OpenAgreement{Details: OpenAgreementDetails{
+	_, err := channel.ConfirmOpen(OpenAgreement{Details: OpenDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -288,7 +288,7 @@ func TestChannel_OpenTx(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	oa := OpenAgreement{
-		Details: OpenAgreementDetails{
+		Details: OpenDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
@@ -296,12 +296,12 @@ func TestChannel_OpenTx(t *testing.T) {
 			ProposingSigner:            localSigner.FromAddress(),
 			ConfirmingSigner:           remoteSigner.FromAddress(),
 		},
-		ProposerSignatures: OpenAgreementSignatures{
+		ProposerSignatures: OpenSignatures{
 			Declaration: xdr.Signature{0},
 			Close:       xdr.Signature{1},
 			Formation:   xdr.Signature{2},
 		},
-		ConfirmerSignatures: OpenAgreementSignatures{
+		ConfirmerSignatures: OpenSignatures{
 			Declaration: xdr.Signature{3},
 			Close:       xdr.Signature{4},
 			Formation:   xdr.Signature{5},
@@ -337,7 +337,7 @@ func TestChannel_OpenTx(t *testing.T) {
 		Operations:    []txnbuild.Operation{&txnbuild.BumpSequence{}},
 	})
 	require.NoError(t, err)
-	channel.openAgreementTransactions = OpenAgreementTransactions{
+	channel.openAgreementTransactions = OpenTransactions{
 		Formation: testTx,
 	}
 	formationTx, err = channel.OpenTx()
@@ -350,7 +350,7 @@ func TestChannel_OpenAgreementIsFull(t *testing.T) {
 	assert.False(t, oa.isFull())
 
 	oa = OpenAgreement{
-		ProposerSignatures: OpenAgreementSignatures{
+		ProposerSignatures: OpenSignatures{
 			Close:       xdr.Signature{1},
 			Declaration: xdr.Signature{1},
 			Formation:   xdr.Signature{1},
@@ -358,7 +358,7 @@ func TestChannel_OpenAgreementIsFull(t *testing.T) {
 	}
 	assert.False(t, oa.isFull())
 
-	oa.ConfirmerSignatures = OpenAgreementSignatures{
+	oa.ConfirmerSignatures = OpenSignatures{
 		Close:       xdr.Signature{1},
 		Declaration: xdr.Signature{1},
 	}
@@ -452,7 +452,7 @@ func TestChannel_ProposeAndConfirmOpen_rejectIfChannelAlreadyOpen(t *testing.T) 
 	require.EqualError(t, err, "validating open agreement: cannot confirm a new open if channel is already opened")
 
 	// A channel without a full open agreement should be able to propose an open
-	initiatorChannel.openAgreement.ConfirmerSignatures = OpenAgreementSignatures{}
+	initiatorChannel.openAgreement.ConfirmerSignatures = OpenSignatures{}
 	_, err = initiatorChannel.ProposeOpen(OpenParams{
 		Asset:     NativeAsset,
 		ExpiresAt: time.Now().Add(5 * time.Minute),

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -17,8 +17,8 @@ import (
 // 3. Sender calls ConfirmPayment
 // 4. Receiver calls ConfirmPayment
 
-// CloseAgreementDetails contains the details that the participants agree on.
-type CloseAgreementDetails struct {
+// CloseDetails contains the details that the participants agree on.
+type CloseDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	IterationNumber            int64
@@ -28,30 +28,30 @@ type CloseAgreementDetails struct {
 	ConfirmingSigner           *keypair.FromAddress
 }
 
-func (d CloseAgreementDetails) Equal(d2 CloseAgreementDetails) bool {
+func (d CloseDetails) Equal(d2 CloseDetails) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
-	type CAD CloseAgreementDetails
+	type CAD CloseDetails
 	return cmp.Equal(CAD(d), CAD(d2))
 }
 
-type CloseAgreementSignatures struct {
+type CloseSignatures struct {
 	Close       xdr.Signature
 	Declaration xdr.Signature
 }
 
-func signCloseAgreementTxs(txs CloseAgreementTransactions, networkPassphrase string, signer *keypair.Full) (s CloseAgreementSignatures, err error) {
+func signCloseAgreementTxs(txs CloseTransactions, networkPassphrase string, signer *keypair.Full) (s CloseSignatures, err error) {
 	s.Declaration, err = signTx(txs.Declaration, networkPassphrase, signer)
 	if err != nil {
-		return CloseAgreementSignatures{}, fmt.Errorf("signing declaration: %w", err)
+		return CloseSignatures{}, fmt.Errorf("signing declaration: %w", err)
 	}
 	s.Close, err = signTx(txs.Close, networkPassphrase, signer)
 	if err != nil {
-		return CloseAgreementSignatures{}, fmt.Errorf("signing close: %w", err)
+		return CloseSignatures{}, fmt.Errorf("signing close: %w", err)
 	}
 	return s, nil
 }
 
-func (s CloseAgreementSignatures) Verify(txs CloseAgreementTransactions, networkPassphrase string, signer *keypair.FromAddress) error {
+func (s CloseSignatures) Verify(txs CloseTransactions, networkPassphrase string, signer *keypair.FromAddress) error {
 	err := verifySigned(txs.Declaration, networkPassphrase, signer, s.Declaration)
 	if err != nil {
 		return fmt.Errorf("verifying declaration signed: %w", err)
@@ -63,9 +63,9 @@ func (s CloseAgreementSignatures) Verify(txs CloseAgreementTransactions, network
 	return nil
 }
 
-// CloseAgreementTransactions contain all the transaction hashes and
+// CloseTransactions contain all the transaction hashes and
 // transactions for the transactions that make up the close agreement.
-type CloseAgreementTransactions struct {
+type CloseTransactions struct {
 	CloseHash       TransactionHash
 	Close           *txnbuild.Transaction
 	DeclarationHash TransactionHash
@@ -75,9 +75,9 @@ type CloseAgreementTransactions struct {
 // CloseAgreement contains everything a participant needs to execute the close
 // agreement on the Stellar network.
 type CloseAgreement struct {
-	Details             CloseAgreementDetails
-	ProposerSignatures  CloseAgreementSignatures
-	ConfirmerSignatures CloseAgreementSignatures
+	Details             CloseDetails
+	ProposerSignatures  CloseSignatures
+	ConfirmerSignatures CloseSignatures
 }
 
 func (ca CloseAgreement) isEmpty() bool {
@@ -90,7 +90,7 @@ func (ca CloseAgreement) Equal(ca2 CloseAgreement) bool {
 	return cmp.Equal(CA(ca), CA(ca2))
 }
 
-func (ca CloseAgreement) SignaturesFor(signer *keypair.FromAddress) *CloseAgreementSignatures {
+func (ca CloseAgreement) SignaturesFor(signer *keypair.FromAddress) *CloseSignatures {
 	if ca.Details.ProposingSigner.Equal(signer) {
 		return &ca.ProposerSignatures
 	}
@@ -138,7 +138,7 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		return CloseAgreement{}, fmt.Errorf("amount over commits: %w", ErrUnderfunded)
 	}
 
-	d := CloseAgreementDetails{
+	d := CloseDetails{
 		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap,
 		IterationNumber:            c.NextIterationNumber(),
@@ -160,7 +160,7 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		Details:            d,
 		ProposerSignatures: sigs,
 	}
-	c.latestUnauthorizedCloseAgreementTransactions = txs
+	c.latestUnauthorizedCloseTransactions = txs
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
@@ -274,9 +274,9 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	// All signatures are present that would be required to submit all
 	// transactions in the payment.
 	c.latestAuthorizedCloseAgreement = ca
-	c.latestAuthorizedCloseAgreementTransactions = txs
+	c.latestAuthorizedCloseTransactions = txs
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}
-	c.latestUnauthorizedCloseAgreementTransactions = CloseAgreementTransactions{}
+	c.latestUnauthorizedCloseTransactions = CloseTransactions{}
 
 	return c.latestAuthorizedCloseAgreement, nil
 }

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -17,8 +17,8 @@ import (
 // 3. Sender calls ConfirmPayment
 // 4. Receiver calls ConfirmPayment
 
-// CloseDetails contains the details that the participants agree on.
-type CloseDetails struct {
+// CloseAgreementDetails contains the details that the participants agree on.
+type CloseAgreementDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	IterationNumber            int64
@@ -28,9 +28,9 @@ type CloseDetails struct {
 	ConfirmingSigner           *keypair.FromAddress
 }
 
-func (d CloseDetails) Equal(d2 CloseDetails) bool {
+func (d CloseAgreementDetails) Equal(d2 CloseAgreementDetails) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
-	type CAD CloseDetails
+	type CAD CloseAgreementDetails
 	return cmp.Equal(CAD(d), CAD(d2))
 }
 
@@ -75,7 +75,7 @@ type CloseTransactions struct {
 // CloseAgreement contains everything a participant needs to execute the close
 // agreement on the Stellar network.
 type CloseAgreement struct {
-	Details             CloseDetails
+	Details             CloseAgreementDetails
 	ProposerSignatures  CloseSignatures
 	ConfirmerSignatures CloseSignatures
 }
@@ -138,7 +138,7 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		return CloseAgreement{}, fmt.Errorf("amount over commits: %w", ErrUnderfunded)
 	}
 
-	d := CloseDetails{
+	d := CloseAgreementDetails{
 		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap,
 		IterationNumber:            c.NextIterationNumber(),

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -22,7 +22,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		{CloseAgreement{}, CloseAgreement{}, true},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -30,7 +30,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -41,7 +41,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -53,7 +53,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -64,7 +64,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -78,7 +78,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -93,7 +93,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -104,7 +104,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -118,7 +118,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -130,7 +130,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -145,7 +145,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -157,7 +157,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -172,7 +172,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -184,7 +184,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -274,14 +274,14 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 	// observation period matches the channels observation period.
 	{
 		initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-			Details: CloseDetails{
+			Details: CloseAgreementDetails{
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
 				ConfirmingSigner:           localSigner.FromAddress(),
 			},
 		}
 
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
@@ -296,7 +296,7 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
 		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseDetails{
+			Details: CloseAgreementDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
@@ -377,7 +377,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	}
 
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			ConfirmingSigner:           localSigner.FromAddress(),
@@ -387,7 +387,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	// A close agreement from the remote participant should be rejected if the
 	// observation period doesn't match the channels observation period.
 	{
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
@@ -401,7 +401,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
 		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseDetails{
+			Details: CloseAgreementDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      0,
 				ObservationPeriodLedgerGap: 0,
@@ -482,7 +482,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    100, // Local (initiator) owes remote (responder) 100.
 			ObservationPeriodTime:      10,
@@ -491,7 +491,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 		},
 	}
 
-	ca := CloseDetails{
+	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -585,7 +585,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    100, // Remote (initiator) owes local (responder) 100.
 			ObservationPeriodTime:      10,
@@ -593,7 +593,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 			ConfirmingSigner:           localSigner.FromAddress(),
 		},
 	}
-	ca := CloseDetails{
+	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    90,  // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -688,7 +688,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    -60, // Remote (responder) owes local (initiator) 60.
 			ObservationPeriodTime:      10,
@@ -697,7 +697,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 		},
 	}
 
-	ca := CloseDetails{
+	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
 		PaymentAmount:              50,
@@ -803,7 +803,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    60, // Remote (initiator) owes local (responder) 60.
 			ObservationPeriodTime:      10,
@@ -812,7 +812,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 		},
 	}
 
-	ca := CloseDetails{
+	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
 		PaymentAmount:              50,
@@ -918,7 +918,7 @@ func TestChannel_ConfirmPayment_initiatorCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    60, // Local (initiator) owes remote (responder) 60.
 			ObservationPeriodTime:      10,
@@ -1004,7 +1004,7 @@ func TestChannel_ConfirmPayment_responderCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    -60, // Local (responder) owes remote (initiator) 60.
 			ObservationPeriodTime:      10,
@@ -1109,7 +1109,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 
 	// Confirming a close agreement with same sequence number but different Amount should error
 	caDifferent := CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            2,
 			Balance:                    400,
 			ObservationPeriodTime:      10,
@@ -1228,7 +1228,7 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 
 	// After proposing a coordinated close, confirming a payment should error.
 	p := CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			ObservationPeriodTime:      10,
 			ObservationPeriodLedgerGap: 10,
 			IterationNumber:            1,
@@ -1254,7 +1254,7 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 
 	// After a confirmed coordinated close, confirming a payment should error.
 	p = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
 			IterationNumber:            2,

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -22,7 +22,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		{CloseAgreement{}, CloseAgreement{}, true},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -30,7 +30,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -41,7 +41,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -53,24 +53,24 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -78,13 +78,13 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -93,24 +93,24 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -118,26 +118,26 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -145,26 +145,26 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GDJ5SXSKKFXINP7TN4J4T4JAXL4VZL7UMIAGZWQTYSKHSNHLSPVOAXRY"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -172,26 +172,26 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           nil,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -274,14 +274,14 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 	// observation period matches the channels observation period.
 	{
 		initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-			Details: CloseAgreementDetails{
+			Details: CloseDetails{
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
 				ConfirmingSigner:           localSigner.FromAddress(),
 			},
 		}
 
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
@@ -296,14 +296,14 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
 		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseAgreementDetails{
+			Details: CloseDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
 				ProposingSigner:            remoteSigner.FromAddress(),
 				ConfirmingSigner:           localSigner.FromAddress(),
 			},
-			ProposerSignatures: CloseAgreementSignatures{
+			ProposerSignatures: CloseSignatures{
 				Declaration: txDecl.Signatures()[0].Signature,
 				Close:       txClose.Signatures()[0].Signature,
 			},
@@ -377,7 +377,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	}
 
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			ConfirmingSigner:           localSigner.FromAddress(),
@@ -387,7 +387,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	// A close agreement from the remote participant should be rejected if the
 	// observation period doesn't match the channels observation period.
 	{
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
@@ -401,12 +401,12 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
 		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseAgreementDetails{
+			Details: CloseDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      0,
 				ObservationPeriodLedgerGap: 0,
 			},
-			ProposerSignatures: CloseAgreementSignatures{
+			ProposerSignatures: CloseSignatures{
 				Declaration: txDecl.Signatures()[0].Signature,
 				Close:       txClose.Signatures()[0].Signature,
 			},
@@ -482,7 +482,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    100, // Local (initiator) owes remote (responder) 100.
 			ObservationPeriodTime:      10,
@@ -491,7 +491,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 		},
 	}
 
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -510,7 +510,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	require.NoError(t, err)
 	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -585,7 +585,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    100, // Remote (initiator) owes local (responder) 100.
 			ObservationPeriodTime:      10,
@@ -593,7 +593,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 			ConfirmingSigner:           localSigner.FromAddress(),
 		},
 	}
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    90,  // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -613,7 +613,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	require.NoError(t, err)
 	_, err = responderChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -688,7 +688,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    -60, // Remote (responder) owes local (initiator) 60.
 			ObservationPeriodTime:      10,
@@ -697,7 +697,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 		},
 	}
 
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
 		PaymentAmount:              50,
@@ -716,7 +716,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	require.NoError(t, err)
 	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -728,7 +728,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	initiatorChannel.UpdateRemoteEscrowAccountBalance(200)
 	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -803,7 +803,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    60, // Remote (initiator) owes local (responder) 60.
 			ObservationPeriodTime:      10,
@@ -812,7 +812,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 		},
 	}
 
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
 		PaymentAmount:              50,
@@ -831,7 +831,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	require.NoError(t, err)
 	_, err = responderChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -843,7 +843,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	responderChannel.UpdateRemoteEscrowAccountBalance(200)
 	_, err = responderChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -918,7 +918,7 @@ func TestChannel_ConfirmPayment_initiatorCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    60, // Local (initiator) owes remote (responder) 60.
 			ObservationPeriodTime:      10,
@@ -1004,7 +1004,7 @@ func TestChannel_ConfirmPayment_responderCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    -60, // Local (responder) owes remote (initiator) 60.
 			ObservationPeriodTime:      10,
@@ -1109,7 +1109,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 
 	// Confirming a close agreement with same sequence number but different Amount should error
 	caDifferent := CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            2,
 			Balance:                    400,
 			ObservationPeriodTime:      10,
@@ -1228,7 +1228,7 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 
 	// After proposing a coordinated close, confirming a payment should error.
 	p := CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			ObservationPeriodTime:      10,
 			ObservationPeriodLedgerGap: 10,
 			IterationNumber:            1,
@@ -1254,7 +1254,7 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 
 	// After a confirmed coordinated close, confirming a payment should error.
 	p = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
 			IterationNumber:            2,

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -69,7 +69,7 @@ func NewChannelFromSnapshot(c Config, s Snapshot) *Channel {
 	channel.remoteEscrowAccount.Balance = s.RemoteEscrowAccountBalance
 
 	channel.openAgreement = s.OpenAgreement
-	channel.openAgreementTransactions = s.OpenAgreementTransactions
+	channel.openTransactions = s.OpenAgreementTransactions
 	channel.openExecutedAndValidated = s.OpenExecutedAndValidated
 	if s.OpenExecutedWithError {
 		channel.openExecutedWithError = fmt.Errorf("open executed with error")
@@ -100,10 +100,10 @@ type Channel struct {
 	localSigner  *keypair.Full
 	remoteSigner *keypair.FromAddress
 
-	openAgreement             OpenAgreement
-	openAgreementTransactions OpenTransactions
-	openExecutedAndValidated  bool
-	openExecutedWithError     error
+	openAgreement            OpenAgreement
+	openTransactions         OpenTransactions
+	openExecutedAndValidated bool
+	openExecutedWithError    error
 
 	latestAuthorizedCloseAgreement      CloseAgreement
 	latestAuthorizedCloseTransactions   CloseTransactions
@@ -122,7 +122,7 @@ func (c *Channel) Snapshot() Snapshot {
 		RemoteEscrowAccountBalance: c.remoteEscrowAccount.Balance,
 
 		OpenAgreement:             c.openAgreement,
-		OpenAgreementTransactions: c.openAgreementTransactions,
+		OpenAgreementTransactions: c.openTransactions,
 		OpenExecutedAndValidated:  c.openExecutedAndValidated,
 		OpenExecutedWithError:     c.openExecutedWithError != nil,
 

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -46,14 +46,14 @@ type Snapshot struct {
 	RemoteEscrowAccountBalance int64
 
 	OpenAgreement             OpenAgreement
-	OpenAgreementTransactions OpenAgreementTransactions
+	OpenAgreementTransactions OpenTransactions
 	OpenExecutedAndValidated  bool
 	OpenExecutedWithError     bool
 
-	LatestAuthorizedCloseAgreement               CloseAgreement
-	LatestAuthorizedCloseAgreementTransactions   CloseAgreementTransactions
-	LatestUnauthorizedCloseAgreement             CloseAgreement
-	LatestUnauthorizedCloseAgreementTransactions CloseAgreementTransactions
+	LatestAuthorizedCloseAgreement      CloseAgreement
+	LatestAuthorizedCloseTransactions   CloseTransactions
+	LatestUnauthorizedCloseAgreement    CloseAgreement
+	LatestUnauthorizedCloseTransactions CloseTransactions
 }
 
 // NewChannelFromSnapshot creates the channel with the given config, and
@@ -76,9 +76,9 @@ func NewChannelFromSnapshot(c Config, s Snapshot) *Channel {
 	}
 
 	channel.latestAuthorizedCloseAgreement = s.LatestAuthorizedCloseAgreement
-	channel.latestAuthorizedCloseAgreementTransactions = s.LatestAuthorizedCloseAgreementTransactions
+	channel.latestAuthorizedCloseTransactions = s.LatestAuthorizedCloseTransactions
 	channel.latestUnauthorizedCloseAgreement = s.LatestUnauthorizedCloseAgreement
-	channel.latestUnauthorizedCloseAgreementTransactions = s.LatestUnauthorizedCloseAgreementTransactions
+	channel.latestUnauthorizedCloseTransactions = s.LatestUnauthorizedCloseTransactions
 
 	return channel
 }
@@ -101,14 +101,14 @@ type Channel struct {
 	remoteSigner *keypair.FromAddress
 
 	openAgreement             OpenAgreement
-	openAgreementTransactions OpenAgreementTransactions
+	openAgreementTransactions OpenTransactions
 	openExecutedAndValidated  bool
 	openExecutedWithError     error
 
-	latestAuthorizedCloseAgreement               CloseAgreement
-	latestAuthorizedCloseAgreementTransactions   CloseAgreementTransactions
-	latestUnauthorizedCloseAgreement             CloseAgreement
-	latestUnauthorizedCloseAgreementTransactions CloseAgreementTransactions
+	latestAuthorizedCloseAgreement      CloseAgreement
+	latestAuthorizedCloseTransactions   CloseTransactions
+	latestUnauthorizedCloseAgreement    CloseAgreement
+	latestUnauthorizedCloseTransactions CloseTransactions
 }
 
 // Snapshot returns a snapshot of the channel's internal state that if combined
@@ -126,10 +126,10 @@ func (c *Channel) Snapshot() Snapshot {
 		OpenExecutedAndValidated:  c.openExecutedAndValidated,
 		OpenExecutedWithError:     c.openExecutedWithError != nil,
 
-		LatestAuthorizedCloseAgreement:               c.latestAuthorizedCloseAgreement,
-		LatestAuthorizedCloseAgreementTransactions:   c.latestAuthorizedCloseAgreementTransactions,
-		LatestUnauthorizedCloseAgreement:             c.latestUnauthorizedCloseAgreement,
-		LatestUnauthorizedCloseAgreementTransactions: c.latestUnauthorizedCloseAgreementTransactions,
+		LatestAuthorizedCloseAgreement:      c.latestAuthorizedCloseAgreement,
+		LatestAuthorizedCloseTransactions:   c.latestAuthorizedCloseTransactions,
+		LatestUnauthorizedCloseAgreement:    c.latestUnauthorizedCloseAgreement,
+		LatestUnauthorizedCloseTransactions: c.latestUnauthorizedCloseTransactions,
 	}
 }
 


### PR DESCRIPTION
### What
Replace the `CloseAgreement` and `OpenAgreement` prefixes on types with simply `Close` and `Open`.

Rename `CloseAgreementSignatures` to `CloseSignatures`.
Rename `CloseAgreementTransactions` to `CloseTransactions`.

Rename `OpenAgreementSignatures` to `OpenSignatures`.
Rename `OpenAgreementTransactions` to `OpenTransactions`.

### Why
As a follow up of the storing transactions work (#294) and as part of the work to make it easy for examples and experiments to store transactions as they occur in the channel I plan to move the `CloseAgreementTransactions` and `CloseAgreement` into some new type. There are quite a few types nested the term 'Agreement' has become a little meaningless as it seems like the word shows up in every type. I think it would be helpful to remove it from everywhere except the types that is in fact the full agreement, which is the `CloseAgreement` type. In this way the `CloseAgreement` is made up of many parts, but the only thing that is the agreement, is the `CloseAgreement` itself.

For #302