### PR TITLE
sdk/state: encapsulate stored txs inside close agreements

### DIFF
--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -108,9 +108,9 @@ func run() error {
 			case agentpkg.OpenedEvent:
 				fmt.Fprintf(os.Stderr, "agent channel opened\n")
 			case agentpkg.PaymentReceivedEvent:
-				fmt.Fprintf(os.Stderr, "agent channel received payment: iteration=%d balance=%s\n", e.CloseAgreement.Details.IterationNumber, amount.StringFromInt64(e.CloseAgreement.Details.Balance))
+				fmt.Fprintf(os.Stderr, "agent channel received payment: iteration=%d balance=%s\n", e.CloseAgreement.Envelope.Details.IterationNumber, amount.StringFromInt64(e.CloseAgreement.Envelope.Details.Balance))
 			case agentpkg.PaymentSentEvent:
-				fmt.Fprintf(os.Stderr, "agent channel sent payment and other participant confirmed: iteration=%d balance=%s\n", e.CloseAgreement.Details.IterationNumber, amount.StringFromInt64(e.CloseAgreement.Details.Balance))
+				fmt.Fprintf(os.Stderr, "agent channel sent payment and other participant confirmed: iteration=%d balance=%s\n", e.CloseAgreement.Envelope.Details.IterationNumber, amount.StringFromInt64(e.CloseAgreement.Envelope.Details.Balance))
 			case agentpkg.ClosingEvent:
 				fmt.Fprintf(os.Stderr, "agent channel closing\n")
 			case agentpkg.ClosedEvent:

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -256,7 +256,7 @@ func (a *Agent) Open() error {
 	enc := msg.NewEncoder(io.MultiWriter(a.conn, a.logWriter))
 	err = enc.Encode(msg.Message{
 		Type:        msg.TypeOpenRequest,
-		OpenRequest: &open,
+		OpenRequest: &open.Envelope,
 	})
 	if err != nil {
 		return fmt.Errorf("sending open: %w", err)
@@ -304,7 +304,7 @@ func (a *Agent) Payment(paymentAmount string) error {
 	enc := msg.NewEncoder(io.MultiWriter(a.conn, a.logWriter))
 	err = enc.Encode(msg.Message{
 		Type:           msg.TypePaymentRequest,
-		PaymentRequest: &ca,
+		PaymentRequest: &ca.Envelope,
 	})
 	if err != nil {
 		return fmt.Errorf("sending payment: %w", err)
@@ -356,7 +356,7 @@ func (a *Agent) DeclareClose() error {
 	enc := msg.NewEncoder(io.MultiWriter(a.conn, a.logWriter))
 	err = enc.Encode(msg.Message{
 		Type:         msg.TypeCloseRequest,
-		CloseRequest: &ca,
+		CloseRequest: &ca.Envelope,
 	})
 	if err != nil {
 		return fmt.Errorf("error: sending the close proposal: %w", err)
@@ -502,7 +502,7 @@ func (a *Agent) handleOpenRequest(m msg.Message, send *msg.Encoder) error {
 	fmt.Fprintf(a.logWriter, "open authorized\n")
 	err = send.Encode(msg.Message{
 		Type:         msg.TypeOpenResponse,
-		OpenResponse: &open,
+		OpenResponse: &open.Envelope,
 	})
 	if err != nil {
 		return fmt.Errorf("encoding open to send back: %w", err)
@@ -563,9 +563,9 @@ func (a *Agent) handlePaymentRequest(m msg.Message, send *msg.Encoder) error {
 		return fmt.Errorf("confirming payment: %w", err)
 	}
 	fmt.Fprintf(a.logWriter, "payment authorized\n")
-	err = send.Encode(msg.Message{Type: msg.TypePaymentResponse, PaymentResponse: &payment})
+	err = send.Encode(msg.Message{Type: msg.TypePaymentResponse, PaymentResponse: &payment.Envelope})
 	if a.events != nil {
-		a.events <- PaymentReceivedEvent{CloseAgreement: payment}
+		a.events <- PaymentReceivedEvent{CloseAgreement: payment.Envelope}
 	}
 	if err != nil {
 		return fmt.Errorf("encoding payment to send back: %w", err)
@@ -590,7 +590,7 @@ func (a *Agent) handlePaymentResponse(m msg.Message, send *msg.Encoder) error {
 	}
 	fmt.Fprintf(a.logWriter, "payment authorized\n")
 	if a.events != nil {
-		a.events <- PaymentSentEvent{CloseAgreement: payment}
+		a.events <- PaymentSentEvent{CloseAgreement: payment.Envelope}
 	}
 	return nil
 }
@@ -613,7 +613,7 @@ func (a *Agent) handleCloseRequest(m msg.Message, send *msg.Encoder) error {
 	}
 	err = send.Encode(msg.Message{
 		Type:          msg.TypeCloseResponse,
-		CloseResponse: &close,
+		CloseResponse: &close.Envelope,
 	})
 	if err != nil {
 		return fmt.Errorf("encoding close to send back: %v\n", err)

--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -565,7 +565,7 @@ func (a *Agent) handlePaymentRequest(m msg.Message, send *msg.Encoder) error {
 	fmt.Fprintf(a.logWriter, "payment authorized\n")
 	err = send.Encode(msg.Message{Type: msg.TypePaymentResponse, PaymentResponse: &payment.Envelope})
 	if a.events != nil {
-		a.events <- PaymentReceivedEvent{CloseAgreement: payment.Envelope}
+		a.events <- PaymentReceivedEvent{CloseAgreement: payment}
 	}
 	if err != nil {
 		return fmt.Errorf("encoding payment to send back: %w", err)
@@ -590,7 +590,7 @@ func (a *Agent) handlePaymentResponse(m msg.Message, send *msg.Encoder) error {
 	}
 	fmt.Fprintf(a.logWriter, "payment authorized\n")
 	if a.events != nil {
-		a.events <- PaymentSentEvent{CloseAgreement: payment.Envelope}
+		a.events <- PaymentSentEvent{CloseAgreement: payment}
 	}
 	return nil
 }

--- a/sdk/agent/agent_test.go
+++ b/sdk/agent/agent_test.go
@@ -296,14 +296,14 @@ func TestAgent_openPaymentClose(t *testing.T) {
 		require.True(t, ok)
 		localPaymentEvent, ok := localEvent.(PaymentSentEvent)
 		require.True(t, ok)
-		assert.Equal(t, int64(2), localPaymentEvent.CloseAgreement.Details.IterationNumber)
-		assert.Equal(t, int64(50_0000000), localPaymentEvent.CloseAgreement.Details.Balance)
+		assert.Equal(t, int64(2), localPaymentEvent.CloseAgreement.Envelope.Details.IterationNumber)
+		assert.Equal(t, int64(50_0000000), localPaymentEvent.CloseAgreement.Envelope.Details.Balance)
 		remoteEvent, ok := <-remoteEvents
 		require.True(t, ok)
 		remotePaymentEvent, ok := remoteEvent.(PaymentReceivedEvent)
 		require.True(t, ok)
-		assert.Equal(t, int64(2), remotePaymentEvent.CloseAgreement.Details.IterationNumber)
-		assert.Equal(t, int64(50_0000000), remotePaymentEvent.CloseAgreement.Details.Balance)
+		assert.Equal(t, int64(2), remotePaymentEvent.CloseAgreement.Envelope.Details.IterationNumber)
+		assert.Equal(t, int64(50_0000000), remotePaymentEvent.CloseAgreement.Envelope.Details.Balance)
 	}
 
 	// Make another payment.
@@ -320,14 +320,14 @@ func TestAgent_openPaymentClose(t *testing.T) {
 		require.True(t, ok)
 		localPaymentEvent, ok := localEvent.(PaymentReceivedEvent)
 		require.True(t, ok)
-		assert.Equal(t, int64(3), localPaymentEvent.CloseAgreement.Details.IterationNumber)
-		assert.Equal(t, int64(30_0000000), localPaymentEvent.CloseAgreement.Details.Balance)
+		assert.Equal(t, int64(3), localPaymentEvent.CloseAgreement.Envelope.Details.IterationNumber)
+		assert.Equal(t, int64(30_0000000), localPaymentEvent.CloseAgreement.Envelope.Details.Balance)
 		remoteEvent, ok := <-remoteEvents
 		require.True(t, ok)
 		remotePaymentEvent, ok := remoteEvent.(PaymentSentEvent)
 		require.True(t, ok)
-		assert.Equal(t, int64(3), remotePaymentEvent.CloseAgreement.Details.IterationNumber)
-		assert.Equal(t, int64(30_0000000), remotePaymentEvent.CloseAgreement.Details.Balance)
+		assert.Equal(t, int64(3), remotePaymentEvent.CloseAgreement.Envelope.Details.IterationNumber)
+		assert.Equal(t, int64(30_0000000), remotePaymentEvent.CloseAgreement.Envelope.Details.Balance)
 	}
 
 	// Expect no txs to have been submitted for payments.

--- a/sdk/agent/events.go
+++ b/sdk/agent/events.go
@@ -27,7 +27,7 @@ func (e OpenedEvent) event() {}
 // PaymentReceivedEvent occurs when a payment is received and the balance it
 // agrees to would be the resulting disbursements from the channel if closed.
 type PaymentReceivedEvent struct {
-	CloseAgreement state.CloseEnvelope
+	CloseAgreement state.CloseAgreement
 }
 
 func (e PaymentReceivedEvent) event() {}
@@ -36,7 +36,7 @@ func (e PaymentReceivedEvent) event() {}
 // confirmed it such that the balance the agreement agrees to would be the
 // resulting disbursements from the channel if closed.
 type PaymentSentEvent struct {
-	CloseAgreement state.CloseEnvelope
+	CloseAgreement state.CloseAgreement
 }
 
 func (e PaymentSentEvent) event() {}

--- a/sdk/agent/events.go
+++ b/sdk/agent/events.go
@@ -27,7 +27,7 @@ func (e OpenedEvent) event() {}
 // PaymentReceivedEvent occurs when a payment is received and the balance it
 // agrees to would be the resulting disbursements from the channel if closed.
 type PaymentReceivedEvent struct {
-	CloseAgreement state.CloseAgreement
+	CloseAgreement state.CloseEnvelope
 }
 
 func (e PaymentReceivedEvent) event() {}
@@ -36,7 +36,7 @@ func (e PaymentReceivedEvent) event() {}
 // confirmed it such that the balance the agreement agrees to would be the
 // resulting disbursements from the channel if closed.
 type PaymentSentEvent struct {
-	CloseAgreement state.CloseAgreement
+	CloseAgreement state.CloseEnvelope
 }
 
 func (e PaymentSentEvent) event() {}

--- a/sdk/msg/msg.go
+++ b/sdk/msg/msg.go
@@ -25,14 +25,14 @@ type Message struct {
 
 	Hello *Hello `json:",omitempty"`
 
-	OpenRequest  *state.OpenAgreement `json:",omitempty"`
-	OpenResponse *state.OpenAgreement `json:",omitempty"`
+	OpenRequest  *state.OpenEnvelope `json:",omitempty"`
+	OpenResponse *state.OpenEnvelope `json:",omitempty"`
 
-	PaymentRequest  *state.CloseAgreement `json:",omitempty"`
-	PaymentResponse *state.CloseAgreement `json:",omitempty"`
+	PaymentRequest  *state.CloseEnvelope `json:",omitempty"`
+	PaymentResponse *state.CloseEnvelope `json:",omitempty"`
 
-	CloseRequest  *state.CloseAgreement `json:",omitempty"`
-	CloseResponse *state.CloseAgreement `json:",omitempty"`
+	CloseRequest  *state.CloseEnvelope `json:",omitempty"`
+	CloseResponse *state.CloseEnvelope `json:",omitempty"`
 }
 
 type Hello struct {

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -14,7 +14,7 @@ import (
 // transactions and still has them stored internally then it will return those
 // previously built transactions, otherwise the transactions will be built from
 // scratch.
-func (c *Channel) closeTxs(oad OpenDetails, d CloseDetails) (txs CloseTransactions, err error) {
+func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (txs CloseTransactions, err error) {
 	if c.openAgreement.Details.Equal(oad) {
 		if c.latestAuthorizedCloseAgreement.Details.Equal(d) {
 			return c.latestAuthorizedCloseTransactions, nil

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -14,13 +14,13 @@ import (
 // transactions and still has them stored internally then it will return those
 // previously built transactions, otherwise the transactions will be built from
 // scratch.
-func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (txs CloseAgreementTransactions, err error) {
+func (c *Channel) closeTxs(oad OpenDetails, d CloseDetails) (txs CloseTransactions, err error) {
 	if c.openAgreement.Details.Equal(oad) {
 		if c.latestAuthorizedCloseAgreement.Details.Equal(d) {
-			return c.latestAuthorizedCloseAgreementTransactions, nil
+			return c.latestAuthorizedCloseTransactions, nil
 		}
 		if c.latestUnauthorizedCloseAgreement.Details.Equal(d) {
-			return c.latestUnauthorizedCloseAgreementTransactions, nil
+			return c.latestUnauthorizedCloseTransactions, nil
 		}
 	}
 	txClose, err := txbuild.Close(txbuild.CloseParams{
@@ -37,11 +37,11 @@ func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (t
 		Asset:                      oad.Asset.Asset(),
 	})
 	if err != nil {
-		return CloseAgreementTransactions{}, err
+		return CloseTransactions{}, err
 	}
 	txCloseHash, err := txClose.Hash(c.networkPassphrase)
 	if err != nil {
-		return CloseAgreementTransactions{}, err
+		return CloseTransactions{}, err
 	}
 	txDecl, err := txbuild.Declaration(txbuild.DeclarationParams{
 		InitiatorEscrow:         c.initiatorEscrowAccount().Address,
@@ -52,13 +52,13 @@ func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (t
 		CloseTxHash:             txCloseHash,
 	})
 	if err != nil {
-		return CloseAgreementTransactions{}, err
+		return CloseTransactions{}, err
 	}
 	txDeclHash, err := txDecl.Hash(c.networkPassphrase)
 	if err != nil {
-		return CloseAgreementTransactions{}, err
+		return CloseTransactions{}, err
 	}
-	txs = CloseAgreementTransactions{
+	txs = CloseTransactions{
 		DeclarationHash: txDeclHash,
 		Declaration:     txDecl,
 		CloseHash:       txCloseHash,
@@ -130,7 +130,7 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 		Details:            d,
 		ProposerSignatures: sigs,
 	}
-	c.latestUnauthorizedCloseAgreementTransactions = txs
+	c.latestUnauthorizedCloseTransactions = txs
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
@@ -202,8 +202,8 @@ func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement
 
 	// The new close agreement is valid and authorized, store and promote it.
 	c.latestAuthorizedCloseAgreement = ca
-	c.latestAuthorizedCloseAgreementTransactions = txs
+	c.latestAuthorizedCloseTransactions = txs
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}
-	c.latestUnauthorizedCloseAgreementTransactions = CloseAgreementTransactions{}
+	c.latestUnauthorizedCloseTransactions = CloseTransactions{}
 	return c.latestAuthorizedCloseAgreement, nil
 }

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -204,7 +204,7 @@ func (c *Channel) ConfirmClose(ce CloseEnvelope) (closeAgreement CloseAgreement,
 
 	// The new close agreement is valid and authorized, store and promote it.
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Envelope: ce,
+		Envelope:     ce,
 		Transactions: txs,
 	}
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -14,13 +14,13 @@ import (
 // transactions and still has them stored internally then it will return those
 // previously built transactions, otherwise the transactions will be built from
 // scratch.
-func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (txs CloseTransactions, err error) {
-	if c.openAgreement.Details.Equal(oad) {
-		if c.latestAuthorizedCloseAgreement.Details.Equal(d) {
-			return c.latestAuthorizedCloseTransactions, nil
+func (c *Channel) closeTxs(oad OpenDetails, d CloseDetails) (txs CloseTransactions, err error) {
+	if c.openAgreement.Envelope.Details.Equal(oad) {
+		if c.latestAuthorizedCloseAgreement.Envelope.Details.Equal(d) {
+			return c.latestAuthorizedCloseAgreement.Transactions, nil
 		}
-		if c.latestUnauthorizedCloseAgreement.Details.Equal(d) {
-			return c.latestUnauthorizedCloseTransactions, nil
+		if c.latestUnauthorizedCloseAgreement.Envelope.Details.Equal(d) {
+			return c.latestUnauthorizedCloseAgreement.Transactions, nil
 		}
 	}
 	txClose, err := txbuild.Close(txbuild.CloseParams{
@@ -71,8 +71,8 @@ func (c *Channel) closeTxs(oad OpenAgreementDetails, d CloseAgreementDetails) (t
 // channel using the latest close agreement. The transactions are signed and
 // ready to submit.
 func (c *Channel) CloseTxs() (declTx *txnbuild.Transaction, closeTx *txnbuild.Transaction, err error) {
-	ca := c.latestAuthorizedCloseAgreement
-	txs, err := c.closeTxs(c.openAgreement.Details, ca.Details)
+	cae := c.latestAuthorizedCloseAgreement.Envelope
+	txs, err := c.closeTxs(c.openAgreement.Envelope.Details, cae.Details)
 	if err != nil {
 		return nil, nil, fmt.Errorf("building declaration and close txs for latest close agreement: %w", err)
 	}
@@ -81,16 +81,16 @@ func (c *Channel) CloseTxs() (declTx *txnbuild.Transaction, closeTx *txnbuild.Tr
 	closeTx = txs.Close
 
 	// Add the declaration signatures to the declaration tx.
-	declTx, _ = declTx.AddSignatureDecorated(xdr.NewDecoratedSignature(ca.ProposerSignatures.Declaration, ca.Details.ProposingSigner.Hint()))
-	declTx, _ = declTx.AddSignatureDecorated(xdr.NewDecoratedSignature(ca.ConfirmerSignatures.Declaration, ca.Details.ConfirmingSigner.Hint()))
+	declTx, _ = declTx.AddSignatureDecorated(xdr.NewDecoratedSignature(cae.ProposerSignatures.Declaration, cae.Details.ProposingSigner.Hint()))
+	declTx, _ = declTx.AddSignatureDecorated(xdr.NewDecoratedSignature(cae.ConfirmerSignatures.Declaration, cae.Details.ConfirmingSigner.Hint()))
 
 	// Add the close signature provided by the confirming signer that is
 	// required to be an extra signer on the declaration tx to the formation tx.
-	declTx, _ = declTx.AddSignatureDecorated(xdr.NewDecoratedSignatureForPayload(ca.ConfirmerSignatures.Close, ca.Details.ConfirmingSigner.Hint(), txs.CloseHash[:]))
+	declTx, _ = declTx.AddSignatureDecorated(xdr.NewDecoratedSignatureForPayload(cae.ConfirmerSignatures.Close, cae.Details.ConfirmingSigner.Hint(), txs.CloseHash[:]))
 
 	// Add the close signatures to the close tx.
-	closeTx, _ = closeTx.AddSignatureDecorated(xdr.NewDecoratedSignature(ca.ProposerSignatures.Close, ca.Details.ProposingSigner.Hint()))
-	closeTx, _ = closeTx.AddSignatureDecorated(xdr.NewDecoratedSignature(ca.ConfirmerSignatures.Close, ca.Details.ConfirmingSigner.Hint()))
+	closeTx, _ = closeTx.AddSignatureDecorated(xdr.NewDecoratedSignature(cae.ProposerSignatures.Close, cae.Details.ProposingSigner.Hint()))
+	closeTx, _ = closeTx.AddSignatureDecorated(xdr.NewDecoratedSignature(cae.ConfirmerSignatures.Close, cae.Details.ConfirmingSigner.Hint()))
 
 	return
 }
@@ -101,22 +101,22 @@ func (c *Channel) CloseTxs() (declTx *txnbuild.Transaction, closeTx *txnbuild.Tr
 // than the original observation time.
 func (c *Channel) ProposeClose() (CloseAgreement, error) {
 	// If an unfinished unauthorized agreement exists, error.
-	if !c.latestUnauthorizedCloseAgreement.isEmpty() {
+	if !c.latestUnauthorizedCloseAgreement.Envelope.isEmpty() {
 		return CloseAgreement{}, fmt.Errorf("cannot propose coordinated close while an unfinished payment exists")
 	}
 
 	// If the channel is not open yet, error.
-	if c.latestAuthorizedCloseAgreement.isEmpty() || !c.openExecutedAndValidated {
+	if c.latestAuthorizedCloseAgreement.Envelope.isEmpty() || !c.openExecutedAndValidated {
 		return CloseAgreement{}, fmt.Errorf("cannot propose a coordinated close before channel is opened")
 	}
 
-	d := c.latestAuthorizedCloseAgreement.Details
+	d := c.latestAuthorizedCloseAgreement.Envelope.Details
 	d.ObservationPeriodTime = 0
 	d.ObservationPeriodLedgerGap = 0
 	d.ProposingSigner = c.localSigner.FromAddress()
 	d.ConfirmingSigner = c.remoteSigner
 
-	txs, err := c.closeTxs(c.openAgreement.Details, d)
+	txs, err := c.closeTxs(c.openAgreement.Envelope.Details, d)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("making declaration and close transactions: %w", err)
 	}
@@ -127,22 +127,24 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 
 	// Store the close agreement while participants iterate on signatures.
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{
-		Details:            d,
-		ProposerSignatures: sigs,
+		Envelope: CloseEnvelope{
+			Details:            d,
+			ProposerSignatures: sigs,
+		},
+		Transactions: txs,
 	}
-	c.latestUnauthorizedCloseTransactions = txs
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
-func (c *Channel) validateClose(ca CloseAgreement) error {
+func (c *Channel) validateClose(ca CloseEnvelope) error {
 	// If the channel is not open yet, error.
-	if c.latestAuthorizedCloseAgreement.isEmpty() || !c.openExecutedAndValidated {
+	if c.latestAuthorizedCloseAgreement.Envelope.isEmpty() || !c.openExecutedAndValidated {
 		return fmt.Errorf("cannot confirm a coordinated close before channel is opened")
 	}
-	if ca.Details.IterationNumber != c.latestAuthorizedCloseAgreement.Details.IterationNumber {
+	if ca.Details.IterationNumber != c.latestAuthorizedCloseAgreement.Envelope.Details.IterationNumber {
 		return fmt.Errorf("close agreement iteration number does not match saved latest authorized close agreement")
 	}
-	if ca.Details.Balance != c.latestAuthorizedCloseAgreement.Details.Balance {
+	if ca.Details.Balance != c.latestAuthorizedCloseAgreement.Envelope.Details.Balance {
 		return fmt.Errorf("close agreement balance does not match saved latest authorized close agreement")
 	}
 	if ca.Details.ObservationPeriodTime != 0 {
@@ -161,19 +163,19 @@ func (c *Channel) validateClose(ca CloseAgreement) error {
 // observation period. The agreement will always be accepted if it is identical
 // to the latest authorized close agreement, and it is signed by the participant
 // proposing the close.
-func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement, err error) {
-	err = c.validateClose(ca)
+func (c *Channel) ConfirmClose(ce CloseEnvelope) (closeAgreement CloseAgreement, err error) {
+	err = c.validateClose(ce)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("validating close agreement: %w", err)
 	}
 
-	txs, err := c.closeTxs(c.openAgreement.Details, ca.Details)
+	txs, err := c.closeTxs(c.openAgreement.Envelope.Details, ce.Details)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("making close transactions: %w", err)
 	}
 
 	// If remote has not signed the txs, error as is invalid.
-	remoteSigs := ca.SignaturesFor(c.remoteSigner)
+	remoteSigs := ce.SignaturesFor(c.remoteSigner)
 	if remoteSigs == nil {
 		return CloseAgreement{}, fmt.Errorf("remote is not a signer")
 	}
@@ -183,7 +185,7 @@ func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement
 	}
 
 	// If local has not signed close, check that the payment is not to the proposer, then sign.
-	localSigs := ca.SignaturesFor(c.localSigner.FromAddress())
+	localSigs := ce.SignaturesFor(c.localSigner.FromAddress())
 	if localSigs == nil {
 		return CloseAgreement{}, fmt.Errorf("local is not a signer")
 	}
@@ -191,19 +193,20 @@ func (c *Channel) ConfirmClose(ca CloseAgreement) (closeAgreement CloseAgreement
 	if err != nil {
 		// If the local is not the confirmer, do not sign, because being the
 		// proposer they should have signed earlier.
-		if !ca.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) {
+		if !ce.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) {
 			return CloseAgreement{}, fmt.Errorf("not signed by local: %w", err)
 		}
-		ca.ConfirmerSignatures, err = signCloseAgreementTxs(txs, c.networkPassphrase, c.localSigner)
+		ce.ConfirmerSignatures, err = signCloseAgreementTxs(txs, c.networkPassphrase, c.localSigner)
 		if err != nil {
 			return CloseAgreement{}, fmt.Errorf("local signing: %w", err)
 		}
 	}
 
 	// The new close agreement is valid and authorized, store and promote it.
-	c.latestAuthorizedCloseAgreement = ca
-	c.latestAuthorizedCloseTransactions = txs
+	c.latestAuthorizedCloseAgreement = CloseAgreement{
+		Envelope: ce,
+		Transactions: txs,
+	}
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}
-	c.latestUnauthorizedCloseTransactions = CloseTransactions{}
 	return c.latestAuthorizedCloseAgreement, nil
 }

--- a/sdk/state/close_test.go
+++ b/sdk/state/close_test.go
@@ -28,7 +28,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	oa := OpenAgreement{
-		Details: OpenDetails{
+		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
@@ -36,7 +36,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		},
 	}
 	ca := CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 2,
 			IterationNumber:            3,

--- a/sdk/state/close_test.go
+++ b/sdk/state/close_test.go
@@ -28,7 +28,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	oa := OpenAgreement{
-		Details: OpenAgreementDetails{
+		Details: OpenDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
@@ -36,7 +36,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		},
 	}
 	ca := CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 2,
 			IterationNumber:            3,
@@ -44,11 +44,11 @@ func TestChannel_CloseTx(t *testing.T) {
 			ProposingSigner:            localSigner.FromAddress(),
 			ConfirmingSigner:           remoteSigner.FromAddress(),
 		},
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: xdr.Signature{0},
 			Close:       xdr.Signature{1},
 		},
-		ConfirmerSignatures: CloseAgreementSignatures{
+		ConfirmerSignatures: CloseSignatures{
 			Declaration: xdr.Signature{2},
 			Close:       xdr.Signature{3},
 		},
@@ -57,7 +57,7 @@ func TestChannel_CloseTx(t *testing.T) {
 	require.NoError(t, err)
 	channel.openAgreement = oa
 	channel.latestAuthorizedCloseAgreement = ca
-	channel.latestAuthorizedCloseAgreementTransactions = txs
+	channel.latestAuthorizedCloseTransactions = txs
 	closeTxHash := txs.CloseHash
 
 	// TODO: Compare the non-signature parts of the txs with the result of
@@ -86,7 +86,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		Operations:    []txnbuild.Operation{&txnbuild.BumpSequence{}},
 	})
 	require.NoError(t, err)
-	channel.latestAuthorizedCloseAgreementTransactions = CloseAgreementTransactions{
+	channel.latestAuthorizedCloseTransactions = CloseTransactions{
 		Declaration: testTx,
 		Close:       testTx,
 	}
@@ -105,7 +105,7 @@ func TestChannel_CloseTx(t *testing.T) {
 		Operations:    []txnbuild.Operation{&txnbuild.BumpSequence{}},
 	})
 	require.NoError(t, err)
-	channel.latestUnauthorizedCloseAgreementTransactions = CloseAgreementTransactions{
+	channel.latestUnauthorizedCloseTransactions = CloseTransactions{
 		Declaration: testTx,
 		Close:       testTx,
 	}

--- a/sdk/state/ingest_test.go
+++ b/sdk/state/ingest_test.go
@@ -48,9 +48,9 @@ func TestChannel_IngestTx_latestUnauthorizedDeclTxViaFeeBump(t *testing.T) {
 		ExpiresAt:                  time.Now().Add(time.Minute),
 	})
 	require.NoError(t, err)
-	open, err = responderChannel.ConfirmOpen(open)
+	open, err = responderChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmOpen(open)
+	_, err = initiatorChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
 	initiatorChannel.UpdateLocalEscrowAccountBalance(100)
 	initiatorChannel.UpdateRemoteEscrowAccountBalance(100)
@@ -68,7 +68,7 @@ func TestChannel_IngestTx_latestUnauthorizedDeclTxViaFeeBump(t *testing.T) {
 	// initiator even though it is authorized in responder.
 	close, err := initiatorChannel.ProposePayment(8)
 	require.NoError(t, err)
-	_, err = responderChannel.ConfirmPayment(close)
+	_, err = responderChannel.ConfirmPayment(close.Envelope)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), initiatorChannel.Balance())
 	assert.Equal(t, int64(8), responderChannel.Balance())
@@ -131,9 +131,9 @@ func TestChannel_IngestTx_latestUnauthorizedDeclTx(t *testing.T) {
 		ExpiresAt:                  time.Now().Add(time.Minute),
 	})
 	require.NoError(t, err)
-	open, err = responderChannel.ConfirmOpen(open)
+	open, err = responderChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmOpen(open)
+	_, err = initiatorChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
 	initiatorChannel.UpdateLocalEscrowAccountBalance(100)
 	initiatorChannel.UpdateRemoteEscrowAccountBalance(100)
@@ -151,7 +151,7 @@ func TestChannel_IngestTx_latestUnauthorizedDeclTx(t *testing.T) {
 	// initiator even though it is authorized in responder.
 	close, err := initiatorChannel.ProposePayment(8)
 	require.NoError(t, err)
-	_, err = responderChannel.ConfirmPayment(close)
+	_, err = responderChannel.ConfirmPayment(close.Envelope)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), initiatorChannel.Balance())
 	assert.Equal(t, int64(8), responderChannel.Balance())
@@ -206,9 +206,9 @@ func TestChannel_IngestTx_latestAuthorizedDeclTx(t *testing.T) {
 		ExpiresAt:                  time.Now().Add(time.Minute),
 	})
 	require.NoError(t, err)
-	open, err = responderChannel.ConfirmOpen(open)
+	open, err = responderChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmOpen(open)
+	_, err = initiatorChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
 
 	// Mock initiatorChannel ingested formation tx successfully.
@@ -261,9 +261,9 @@ func TestChannel_IngestTx_oldDeclTx(t *testing.T) {
 		ExpiresAt:                  time.Now().Add(time.Minute),
 	})
 	require.NoError(t, err)
-	open, err = responderChannel.ConfirmOpen(open)
+	open, err = responderChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmOpen(open)
+	_, err = initiatorChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
 	initiatorChannel.UpdateLocalEscrowAccountBalance(100)
 	initiatorChannel.UpdateRemoteEscrowAccountBalance(100)
@@ -285,9 +285,9 @@ func TestChannel_IngestTx_oldDeclTx(t *testing.T) {
 	// New payment.
 	close, err := initiatorChannel.ProposePayment(8)
 	require.NoError(t, err)
-	close, err = responderChannel.ConfirmPayment(close)
+	close, err = responderChannel.ConfirmPayment(close.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmPayment(close)
+	_, err = initiatorChannel.ConfirmPayment(close.Envelope)
 	require.NoError(t, err)
 
 	// Pretend that responder broadcasts the old declTx, and
@@ -403,9 +403,9 @@ func TestChannel_IngestTx_updateBalancesNonNative(t *testing.T) {
 		ExpiresAt:                  time.Now().Add(time.Minute),
 	})
 	require.NoError(t, err)
-	open, err = responderChannel.ConfirmOpen(open)
+	open, err = responderChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmOpen(open)
+	_, err = initiatorChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
 
 	initiatorChannel.UpdateLocalEscrowAccountBalance(1_000_0000000)
@@ -509,9 +509,9 @@ func TestChannel_IngestTx_updateState_nativeAsset(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, StateNone, cs)
 
-	open, err = responderChannel.ConfirmOpen(open)
+	open, err = responderChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmOpen(open)
+	_, err = initiatorChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
 
 	formationTx, err := responderChannel.OpenTx()
@@ -609,9 +609,9 @@ func TestChannel_IngestTx_updateState_nonNativeAsset(t *testing.T) {
 	assert.Equal(t, StateNone, cs)
 
 	// Open steps.
-	open, err = responderChannel.ConfirmOpen(open)
+	open, err = responderChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmOpen(open)
+	_, err = initiatorChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
 
 	formationTx, err := responderChannel.OpenTx()
@@ -732,9 +732,9 @@ func TestChannel_IngestTx_updateState_invalid_initiatorEscrowHasExtraSigner(t *t
 		StartingSequence:           102,
 	})
 	require.NoError(t, err)
-	open, err = responderChannel.ConfirmOpen(open)
+	open, err = responderChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmOpen(open)
+	_, err = initiatorChannel.ConfirmOpen(open.Envelope)
 	require.NoError(t, err)
 
 	formationTx, err := responderChannel.OpenTx()

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -63,30 +63,30 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 		StartingSequence:           s,
 	})
 	require.NoError(t, err)
-	assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-	assert.NotEmpty(t, open.ProposerSignatures.Close)
-	assert.NotEmpty(t, open.ProposerSignatures.Formation)
-	assert.Empty(t, open.ConfirmerSignatures)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+	assert.Empty(t, open.Envelope.ConfirmerSignatures)
 	{
 		// R signs, R is done
-		open, err = responderChannel.ConfirmOpen(open)
+		open, err = responderChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
-		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-		assert.NotEmpty(t, open.ProposerSignatures.Close)
-		assert.NotEmpty(t, open.ProposerSignatures.Formation)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Formation)
 
 		// I receives the signatures, I is done
-		open, err = initiatorChannel.ConfirmOpen(open)
+		open, err = initiatorChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
-		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-		assert.NotEmpty(t, open.ProposerSignatures.Close)
-		assert.NotEmpty(t, open.ProposerSignatures.Formation)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Formation)
 	}
 
 	{
@@ -190,11 +190,11 @@ func TestOpenUpdatesUncoordinatedClose(t *testing.T) {
 		require.NoError(t, err)
 
 		// Receiver: receives new payment, validates, then confirms by signing
-		payment, err = receivingChannel.ConfirmPayment(payment)
+		payment, err = receivingChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 
 		// Sender: stores receiver's signatures
-		_, err = sendingChannel.ConfirmPayment(payment)
+		_, err = sendingChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 
 		// Record the close tx's at this point in time.
@@ -339,30 +339,30 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 		StartingSequence:           s,
 	})
 	require.NoError(t, err)
-	assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-	assert.NotEmpty(t, open.ProposerSignatures.Close)
-	assert.NotEmpty(t, open.ProposerSignatures.Formation)
-	assert.Empty(t, open.ConfirmerSignatures)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+	assert.Empty(t, open.Envelope.ConfirmerSignatures)
 	{
 		// R signs, R is done
-		open, err = responderChannel.ConfirmOpen(open)
+		open, err = responderChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
-		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-		assert.NotEmpty(t, open.ProposerSignatures.Close)
-		assert.NotEmpty(t, open.ProposerSignatures.Formation)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Formation)
 
 		// I stores the signatures, I is done.
-		open, err = initiatorChannel.ConfirmOpen(open)
+		open, err = initiatorChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
-		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-		assert.NotEmpty(t, open.ProposerSignatures.Close)
-		assert.NotEmpty(t, open.ProposerSignatures.Formation)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Formation)
 	}
 
 	{
@@ -457,11 +457,11 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Receiver: receives new payment, validates, then confirms by signing
-		payment, err = receivingChannel.ConfirmPayment(payment)
+		payment, err = receivingChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 
 		// Sender: stores the receivers signatures
-		_, err = sendingChannel.ConfirmPayment(payment)
+		_, err = sendingChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 	}
 
@@ -486,10 +486,10 @@ func TestOpenUpdatesCoordinatedCloseStartCloseThenCoordinate(t *testing.T) {
 	ca, err := initiatorChannel.ProposeClose()
 	require.NoError(t, err)
 
-	ca, err = responderChannel.ConfirmClose(ca)
+	ca, err = responderChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
 
-	_, err = initiatorChannel.ConfirmClose(ca)
+	_, err = initiatorChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
 
 	t.Log("Initiator closing channel with new coordinated close transaction")
@@ -555,31 +555,31 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-	assert.NotEmpty(t, open.ProposerSignatures.Close)
-	assert.NotEmpty(t, open.ProposerSignatures.Formation)
-	assert.Empty(t, open.ConfirmerSignatures)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+	assert.Empty(t, open.Envelope.ConfirmerSignatures)
 
 	{
 		// R signs txClose and txDecl
-		open, err = responderChannel.ConfirmOpen(open)
+		open, err = responderChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
-		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-		assert.NotEmpty(t, open.ProposerSignatures.Close)
-		assert.NotEmpty(t, open.ProposerSignatures.Formation)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Formation)
 
 		// I receives the signatures, I is done
-		open, err = initiatorChannel.ConfirmOpen(open)
+		open, err = initiatorChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
-		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-		assert.NotEmpty(t, open.ProposerSignatures.Close)
-		assert.NotEmpty(t, open.ProposerSignatures.Formation)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Formation)
 	}
 
 	{
@@ -674,11 +674,11 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 		require.NoError(t, err)
 
 		// Receiver: receives new payment, validates, then confirms by signing
-		payment, err = receivingChannel.ConfirmPayment(payment)
+		payment, err = receivingChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 
 		// Sender: stores the signatures from receiver
-		_, err = sendingChannel.ConfirmPayment(payment)
+		_, err = sendingChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 	}
 
@@ -689,10 +689,10 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartClose(t *testing.T) {
 	ca, err := initiatorChannel.ProposeClose()
 	require.NoError(t, err)
 
-	ca, err = responderChannel.ConfirmClose(ca)
+	ca, err = responderChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
 
-	_, err = initiatorChannel.ConfirmClose(ca)
+	_, err = initiatorChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
 
 	t.Log("Initiator submitting latest declaration transaction")
@@ -773,30 +773,30 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 	})
 
 	require.NoError(t, err)
-	assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-	assert.NotEmpty(t, open.ProposerSignatures.Close)
-	assert.NotEmpty(t, open.ProposerSignatures.Formation)
-	assert.Empty(t, open.ConfirmerSignatures)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+	assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+	assert.Empty(t, open.Envelope.ConfirmerSignatures)
 	{
 		// R signs
-		open, err = responderChannel.ConfirmOpen(open)
+		open, err = responderChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
-		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-		assert.NotEmpty(t, open.ProposerSignatures.Close)
-		assert.NotEmpty(t, open.ProposerSignatures.Formation)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Formation)
 
 		// I receives the signatures, I is done
-		open, err = initiatorChannel.ConfirmOpen(open)
+		open, err = initiatorChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
-		assert.NotEmpty(t, open.ProposerSignatures.Declaration)
-		assert.NotEmpty(t, open.ProposerSignatures.Close)
-		assert.NotEmpty(t, open.ProposerSignatures.Formation)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Declaration)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Close)
-		assert.NotEmpty(t, open.ConfirmerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ProposerSignatures.Formation)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Declaration)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Close)
+		assert.NotEmpty(t, open.Envelope.ConfirmerSignatures.Formation)
 	}
 
 	{
@@ -891,11 +891,11 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 		require.NoError(t, err)
 
 		// Receiver: receives new payment, validates, then confirms by signing
-		payment, err = receivingChannel.ConfirmPayment(payment)
+		payment, err = receivingChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 
 		// Sender: stores signatures from receiver
-		_, err = sendingChannel.ConfirmPayment(payment)
+		_, err = sendingChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 	}
 
@@ -906,10 +906,10 @@ func TestOpenUpdatesCoordinatedCloseCoordinateThenStartCloseByRemote(t *testing.
 	ca, err := initiatorChannel.ProposeClose()
 	require.NoError(t, err)
 
-	ca, err = responderChannel.ConfirmClose(ca)
+	ca, err = responderChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
 
-	_, err = initiatorChannel.ConfirmClose(ca)
+	_, err = initiatorChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
 
 	t.Log("Responder submitting latest declaration transaction")
@@ -993,9 +993,9 @@ func TestOpenUpdatesUncoordinatedClose_recieverNotReturningSigs(t *testing.T) {
 			StartingSequence:           s,
 		})
 		require.NoError(t, err)
-		open, err = responderChannel.ConfirmOpen(open)
+		open, err = responderChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(open)
+		_, err = initiatorChannel.ConfirmOpen(open.Envelope)
 		require.NoError(t, err)
 		tx, err := initiatorChannel.OpenTx()
 		require.NoError(t, err)
@@ -1054,9 +1054,9 @@ func TestOpenUpdatesUncoordinatedClose_recieverNotReturningSigs(t *testing.T) {
 	{
 		payment, err := initiatorChannel.ProposePayment(8)
 		require.NoError(t, err)
-		payment, err = responderChannel.ConfirmPayment(payment)
+		payment, err = responderChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmPayment(payment)
+		_, err = initiatorChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 	}
 
@@ -1064,7 +1064,7 @@ func TestOpenUpdatesUncoordinatedClose_recieverNotReturningSigs(t *testing.T) {
 	{
 		payment, err := initiatorChannel.ProposePayment(2)
 		require.NoError(t, err)
-		_, err = responderChannel.ConfirmPayment(payment)
+		_, err = responderChannel.ConfirmPayment(payment.Envelope)
 		require.NoError(t, err)
 		// Pretend the responder doesn't pass back their response to the
 		// initiator. The initiator never sees their signatures, so the

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-type OpenDetails struct {
+type OpenAgreementDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	Asset                      Asset
@@ -21,7 +21,7 @@ type OpenDetails struct {
 	ConfirmingSigner           *keypair.FromAddress
 }
 
-func (d OpenDetails) Equal(d2 OpenDetails) bool {
+func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
 	return d.ObservationPeriodTime == d2.ObservationPeriodTime &&
 		d.ObservationPeriodLedgerGap == d2.ObservationPeriodLedgerGap &&
 		d.Asset == d2.Asset &&
@@ -85,7 +85,7 @@ type OpenTransactions struct {
 }
 
 type OpenAgreement struct {
-	Details             OpenDetails
+	Details             OpenAgreementDetails
 	ProposerSignatures  OpenSignatures
 	ConfirmerSignatures OpenSignatures
 }
@@ -131,11 +131,11 @@ type OpenParams struct {
 // the channel has previous build the open transactions then it will return
 // those previously built transactions, otherwise the transactions will be built
 // from scratch.
-func (c *Channel) openTxs(d OpenDetails) (txs OpenTransactions, err error) {
+func (c *Channel) openTxs(d OpenAgreementDetails) (txs OpenTransactions, err error) {
 	if c.openAgreement.Details.Equal(d) {
 		return c.openTransactions, nil
 	}
-	cad := CloseDetails{
+	cad := CloseAgreementDetails{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: d.ObservationPeriodLedgerGap,
 		IterationNumber:            1,
@@ -217,7 +217,7 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 		return OpenAgreement{}, fmt.Errorf("cannot propose a new open if channel is already opened")
 	}
 
-	d := OpenDetails{
+	d := OpenAgreementDetails{
 		ObservationPeriodTime:      p.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: p.ObservationPeriodLedgerGap,
 		Asset:                      p.Asset,
@@ -309,7 +309,7 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 	// All signatures are present that would be required to submit all
 	// transactions in the open.
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    0,
 			ObservationPeriodTime:      m.Details.ObservationPeriodTime,

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-type OpenAgreementDetails struct {
+type OpenDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	Asset                      Asset
@@ -21,7 +21,7 @@ type OpenAgreementDetails struct {
 	ConfirmingSigner           *keypair.FromAddress
 }
 
-func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
+func (d OpenDetails) Equal(d2 OpenDetails) bool {
 	return d.ObservationPeriodTime == d2.ObservationPeriodTime &&
 		d.ObservationPeriodLedgerGap == d2.ObservationPeriodLedgerGap &&
 		d.Asset == d2.Asset &&
@@ -31,33 +31,33 @@ func (d OpenAgreementDetails) Equal(d2 OpenAgreementDetails) bool {
 		d.ConfirmingSigner.Equal(d2.ConfirmingSigner)
 }
 
-type OpenAgreementSignatures struct {
+type OpenSignatures struct {
 	Close       xdr.Signature
 	Declaration xdr.Signature
 	Formation   xdr.Signature
 }
 
-func (oas OpenAgreementSignatures) isFull() bool {
+func (oas OpenSignatures) isFull() bool {
 	return len(oas.Close) > 0 && len(oas.Declaration) > 0 && len(oas.Formation) > 0
 }
 
-func signOpenAgreementTxs(txs OpenAgreementTransactions, networkPassphrase string, signer *keypair.Full) (s OpenAgreementSignatures, err error) {
+func signOpenAgreementTxs(txs OpenTransactions, networkPassphrase string, signer *keypair.Full) (s OpenSignatures, err error) {
 	s.Declaration, err = signTx(txs.Declaration, networkPassphrase, signer)
 	if err != nil {
-		return OpenAgreementSignatures{}, fmt.Errorf("signing declaration: %w", err)
+		return OpenSignatures{}, fmt.Errorf("signing declaration: %w", err)
 	}
 	s.Close, err = signTx(txs.Close, networkPassphrase, signer)
 	if err != nil {
-		return OpenAgreementSignatures{}, fmt.Errorf("signing close: %w", err)
+		return OpenSignatures{}, fmt.Errorf("signing close: %w", err)
 	}
 	s.Formation, err = signTx(txs.Formation, networkPassphrase, signer)
 	if err != nil {
-		return OpenAgreementSignatures{}, fmt.Errorf("signing formation: %w", err)
+		return OpenSignatures{}, fmt.Errorf("signing formation: %w", err)
 	}
 	return s, nil
 }
 
-func (s OpenAgreementSignatures) Verify(txs OpenAgreementTransactions, networkPassphrase string, signer *keypair.FromAddress) error {
+func (s OpenSignatures) Verify(txs OpenTransactions, networkPassphrase string, signer *keypair.FromAddress) error {
 	err := verifySigned(txs.Declaration, networkPassphrase, signer, s.Declaration)
 	if err != nil {
 		return fmt.Errorf("verifying declaration signed: %w", err)
@@ -73,9 +73,9 @@ func (s OpenAgreementSignatures) Verify(txs OpenAgreementTransactions, networkPa
 	return nil
 }
 
-// OpenAgreementTransactions contain all the transaction hashes and transactions
+// OpenTransactions contain all the transaction hashes and transactions
 // that make up the open agreement.
-type OpenAgreementTransactions struct {
+type OpenTransactions struct {
 	CloseHash       TransactionHash
 	Close           *txnbuild.Transaction
 	DeclarationHash TransactionHash
@@ -85,9 +85,9 @@ type OpenAgreementTransactions struct {
 }
 
 type OpenAgreement struct {
-	Details             OpenAgreementDetails
-	ProposerSignatures  OpenAgreementSignatures
-	ConfirmerSignatures OpenAgreementSignatures
+	Details             OpenDetails
+	ProposerSignatures  OpenSignatures
+	ConfirmerSignatures OpenSignatures
 }
 
 func (oa OpenAgreement) isEmpty() bool {
@@ -106,7 +106,7 @@ func (oa OpenAgreement) Equal(oa2 OpenAgreement) bool {
 	return cmp.Equal(OA(oa), OA(oa2))
 }
 
-func (oa OpenAgreement) SignaturesFor(signer *keypair.FromAddress) *OpenAgreementSignatures {
+func (oa OpenAgreement) SignaturesFor(signer *keypair.FromAddress) *OpenSignatures {
 	if oa.Details.ProposingSigner.Equal(signer) {
 		return &oa.ProposerSignatures
 	}
@@ -131,11 +131,11 @@ type OpenParams struct {
 // the channel has previous build the open transactions then it will return
 // those previously built transactions, otherwise the transactions will be built
 // from scratch.
-func (c *Channel) openTxs(d OpenAgreementDetails) (txs OpenAgreementTransactions, err error) {
+func (c *Channel) openTxs(d OpenDetails) (txs OpenTransactions, err error) {
 	if c.openAgreement.Details.Equal(d) {
 		return c.openAgreementTransactions, nil
 	}
-	cad := CloseAgreementDetails{
+	cad := CloseDetails{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: d.ObservationPeriodLedgerGap,
 		IterationNumber:            1,
@@ -171,7 +171,7 @@ func (c *Channel) openTxs(d OpenAgreementDetails) (txs OpenAgreementTransactions
 		return
 	}
 
-	txs = OpenAgreementTransactions{
+	txs = OpenTransactions{
 		DeclarationHash: closeTxs.DeclarationHash,
 		Declaration:     closeTxs.Declaration,
 		CloseHash:       closeTxs.CloseHash,
@@ -217,7 +217,7 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 		return OpenAgreement{}, fmt.Errorf("cannot propose a new open if channel is already opened")
 	}
 
-	d := OpenAgreementDetails{
+	d := OpenDetails{
 		ObservationPeriodTime:      p.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: p.ObservationPeriodLedgerGap,
 		Asset:                      p.Asset,
@@ -309,7 +309,7 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 	// All signatures are present that would be required to submit all
 	// transactions in the open.
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    0,
 			ObservationPeriodTime:      m.Details.ObservationPeriodTime,
@@ -317,16 +317,16 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 			ProposingSigner:            m.Details.ProposingSigner,
 			ConfirmingSigner:           m.Details.ConfirmingSigner,
 		},
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: m.ProposerSignatures.Declaration,
 			Close:       m.ProposerSignatures.Close,
 		},
-		ConfirmerSignatures: CloseAgreementSignatures{
+		ConfirmerSignatures: CloseSignatures{
 			Declaration: m.ConfirmerSignatures.Declaration,
 			Close:       m.ConfirmerSignatures.Close,
 		},
 	}
-	c.latestAuthorizedCloseAgreementTransactions = CloseAgreementTransactions{
+	c.latestAuthorizedCloseTransactions = CloseTransactions{
 		DeclarationHash: txs.DeclarationHash,
 		Declaration:     txs.Declaration,
 		CloseHash:       txs.CloseHash,

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -133,7 +133,7 @@ type OpenParams struct {
 // from scratch.
 func (c *Channel) openTxs(d OpenDetails) (txs OpenTransactions, err error) {
 	if c.openAgreement.Details.Equal(d) {
-		return c.openAgreementTransactions, nil
+		return c.openTransactions, nil
 	}
 	cad := CloseDetails{
 		ObservationPeriodTime:      d.ObservationPeriodTime,
@@ -240,7 +240,7 @@ func (c *Channel) ProposeOpen(p OpenParams) (OpenAgreement, error) {
 		ProposerSignatures: sigs,
 	}
 	c.openAgreement = open
-	c.openAgreementTransactions = txs
+	c.openTransactions = txs
 	return open, nil
 }
 
@@ -337,6 +337,6 @@ func (c *Channel) ConfirmOpen(m OpenAgreement) (open OpenAgreement, err error) {
 		ProposerSignatures:  m.ProposerSignatures,
 		ConfirmerSignatures: m.ConfirmerSignatures,
 	}
-	c.openAgreementTransactions = txs
+	c.openTransactions = txs
 	return c.openAgreement, nil
 }

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -24,7 +24,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		{OpenAgreement{}, OpenAgreement{}, true},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -33,7 +33,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -45,7 +45,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -58,7 +58,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -70,7 +70,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -85,7 +85,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -101,7 +101,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -113,7 +113,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -128,7 +128,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -140,7 +140,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenDetails{
+				Details: OpenAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -218,14 +218,14 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	channel.openAgreement = OpenAgreement{
-		Details: OpenDetails{
+		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
 		},
 	}
 
-	oa := OpenDetails{
+	oa := OpenAgreementDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -264,7 +264,7 @@ func TestConfirmOpen_rejectsOpenAgreementsWithLongFormations(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 
-	_, err := channel.ConfirmOpen(OpenAgreement{Details: OpenDetails{
+	_, err := channel.ConfirmOpen(OpenAgreement{Details: OpenAgreementDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -288,7 +288,7 @@ func TestChannel_OpenTx(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	oa := OpenAgreement{
-		Details: OpenDetails{
+		Details: OpenAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -310,7 +310,7 @@ func TestChannel_OpenTx(t *testing.T) {
 	txs, err := channel.openTxs(oa.Details)
 	require.NoError(t, err)
 	channel.openAgreement = oa
-	channel.openAgreementTransactions = txs
+	channel.openTransactions = txs
 	declTxHash := txs.DeclarationHash
 	closeTxHash := txs.CloseHash
 
@@ -337,7 +337,7 @@ func TestChannel_OpenTx(t *testing.T) {
 		Operations:    []txnbuild.Operation{&txnbuild.BumpSequence{}},
 	})
 	require.NoError(t, err)
-	channel.openAgreementTransactions = OpenTransactions{
+	channel.openTransactions = OpenTransactions{
 		Formation: testTx,
 	}
 	formationTx, err = channel.OpenTx()

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -17,14 +17,14 @@ import (
 func TestOpenAgreement_Equal(t *testing.T) {
 	kp := keypair.MustRandom().FromAddress()
 	testCases := []struct {
-		oa1       OpenAgreement
-		oa2       OpenAgreement
+		oa1       OpenEnvelope
+		oa2       OpenEnvelope
 		wantEqual bool
 	}{
-		{OpenAgreement{}, OpenAgreement{}, true},
+		{OpenEnvelope{}, OpenEnvelope{}, true},
 		{
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -32,8 +32,8 @@ func TestOpenAgreement_Equal(t *testing.T) {
 					ConfirmingSigner:           kp,
 				},
 			},
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -44,8 +44,8 @@ func TestOpenAgreement_Equal(t *testing.T) {
 			true,
 		},
 		{
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -53,12 +53,12 @@ func TestOpenAgreement_Equal(t *testing.T) {
 					ConfirmingSigner:           kp,
 				},
 			},
-			OpenAgreement{},
+			OpenEnvelope{},
 			false,
 		},
 		{
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -69,8 +69,8 @@ func TestOpenAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -84,8 +84,8 @@ func TestOpenAgreement_Equal(t *testing.T) {
 			true,
 		},
 		{
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -96,12 +96,12 @@ func TestOpenAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			OpenAgreement{},
+			OpenEnvelope{},
 			false,
 		},
 		{
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -112,8 +112,8 @@ func TestOpenAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -127,8 +127,8 @@ func TestOpenAgreement_Equal(t *testing.T) {
 			false,
 		},
 		{
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -139,8 +139,8 @@ func TestOpenAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			OpenAgreement{
-				Details: OpenAgreementDetails{
+			OpenEnvelope{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -218,14 +218,16 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	channel.openAgreement = OpenAgreement{
-		Details: OpenAgreementDetails{
-			ObservationPeriodTime:      1,
-			ObservationPeriodLedgerGap: 1,
-			Asset:                      NativeAsset,
+		Envelope: OpenEnvelope{
+			Details: OpenDetails{
+				ObservationPeriodTime:      1,
+				ObservationPeriodLedgerGap: 1,
+				Asset:                      NativeAsset,
+			},
 		},
 	}
 
-	oa := OpenAgreementDetails{
+	oa := OpenDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -235,7 +237,7 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		// invalid ObservationPeriodTime
 		d := oa
 		d.ObservationPeriodTime = 0
-		_, err := channel.ConfirmOpen(OpenAgreement{Details: d})
+		_, err := channel.ConfirmOpen(OpenEnvelope{Details: d})
 		require.EqualError(t, err, "validating open agreement: input open agreement details do not match the saved open agreement details")
 	}
 
@@ -243,7 +245,7 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		// invalid different asset
 		d := oa
 		d.Asset = "ABC:GCDFU7RNY6HTYQKP7PYHBMXXKXZ4HET6LMJ5CDO7YL5NMYH4T2BSZCPZ"
-		_, err := channel.ConfirmOpen(OpenAgreement{Details: d})
+		_, err := channel.ConfirmOpen(OpenEnvelope{Details: d})
 		require.EqualError(t, err, "validating open agreement: input open agreement details do not match the saved open agreement details")
 	}
 }
@@ -264,7 +266,7 @@ func TestConfirmOpen_rejectsOpenAgreementsWithLongFormations(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 
-	_, err := channel.ConfirmOpen(OpenAgreement{Details: OpenAgreementDetails{
+	_, err := channel.ConfirmOpen(OpenEnvelope{Details: OpenDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -287,8 +289,8 @@ func TestChannel_OpenTx(t *testing.T) {
 		LocalEscrowAccount:  localEscrowAccount,
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
-	oa := OpenAgreement{
-		Details: OpenAgreementDetails{
+	oe := OpenEnvelope{
+		Details: OpenDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
@@ -307,10 +309,9 @@ func TestChannel_OpenTx(t *testing.T) {
 			Formation:   xdr.Signature{5},
 		},
 	}
-	txs, err := channel.openTxs(oa.Details)
+	txs, err := channel.openTxs(oe.Details)
 	require.NoError(t, err)
-	channel.openAgreement = oa
-	channel.openTransactions = txs
+	channel.openAgreement = OpenAgreement{Envelope: oe, Transactions: txs}
 	declTxHash := txs.DeclarationHash
 	closeTxHash := txs.CloseHash
 
@@ -337,7 +338,7 @@ func TestChannel_OpenTx(t *testing.T) {
 		Operations:    []txnbuild.Operation{&txnbuild.BumpSequence{}},
 	})
 	require.NoError(t, err)
-	channel.openTransactions = OpenTransactions{
+	channel.openAgreement.Transactions = OpenTransactions{
 		Formation: testTx,
 	}
 	formationTx, err = channel.OpenTx()
@@ -346,10 +347,10 @@ func TestChannel_OpenTx(t *testing.T) {
 }
 
 func TestChannel_OpenAgreementIsFull(t *testing.T) {
-	oa := OpenAgreement{}
+	oa := OpenEnvelope{}
 	assert.False(t, oa.isFull())
 
-	oa = OpenAgreement{
+	oa = OpenEnvelope{
 		ProposerSignatures: OpenSignatures{
 			Close:       xdr.Signature{1},
 			Declaration: xdr.Signature{1},
@@ -402,9 +403,9 @@ func TestChannel_ProposeAndConfirmOpen_rejectIfChannelAlreadyOpen(t *testing.T) 
 		StartingSequence:           101,
 	})
 	require.NoError(t, err)
-	m, err = responderChannel.ConfirmOpen(m)
+	m, err = responderChannel.ConfirmOpen(m.Envelope)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmOpen(m)
+	_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 	require.NoError(t, err)
 
 	{
@@ -448,11 +449,11 @@ func TestChannel_ProposeAndConfirmOpen_rejectIfChannelAlreadyOpen(t *testing.T) 
 	})
 	require.EqualError(t, err, "cannot propose a new open if channel is already opened")
 
-	_, err = responderChannel.ConfirmOpen(m)
+	_, err = responderChannel.ConfirmOpen(m.Envelope)
 	require.EqualError(t, err, "validating open agreement: cannot confirm a new open if channel is already opened")
 
 	// A channel without a full open agreement should be able to propose an open
-	initiatorChannel.openAgreement.ConfirmerSignatures = OpenSignatures{}
+	initiatorChannel.openAgreement.Envelope.ConfirmerSignatures = OpenSignatures{}
 	_, err = initiatorChannel.ProposeOpen(OpenParams{
 		Asset:     NativeAsset,
 		ExpiresAt: time.Now().Add(5 * time.Minute),

--- a/sdk/state/open_test.go
+++ b/sdk/state/open_test.go
@@ -24,7 +24,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		{OpenAgreement{}, OpenAgreement{}, true},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -33,7 +33,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 				},
 			},
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -45,7 +45,7 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
@@ -58,26 +58,26 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -85,14 +85,14 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -101,26 +101,26 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -128,26 +128,26 @@ func TestOpenAgreement_Equal(t *testing.T) {
 		},
 		{
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           kp,
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			OpenAgreement{
-				Details: OpenAgreementDetails{
+				Details: OpenDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					Asset:                      "native",
 					ExpiresAt:                  time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC),
 					ConfirmingSigner:           keypair.MustRandom().FromAddress(),
 				},
-				ProposerSignatures: OpenAgreementSignatures{
+				ProposerSignatures: OpenSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -218,14 +218,14 @@ func TestConfirmOpen_rejectsDifferentOpenAgreements(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	channel.openAgreement = OpenAgreement{
-		Details: OpenAgreementDetails{
+		Details: OpenDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
 		},
 	}
 
-	oa := OpenAgreementDetails{
+	oa := OpenDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -264,7 +264,7 @@ func TestConfirmOpen_rejectsOpenAgreementsWithLongFormations(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 
-	_, err := channel.ConfirmOpen(OpenAgreement{Details: OpenAgreementDetails{
+	_, err := channel.ConfirmOpen(OpenAgreement{Details: OpenDetails{
 		ObservationPeriodTime:      1,
 		ObservationPeriodLedgerGap: 1,
 		Asset:                      NativeAsset,
@@ -288,7 +288,7 @@ func TestChannel_OpenTx(t *testing.T) {
 		RemoteEscrowAccount: remoteEscrowAccount,
 	})
 	oa := OpenAgreement{
-		Details: OpenAgreementDetails{
+		Details: OpenDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			Asset:                      NativeAsset,
@@ -296,12 +296,12 @@ func TestChannel_OpenTx(t *testing.T) {
 			ProposingSigner:            localSigner.FromAddress(),
 			ConfirmingSigner:           remoteSigner.FromAddress(),
 		},
-		ProposerSignatures: OpenAgreementSignatures{
+		ProposerSignatures: OpenSignatures{
 			Declaration: xdr.Signature{0},
 			Close:       xdr.Signature{1},
 			Formation:   xdr.Signature{2},
 		},
-		ConfirmerSignatures: OpenAgreementSignatures{
+		ConfirmerSignatures: OpenSignatures{
 			Declaration: xdr.Signature{3},
 			Close:       xdr.Signature{4},
 			Formation:   xdr.Signature{5},
@@ -337,7 +337,7 @@ func TestChannel_OpenTx(t *testing.T) {
 		Operations:    []txnbuild.Operation{&txnbuild.BumpSequence{}},
 	})
 	require.NoError(t, err)
-	channel.openAgreementTransactions = OpenAgreementTransactions{
+	channel.openAgreementTransactions = OpenTransactions{
 		Formation: testTx,
 	}
 	formationTx, err = channel.OpenTx()
@@ -350,7 +350,7 @@ func TestChannel_OpenAgreementIsFull(t *testing.T) {
 	assert.False(t, oa.isFull())
 
 	oa = OpenAgreement{
-		ProposerSignatures: OpenAgreementSignatures{
+		ProposerSignatures: OpenSignatures{
 			Close:       xdr.Signature{1},
 			Declaration: xdr.Signature{1},
 			Formation:   xdr.Signature{1},
@@ -358,7 +358,7 @@ func TestChannel_OpenAgreementIsFull(t *testing.T) {
 	}
 	assert.False(t, oa.isFull())
 
-	oa.ConfirmerSignatures = OpenAgreementSignatures{
+	oa.ConfirmerSignatures = OpenSignatures{
 		Close:       xdr.Signature{1},
 		Declaration: xdr.Signature{1},
 	}
@@ -452,7 +452,7 @@ func TestChannel_ProposeAndConfirmOpen_rejectIfChannelAlreadyOpen(t *testing.T) 
 	require.EqualError(t, err, "validating open agreement: cannot confirm a new open if channel is already opened")
 
 	// A channel without a full open agreement should be able to propose an open
-	initiatorChannel.openAgreement.ConfirmerSignatures = OpenAgreementSignatures{}
+	initiatorChannel.openAgreement.ConfirmerSignatures = OpenSignatures{}
 	_, err = initiatorChannel.ProposeOpen(OpenParams{
 		Asset:     NativeAsset,
 		ExpiresAt: time.Now().Add(5 * time.Minute),

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -283,7 +283,7 @@ func (c *Channel) ConfirmPayment(ce CloseEnvelope) (closeAgreement CloseAgreemen
 	// All signatures are present that would be required to submit all
 	// transactions in the payment.
 	c.latestAuthorizedCloseAgreement = CloseAgreement{
-		Envelope: ce,
+		Envelope:     ce,
 		Transactions: txs,
 	}
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -17,8 +17,8 @@ import (
 // 3. Sender calls ConfirmPayment
 // 4. Receiver calls ConfirmPayment
 
-// CloseAgreementDetails contains the details that the participants agree on.
-type CloseAgreementDetails struct {
+// CloseDetails contains the details that the participants agree on.
+type CloseDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	IterationNumber            int64
@@ -28,30 +28,30 @@ type CloseAgreementDetails struct {
 	ConfirmingSigner           *keypair.FromAddress
 }
 
-func (d CloseAgreementDetails) Equal(d2 CloseAgreementDetails) bool {
+func (d CloseDetails) Equal(d2 CloseDetails) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
-	type CAD CloseAgreementDetails
+	type CAD CloseDetails
 	return cmp.Equal(CAD(d), CAD(d2))
 }
 
-type CloseAgreementSignatures struct {
+type CloseSignatures struct {
 	Close       xdr.Signature
 	Declaration xdr.Signature
 }
 
-func signCloseAgreementTxs(txs CloseAgreementTransactions, networkPassphrase string, signer *keypair.Full) (s CloseAgreementSignatures, err error) {
+func signCloseAgreementTxs(txs CloseTransactions, networkPassphrase string, signer *keypair.Full) (s CloseSignatures, err error) {
 	s.Declaration, err = signTx(txs.Declaration, networkPassphrase, signer)
 	if err != nil {
-		return CloseAgreementSignatures{}, fmt.Errorf("signing declaration: %w", err)
+		return CloseSignatures{}, fmt.Errorf("signing declaration: %w", err)
 	}
 	s.Close, err = signTx(txs.Close, networkPassphrase, signer)
 	if err != nil {
-		return CloseAgreementSignatures{}, fmt.Errorf("signing close: %w", err)
+		return CloseSignatures{}, fmt.Errorf("signing close: %w", err)
 	}
 	return s, nil
 }
 
-func (s CloseAgreementSignatures) Verify(txs CloseAgreementTransactions, networkPassphrase string, signer *keypair.FromAddress) error {
+func (s CloseSignatures) Verify(txs CloseTransactions, networkPassphrase string, signer *keypair.FromAddress) error {
 	err := verifySigned(txs.Declaration, networkPassphrase, signer, s.Declaration)
 	if err != nil {
 		return fmt.Errorf("verifying declaration signed: %w", err)
@@ -63,9 +63,9 @@ func (s CloseAgreementSignatures) Verify(txs CloseAgreementTransactions, network
 	return nil
 }
 
-// CloseAgreementTransactions contain all the transaction hashes and
+// CloseTransactions contain all the transaction hashes and
 // transactions for the transactions that make up the close agreement.
-type CloseAgreementTransactions struct {
+type CloseTransactions struct {
 	CloseHash       TransactionHash
 	Close           *txnbuild.Transaction
 	DeclarationHash TransactionHash
@@ -75,9 +75,9 @@ type CloseAgreementTransactions struct {
 // CloseAgreement contains everything a participant needs to execute the close
 // agreement on the Stellar network.
 type CloseAgreement struct {
-	Details             CloseAgreementDetails
-	ProposerSignatures  CloseAgreementSignatures
-	ConfirmerSignatures CloseAgreementSignatures
+	Details             CloseDetails
+	ProposerSignatures  CloseSignatures
+	ConfirmerSignatures CloseSignatures
 }
 
 func (ca CloseAgreement) isEmpty() bool {
@@ -90,7 +90,7 @@ func (ca CloseAgreement) Equal(ca2 CloseAgreement) bool {
 	return cmp.Equal(CA(ca), CA(ca2))
 }
 
-func (ca CloseAgreement) SignaturesFor(signer *keypair.FromAddress) *CloseAgreementSignatures {
+func (ca CloseAgreement) SignaturesFor(signer *keypair.FromAddress) *CloseSignatures {
 	if ca.Details.ProposingSigner.Equal(signer) {
 		return &ca.ProposerSignatures
 	}
@@ -138,7 +138,7 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		return CloseAgreement{}, fmt.Errorf("amount over commits: %w", ErrUnderfunded)
 	}
 
-	d := CloseAgreementDetails{
+	d := CloseDetails{
 		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap,
 		IterationNumber:            c.NextIterationNumber(),
@@ -160,7 +160,7 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		Details:            d,
 		ProposerSignatures: sigs,
 	}
-	c.latestUnauthorizedCloseAgreementTransactions = txs
+	c.latestUnauthorizedCloseTransactions = txs
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
@@ -274,9 +274,9 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	// All signatures are present that would be required to submit all
 	// transactions in the payment.
 	c.latestAuthorizedCloseAgreement = ca
-	c.latestAuthorizedCloseAgreementTransactions = txs
+	c.latestAuthorizedCloseTransactions = txs
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}
-	c.latestUnauthorizedCloseAgreementTransactions = CloseAgreementTransactions{}
+	c.latestUnauthorizedCloseTransactions = CloseTransactions{}
 
 	return c.latestAuthorizedCloseAgreement, nil
 }

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -17,8 +17,8 @@ import (
 // 3. Sender calls ConfirmPayment
 // 4. Receiver calls ConfirmPayment
 
-// CloseDetails contains the details that the participants agree on.
-type CloseDetails struct {
+// CloseAgreementDetails contains the details that the participants agree on.
+type CloseAgreementDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	IterationNumber            int64
@@ -28,9 +28,9 @@ type CloseDetails struct {
 	ConfirmingSigner           *keypair.FromAddress
 }
 
-func (d CloseDetails) Equal(d2 CloseDetails) bool {
+func (d CloseAgreementDetails) Equal(d2 CloseAgreementDetails) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
-	type CAD CloseDetails
+	type CAD CloseAgreementDetails
 	return cmp.Equal(CAD(d), CAD(d2))
 }
 
@@ -75,7 +75,7 @@ type CloseTransactions struct {
 // CloseAgreement contains everything a participant needs to execute the close
 // agreement on the Stellar network.
 type CloseAgreement struct {
-	Details             CloseDetails
+	Details             CloseAgreementDetails
 	ProposerSignatures  CloseSignatures
 	ConfirmerSignatures CloseSignatures
 }
@@ -138,7 +138,7 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		return CloseAgreement{}, fmt.Errorf("amount over commits: %w", ErrUnderfunded)
 	}
 
-	d := CloseDetails{
+	d := CloseAgreementDetails{
 		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime,
 		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap,
 		IterationNumber:            c.NextIterationNumber(),

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -17,8 +17,8 @@ import (
 // 3. Sender calls ConfirmPayment
 // 4. Receiver calls ConfirmPayment
 
-// CloseAgreementDetails contains the details that the participants agree on.
-type CloseAgreementDetails struct {
+// CloseDetails contains the details that the participants agree on.
+type CloseDetails struct {
 	ObservationPeriodTime      time.Duration
 	ObservationPeriodLedgerGap int64
 	IterationNumber            int64
@@ -28,9 +28,9 @@ type CloseAgreementDetails struct {
 	ConfirmingSigner           *keypair.FromAddress
 }
 
-func (d CloseAgreementDetails) Equal(d2 CloseAgreementDetails) bool {
+func (d CloseDetails) Equal(d2 CloseDetails) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
-	type CAD CloseAgreementDetails
+	type CAD CloseDetails
 	return cmp.Equal(CAD(d), CAD(d2))
 }
 
@@ -72,25 +72,25 @@ type CloseTransactions struct {
 	Declaration     *txnbuild.Transaction
 }
 
-// CloseAgreement contains everything a participant needs to execute the close
+// CloseEnvelope contains everything a participant needs to execute the close
 // agreement on the Stellar network.
-type CloseAgreement struct {
-	Details             CloseAgreementDetails
+type CloseEnvelope struct {
+	Details             CloseDetails
 	ProposerSignatures  CloseSignatures
 	ConfirmerSignatures CloseSignatures
 }
 
-func (ca CloseAgreement) isEmpty() bool {
-	return ca.Equal(CloseAgreement{})
+func (ca CloseEnvelope) isEmpty() bool {
+	return ca.Equal(CloseEnvelope{})
 }
 
-func (ca CloseAgreement) Equal(ca2 CloseAgreement) bool {
+func (ca CloseEnvelope) Equal(ca2 CloseEnvelope) bool {
 	// TODO: Replace cmp.Equal with a hand written equals.
-	type CA CloseAgreement
+	type CA CloseEnvelope
 	return cmp.Equal(CA(ca), CA(ca2))
 }
 
-func (ca CloseAgreement) SignaturesFor(signer *keypair.FromAddress) *CloseSignatures {
+func (ca CloseEnvelope) SignaturesFor(signer *keypair.FromAddress) *CloseSignatures {
 	if ca.Details.ProposingSigner.Equal(signer) {
 		return &ca.ProposerSignatures
 	}
@@ -100,30 +100,37 @@ func (ca CloseAgreement) SignaturesFor(signer *keypair.FromAddress) *CloseSignat
 	return nil
 }
 
+// CloseAgreement contains all the information known for an agreement proposed
+// or confirmed by the channel.
+type CloseAgreement struct {
+	Envelope     CloseEnvelope
+	Transactions CloseTransactions
+}
+
 func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 	if amount <= 0 {
 		return CloseAgreement{}, fmt.Errorf("payment amount must be greater than 0")
 	}
 
 	// If the channel is not open yet, error.
-	if c.latestAuthorizedCloseAgreement.isEmpty() || !c.openExecutedAndValidated {
+	if c.latestAuthorizedCloseAgreement.Envelope.isEmpty() || !c.openExecutedAndValidated {
 		return CloseAgreement{}, fmt.Errorf("cannot propose a payment before channel is opened")
 	}
 
 	// If a coordinated close has been accepted already, error.
-	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
-		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
+	if !c.latestAuthorizedCloseAgreement.Envelope.isEmpty() && c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodTime == 0 &&
+		c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodLedgerGap == 0 {
 		return CloseAgreement{}, fmt.Errorf("cannot propose payment after an accepted coordinated close")
 	}
 
 	// If a coordinated close has been proposed by this channel already, error.
-	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
-		c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
+	if !c.latestUnauthorizedCloseAgreement.Envelope.isEmpty() && c.latestUnauthorizedCloseAgreement.Envelope.Details.ObservationPeriodTime == 0 &&
+		c.latestUnauthorizedCloseAgreement.Envelope.Details.ObservationPeriodLedgerGap == 0 {
 		return CloseAgreement{}, fmt.Errorf("cannot propose payment after proposing a coordinated close")
 	}
 
 	// If an unfinished unauthorized agreement exists, error.
-	if !c.latestUnauthorizedCloseAgreement.isEmpty() {
+	if !c.latestUnauthorizedCloseAgreement.Envelope.isEmpty() {
 		return CloseAgreement{}, fmt.Errorf("cannot start a new payment while an unfinished one exists")
 	}
 
@@ -138,16 +145,16 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 		return CloseAgreement{}, fmt.Errorf("amount over commits: %w", ErrUnderfunded)
 	}
 
-	d := CloseAgreementDetails{
-		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime,
-		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap,
+	d := CloseDetails{
+		ObservationPeriodTime:      c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodTime,
+		ObservationPeriodLedgerGap: c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodLedgerGap,
 		IterationNumber:            c.NextIterationNumber(),
 		Balance:                    newBalance,
 		PaymentAmount:              amount,
 		ProposingSigner:            c.localSigner.FromAddress(),
 		ConfirmingSigner:           c.remoteSigner,
 	}
-	txs, err := c.closeTxs(c.openAgreement.Details, d)
+	txs, err := c.closeTxs(c.openAgreement.Envelope.Details, d)
 	if err != nil {
 		return CloseAgreement{}, err
 	}
@@ -157,10 +164,12 @@ func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
 	}
 
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{
-		Details:            d,
-		ProposerSignatures: sigs,
+		Envelope: CloseEnvelope{
+			Details:            d,
+			ProposerSignatures: sigs,
+		},
+		Transactions: txs,
 	}
-	c.latestUnauthorizedCloseTransactions = txs
 	return c.latestUnauthorizedCloseAgreement, nil
 }
 
@@ -169,51 +178,51 @@ var ErrUnderfunded = fmt.Errorf("account is underfunded to make payment")
 // validatePayment validates the close agreement given to the ConfirmPayment method. Note that
 // there are additional verifications ConfirmPayment performs that are based
 // on the state of the close agreement signatures.
-func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
+func (c *Channel) validatePayment(ce CloseEnvelope) (err error) {
 	// If the channel is not open yet, error.
-	if c.latestAuthorizedCloseAgreement.isEmpty() || !c.openExecutedAndValidated {
+	if c.latestAuthorizedCloseAgreement.Envelope.isEmpty() || !c.openExecutedAndValidated {
 		return fmt.Errorf("cannot confirm a payment before channel is opened")
 	}
 
 	// If a coordinated close has been proposed by this channel already, error.
-	if !c.latestUnauthorizedCloseAgreement.isEmpty() && c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
-		c.latestUnauthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
+	if !c.latestUnauthorizedCloseAgreement.Envelope.isEmpty() && c.latestUnauthorizedCloseAgreement.Envelope.Details.ObservationPeriodTime == 0 &&
+		c.latestUnauthorizedCloseAgreement.Envelope.Details.ObservationPeriodLedgerGap == 0 {
 		return fmt.Errorf("cannot confirm payment after proposing a coordinated close")
 	}
 
 	// If a coordinated close has been accepted already, error.
-	if !c.latestAuthorizedCloseAgreement.isEmpty() && c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime == 0 &&
-		c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap == 0 {
+	if !c.latestAuthorizedCloseAgreement.Envelope.isEmpty() && c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodTime == 0 &&
+		c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodLedgerGap == 0 {
 		return fmt.Errorf("cannot confirm payment after an accepted coordinated close")
 	}
 
 	// If the new close agreement details are incorrect, error.
-	if ca.Details.IterationNumber != c.NextIterationNumber() {
-		return fmt.Errorf("invalid payment iteration number, got: %d want: %d", ca.Details.IterationNumber, c.NextIterationNumber())
+	if ce.Details.IterationNumber != c.NextIterationNumber() {
+		return fmt.Errorf("invalid payment iteration number, got: %d want: %d", ce.Details.IterationNumber, c.NextIterationNumber())
 	}
-	if ca.Details.ObservationPeriodTime != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodTime ||
-		ca.Details.ObservationPeriodLedgerGap != c.latestAuthorizedCloseAgreement.Details.ObservationPeriodLedgerGap {
+	if ce.Details.ObservationPeriodTime != c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodTime ||
+		ce.Details.ObservationPeriodLedgerGap != c.latestAuthorizedCloseAgreement.Envelope.Details.ObservationPeriodLedgerGap {
 		return fmt.Errorf("invalid payment observation period: different than channel state")
 	}
-	if !c.latestUnauthorizedCloseAgreement.isEmpty() && !ca.Details.Equal(c.latestUnauthorizedCloseAgreement.Details) {
+	if !c.latestUnauthorizedCloseAgreement.Envelope.isEmpty() && !ce.Details.Equal(c.latestUnauthorizedCloseAgreement.Envelope.Details) {
 		return fmt.Errorf("close agreement does not match the close agreement already in progress")
 	}
-	if !ca.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) && !ca.Details.ConfirmingSigner.Equal(c.remoteSigner) {
-		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ca.Details.ConfirmingSigner.Address())
+	if !ce.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) && !ce.Details.ConfirmingSigner.Equal(c.remoteSigner) {
+		return fmt.Errorf("close agreement confirmer does not match a local or remote signer, got: %s", ce.Details.ConfirmingSigner.Address())
 	}
-	if !ca.Details.ProposingSigner.Equal(c.localSigner.FromAddress()) && !ca.Details.ProposingSigner.Equal(c.remoteSigner) {
-		return fmt.Errorf("close agreement proposer does not match a local or remote signer, got: %s", ca.Details.ProposingSigner.Address())
+	if !ce.Details.ProposingSigner.Equal(c.localSigner.FromAddress()) && !ce.Details.ProposingSigner.Equal(c.remoteSigner) {
+		return fmt.Errorf("close agreement proposer does not match a local or remote signer, got: %s", ce.Details.ProposingSigner.Address())
 	}
 
 	// If the close agreement payment amount is incorrect, error.
-	pa := ca.Details.PaymentAmount
-	proposerIsResponder := ca.Details.ProposingSigner.Equal(c.responderSigner())
+	pa := ce.Details.PaymentAmount
+	proposerIsResponder := ce.Details.ProposingSigner.Equal(c.responderSigner())
 	if proposerIsResponder {
-		pa = ca.Details.PaymentAmount * -1
+		pa = ce.Details.PaymentAmount * -1
 	}
-	if c.Balance()+pa != ca.Details.Balance {
+	if c.Balance()+pa != ce.Details.Balance {
 		return fmt.Errorf("close agreement payment amount is unexpected: current balance: %d proposed balance: %d payment amount: %d initiator proposed: %t",
-			c.Balance(), ca.Details.Balance, ca.Details.PaymentAmount, !proposerIsResponder)
+			c.Balance(), ce.Details.Balance, ce.Details.PaymentAmount, !proposerIsResponder)
 	}
 	return nil
 }
@@ -221,20 +230,20 @@ func (c *Channel) validatePayment(ca CloseAgreement) (err error) {
 // ConfirmPayment confirms an agreement. The destination of a payment calls this
 // once to sign and store the agreement. The source of a payment calls this once
 // with a copy of the agreement signed by the destination to store the destination's signatures.
-func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreement, err error) {
-	err = c.validatePayment(ca)
+func (c *Channel) ConfirmPayment(ce CloseEnvelope) (closeAgreement CloseAgreement, err error) {
+	err = c.validatePayment(ce)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("validating payment: %w", err)
 	}
 
 	// create payment transactions
-	txs, err := c.closeTxs(c.openAgreement.Details, ca.Details)
+	txs, err := c.closeTxs(c.openAgreement.Envelope.Details, ce.Details)
 	if err != nil {
 		return CloseAgreement{}, err
 	}
 
 	// If remote has not signed the txs, error as is invalid.
-	remoteSigs := ca.SignaturesFor(c.remoteSigner)
+	remoteSigs := ce.SignaturesFor(c.remoteSigner)
 	if remoteSigs == nil {
 		return CloseAgreement{}, fmt.Errorf("remote is not a signer")
 	}
@@ -244,7 +253,7 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	}
 
 	// If local has not signed close, check that the payment is not to the proposer, then sign.
-	localSigs := ca.SignaturesFor(c.localSigner.FromAddress())
+	localSigs := ce.SignaturesFor(c.localSigner.FromAddress())
 	if localSigs == nil {
 		return CloseAgreement{}, fmt.Errorf("local is not a signer")
 	}
@@ -252,20 +261,20 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 	if err != nil {
 		// If the local is not the confirmer, do not sign, because being the
 		// proposer they should have signed earlier.
-		if !ca.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) {
+		if !ce.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) {
 			return CloseAgreement{}, fmt.Errorf("not signed by local: %w", err)
 		}
 		// If the payment is to the proposer, error, because the payment channel
 		// only supports pushing money to the other participant not pulling.
-		if (c.initiator && ca.Details.Balance > c.latestAuthorizedCloseAgreement.Details.Balance) ||
-			(!c.initiator && ca.Details.Balance < c.latestAuthorizedCloseAgreement.Details.Balance) {
+		if (c.initiator && ce.Details.Balance > c.latestAuthorizedCloseAgreement.Envelope.Details.Balance) ||
+			(!c.initiator && ce.Details.Balance < c.latestAuthorizedCloseAgreement.Envelope.Details.Balance) {
 			return CloseAgreement{}, fmt.Errorf("close agreement is a payment to the proposer")
 		}
 		// If the payment over extends the proposers ability to pay, error.
-		if c.amountToLocal(ca.Details.Balance) > c.remoteEscrowAccount.Balance {
+		if c.amountToLocal(ce.Details.Balance) > c.remoteEscrowAccount.Balance {
 			return CloseAgreement{}, fmt.Errorf("close agreement over commits: %w", ErrUnderfunded)
 		}
-		ca.ConfirmerSignatures, err = signCloseAgreementTxs(txs, c.networkPassphrase, c.localSigner)
+		ce.ConfirmerSignatures, err = signCloseAgreementTxs(txs, c.networkPassphrase, c.localSigner)
 		if err != nil {
 			return CloseAgreement{}, fmt.Errorf("local signing: %w", err)
 		}
@@ -273,10 +282,11 @@ func (c *Channel) ConfirmPayment(ca CloseAgreement) (closeAgreement CloseAgreeme
 
 	// All signatures are present that would be required to submit all
 	// transactions in the payment.
-	c.latestAuthorizedCloseAgreement = ca
-	c.latestAuthorizedCloseTransactions = txs
+	c.latestAuthorizedCloseAgreement = CloseAgreement{
+		Envelope: ce,
+		Transactions: txs,
+	}
 	c.latestUnauthorizedCloseAgreement = CloseAgreement{}
-	c.latestUnauthorizedCloseTransactions = CloseTransactions{}
 
 	return c.latestAuthorizedCloseAgreement, nil
 }

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -22,7 +22,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		{CloseAgreement{}, CloseAgreement{}, true},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -30,7 +30,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -41,7 +41,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -53,7 +53,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -64,7 +64,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -78,7 +78,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -93,7 +93,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -104,7 +104,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -118,7 +118,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -130,7 +130,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -145,7 +145,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -157,7 +157,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -172,7 +172,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -184,7 +184,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseDetails{
+				Details: CloseAgreementDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -274,14 +274,14 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 	// observation period matches the channels observation period.
 	{
 		initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-			Details: CloseDetails{
+			Details: CloseAgreementDetails{
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
 				ConfirmingSigner:           localSigner.FromAddress(),
 			},
 		}
 
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
@@ -296,7 +296,7 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
 		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseDetails{
+			Details: CloseAgreementDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
@@ -377,7 +377,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	}
 
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			ConfirmingSigner:           localSigner.FromAddress(),
@@ -387,7 +387,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	// A close agreement from the remote participant should be rejected if the
 	// observation period doesn't match the channels observation period.
 	{
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
@@ -401,7 +401,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
 		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseDetails{
+			Details: CloseAgreementDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      0,
 				ObservationPeriodLedgerGap: 0,
@@ -482,7 +482,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    100, // Local (initiator) owes remote (responder) 100.
 			ObservationPeriodTime:      10,
@@ -491,7 +491,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 		},
 	}
 
-	ca := CloseDetails{
+	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -585,7 +585,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    100, // Remote (initiator) owes local (responder) 100.
 			ObservationPeriodTime:      10,
@@ -593,7 +593,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 			ConfirmingSigner:           localSigner.FromAddress(),
 		},
 	}
-	ca := CloseDetails{
+	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    90,  // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -688,7 +688,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    -60, // Remote (responder) owes local (initiator) 60.
 			ObservationPeriodTime:      10,
@@ -697,7 +697,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 		},
 	}
 
-	ca := CloseDetails{
+	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
 		PaymentAmount:              50,
@@ -803,7 +803,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    60, // Remote (initiator) owes local (responder) 60.
 			ObservationPeriodTime:      10,
@@ -812,7 +812,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 		},
 	}
 
-	ca := CloseDetails{
+	ca := CloseAgreementDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
 		PaymentAmount:              50,
@@ -918,7 +918,7 @@ func TestChannel_ConfirmPayment_initiatorCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    60, // Local (initiator) owes remote (responder) 60.
 			ObservationPeriodTime:      10,
@@ -1004,7 +1004,7 @@ func TestChannel_ConfirmPayment_responderCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            1,
 			Balance:                    -60, // Local (responder) owes remote (initiator) 60.
 			ObservationPeriodTime:      10,
@@ -1109,7 +1109,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 
 	// Confirming a close agreement with same sequence number but different Amount should error
 	caDifferent := CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			IterationNumber:            2,
 			Balance:                    400,
 			ObservationPeriodTime:      10,
@@ -1228,7 +1228,7 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 
 	// After proposing a coordinated close, confirming a payment should error.
 	p := CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			ObservationPeriodTime:      10,
 			ObservationPeriodLedgerGap: 10,
 			IterationNumber:            1,
@@ -1254,7 +1254,7 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 
 	// After a confirmed coordinated close, confirming a payment should error.
 	p = CloseAgreement{
-		Details: CloseDetails{
+		Details: CloseAgreementDetails{
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
 			IterationNumber:            2,

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -22,7 +22,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		{CloseAgreement{}, CloseAgreement{}, true},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -30,7 +30,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -41,7 +41,7 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -53,24 +53,24 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -78,13 +78,13 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -93,24 +93,24 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -118,26 +118,26 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -145,26 +145,26 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GDJ5SXSKKFXINP7TN4J4T4JAXL4VZL7UMIAGZWQTYSKHSNHLSPVOAXRY"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -172,26 +172,26 @@ func TestCloseAgreement_Equal(t *testing.T) {
 		},
 		{
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           keypair.MustParseAddress("GCJFS4LZFAM7NKFQFEWE4W2SCGARSE2SMLGNWGHH2LSZ6CLX326MZWPO"),
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
 			CloseAgreement{
-				Details: CloseAgreementDetails{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 					ConfirmingSigner:           nil,
 				},
-				ProposerSignatures: CloseAgreementSignatures{
+				ProposerSignatures: CloseSignatures{
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
@@ -274,14 +274,14 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 	// observation period matches the channels observation period.
 	{
 		initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-			Details: CloseAgreementDetails{
+			Details: CloseDetails{
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
 				ConfirmingSigner:           localSigner.FromAddress(),
 			},
 		}
 
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
@@ -296,14 +296,14 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
 		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseAgreementDetails{
+			Details: CloseDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
 				ProposingSigner:            remoteSigner.FromAddress(),
 				ConfirmingSigner:           localSigner.FromAddress(),
 			},
-			ProposerSignatures: CloseAgreementSignatures{
+			ProposerSignatures: CloseSignatures{
 				Declaration: txDecl.Signatures()[0].Signature,
 				Close:       txClose.Signatures()[0].Signature,
 			},
@@ -377,7 +377,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	}
 
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
 			ConfirmingSigner:           localSigner.FromAddress(),
@@ -387,7 +387,7 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	// A close agreement from the remote participant should be rejected if the
 	// observation period doesn't match the channels observation period.
 	{
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
@@ -401,12 +401,12 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
 		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseAgreementDetails{
+			Details: CloseDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      0,
 				ObservationPeriodLedgerGap: 0,
 			},
-			ProposerSignatures: CloseAgreementSignatures{
+			ProposerSignatures: CloseSignatures{
 				Declaration: txDecl.Signatures()[0].Signature,
 				Close:       txClose.Signatures()[0].Signature,
 			},
@@ -482,7 +482,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    100, // Local (initiator) owes remote (responder) 100.
 			ObservationPeriodTime:      10,
@@ -491,7 +491,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 		},
 	}
 
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -510,7 +510,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	require.NoError(t, err)
 	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -585,7 +585,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    100, // Remote (initiator) owes local (responder) 100.
 			ObservationPeriodTime:      10,
@@ -593,7 +593,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 			ConfirmingSigner:           localSigner.FromAddress(),
 		},
 	}
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    90,  // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -613,7 +613,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	require.NoError(t, err)
 	_, err = responderChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -688,7 +688,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    -60, // Remote (responder) owes local (initiator) 60.
 			ObservationPeriodTime:      10,
@@ -697,7 +697,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 		},
 	}
 
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
 		PaymentAmount:              50,
@@ -716,7 +716,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	require.NoError(t, err)
 	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -728,7 +728,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	initiatorChannel.UpdateRemoteEscrowAccountBalance(200)
 	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -803,7 +803,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    60, // Remote (initiator) owes local (responder) 60.
 			ObservationPeriodTime:      10,
@@ -812,7 +812,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 		},
 	}
 
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
 		PaymentAmount:              50,
@@ -831,7 +831,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	require.NoError(t, err)
 	_, err = responderChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -843,7 +843,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	responderChannel.UpdateRemoteEscrowAccountBalance(200)
 	_, err = responderChannel.ConfirmPayment(CloseAgreement{
 		Details: ca,
-		ProposerSignatures: CloseAgreementSignatures{
+		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
 			Close:       txClose.Signatures()[0].Signature,
 		},
@@ -918,7 +918,7 @@ func TestChannel_ConfirmPayment_initiatorCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    60, // Local (initiator) owes remote (responder) 60.
 			ObservationPeriodTime:      10,
@@ -1004,7 +1004,7 @@ func TestChannel_ConfirmPayment_responderCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    -60, // Local (responder) owes remote (initiator) 60.
 			ObservationPeriodTime:      10,
@@ -1109,7 +1109,7 @@ func TestLastConfirmedPayment(t *testing.T) {
 
 	// Confirming a close agreement with same sequence number but different Amount should error
 	caDifferent := CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			IterationNumber:            2,
 			Balance:                    400,
 			ObservationPeriodTime:      10,
@@ -1228,7 +1228,7 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 
 	// After proposing a coordinated close, confirming a payment should error.
 	p := CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			ObservationPeriodTime:      10,
 			ObservationPeriodLedgerGap: 10,
 			IterationNumber:            1,
@@ -1254,7 +1254,7 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 
 	// After a confirmed coordinated close, confirming a payment should error.
 	p = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Details: CloseDetails{
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
 			IterationNumber:            2,

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -15,22 +15,22 @@ import (
 
 func TestCloseAgreement_Equal(t *testing.T) {
 	testCases := []struct {
-		ca1       CloseAgreement
-		ca2       CloseAgreement
+		ca1       CloseEnvelope
+		ca2       CloseEnvelope
 		wantEqual bool
 	}{
-		{CloseAgreement{}, CloseAgreement{}, true},
+		{CloseEnvelope{}, CloseEnvelope{}, true},
 		{
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
 			},
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -40,20 +40,20 @@ func TestCloseAgreement_Equal(t *testing.T) {
 			true,
 		},
 		{
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
 					Balance:                    100,
 				},
 			},
-			CloseAgreement{},
+			CloseEnvelope{},
 			false,
 		},
 		{
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -63,8 +63,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -77,8 +77,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 			true,
 		},
 		{
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -88,12 +88,12 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			CloseAgreement{},
+			CloseEnvelope{},
 			false,
 		},
 		{
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -103,8 +103,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -117,8 +117,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 			false,
 		},
 		{
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -129,8 +129,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -144,8 +144,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 			true,
 		},
 		{
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -156,8 +156,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -171,8 +171,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 			false,
 		},
 		{
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -183,8 +183,8 @@ func TestCloseAgreement_Equal(t *testing.T) {
 					Close: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 				},
 			},
-			CloseAgreement{
-				Details: CloseAgreementDetails{
+			CloseEnvelope{
+				Details: CloseDetails{
 					ObservationPeriodTime:      time.Minute,
 					ObservationPeriodLedgerGap: 2,
 					IterationNumber:            3,
@@ -240,9 +240,9 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 			StartingSequence: 101,
 		})
 		require.NoError(t, err)
-		m, err = responderChannel.ConfirmOpen(m)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(m)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := initiatorChannel.OpenTx()
@@ -274,14 +274,16 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 	// observation period matches the channels observation period.
 	{
 		initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-			Details: CloseAgreementDetails{
-				ObservationPeriodTime:      1,
-				ObservationPeriodLedgerGap: 1,
-				ConfirmingSigner:           localSigner.FromAddress(),
+			Envelope: CloseEnvelope{
+				Details: CloseDetails{
+					ObservationPeriodTime:      1,
+					ObservationPeriodLedgerGap: 1,
+					ConfirmingSigner:           localSigner.FromAddress(),
+				},
 			},
 		}
 
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Envelope.Details, CloseDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      1,
 			ObservationPeriodLedgerGap: 1,
@@ -295,8 +297,8 @@ func TestChannel_ConfirmPayment_acceptsSameObservationPeriod(t *testing.T) {
 		require.NoError(t, err)
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseAgreementDetails{
+		_, err = initiatorChannel.ConfirmPayment(CloseEnvelope{
+			Details: CloseDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      1,
 				ObservationPeriodLedgerGap: 1,
@@ -346,9 +348,9 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 			StartingSequence: 101,
 		})
 		require.NoError(t, err)
-		m, err = responderChannel.ConfirmOpen(m)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(m)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := initiatorChannel.OpenTx()
@@ -377,17 +379,19 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 	}
 
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
-			ObservationPeriodTime:      1,
-			ObservationPeriodLedgerGap: 1,
-			ConfirmingSigner:           localSigner.FromAddress(),
+		Envelope: CloseEnvelope{
+			Details: CloseDetails{
+				ObservationPeriodTime:      1,
+				ObservationPeriodLedgerGap: 1,
+				ConfirmingSigner:           localSigner.FromAddress(),
+			},
 		},
 	}
 
 	// A close agreement from the remote participant should be rejected if the
 	// observation period doesn't match the channels observation period.
 	{
-		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, CloseAgreementDetails{
+		txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Envelope.Details, CloseDetails{
 			IterationNumber:            1,
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
@@ -400,8 +404,8 @@ func TestChannel_ConfirmPayment_rejectsDifferentObservationPeriod(t *testing.T) 
 		require.NoError(t, err)
 		txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
-			Details: CloseAgreementDetails{
+		_, err = initiatorChannel.ConfirmPayment(CloseEnvelope{
+			Details: CloseDetails{
 				IterationNumber:            1,
 				ObservationPeriodTime:      0,
 				ObservationPeriodLedgerGap: 0,
@@ -449,9 +453,9 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 			StartingSequence: 101,
 		})
 		require.NoError(t, err)
-		m, err = responderChannel.ConfirmOpen(m)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(m)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := initiatorChannel.OpenTx()
@@ -482,16 +486,18 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
-			IterationNumber:            1,
-			Balance:                    100, // Local (initiator) owes remote (responder) 100.
-			ObservationPeriodTime:      10,
-			ObservationPeriodLedgerGap: 10,
-			ConfirmingSigner:           localSigner.FromAddress(),
+		Envelope: CloseEnvelope{
+			Details: CloseDetails{
+				IterationNumber:            1,
+				Balance:                    100, // Local (initiator) owes remote (responder) 100.
+				ObservationPeriodTime:      10,
+				ObservationPeriodLedgerGap: 10,
+				ConfirmingSigner:           localSigner.FromAddress(),
+			},
 		},
 	}
 
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Local (initiator) owes remote (responder) 110, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -500,7 +506,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
 	}
-	txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
+	txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Envelope.Details, ca)
 	txDecl := txs.Declaration
 	txClose := txs.Close
 	require.NoError(t, err)
@@ -508,7 +514,7 @@ func TestChannel_ConfirmPayment_localWhoIsInitiatorRejectsPaymentToRemoteWhoIsRe
 	require.NoError(t, err)
 	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
+	_, err = initiatorChannel.ConfirmPayment(CloseEnvelope{
 		Details: ca,
 		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
@@ -552,9 +558,9 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 			StartingSequence: 101,
 		})
 		require.NoError(t, err)
-		m, err = responderChannel.ConfirmOpen(m)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(m)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := initiatorChannel.OpenTx()
@@ -585,15 +591,17 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
-			IterationNumber:            1,
-			Balance:                    100, // Remote (initiator) owes local (responder) 100.
-			ObservationPeriodTime:      10,
-			ObservationPeriodLedgerGap: 10,
-			ConfirmingSigner:           localSigner.FromAddress(),
+		Envelope: CloseEnvelope{
+			Details: CloseDetails{
+				IterationNumber:            1,
+				Balance:                    100, // Remote (initiator) owes local (responder) 100.
+				ObservationPeriodTime:      10,
+				ObservationPeriodLedgerGap: 10,
+				ConfirmingSigner:           localSigner.FromAddress(),
+			},
 		},
 	}
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    90,  // Remote (initiator) owes local (responder) 90, payment of 10 from ❌ local to remote.
 		PaymentAmount:              -10, // Not possible to have a negative payment amount, but hardcode to test this validation.
@@ -603,7 +611,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 		ObservationPeriodLedgerGap: 10,
 	}
 
-	txs, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
+	txs, err := responderChannel.closeTxs(responderChannel.openAgreement.Envelope.Details, ca)
 	txDecl := txs.Declaration
 	txClose := txs.Close
 	require.NoError(t, err)
@@ -611,7 +619,7 @@ func TestChannel_ConfirmPayment_localWhoIsResponderRejectsPaymentToRemoteWhoIsIn
 	require.NoError(t, err)
 	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
-	_, err = responderChannel.ConfirmPayment(CloseAgreement{
+	_, err = responderChannel.ConfirmPayment(CloseEnvelope{
 		Details: ca,
 		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
@@ -655,9 +663,9 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 			StartingSequence: 101,
 		})
 		require.NoError(t, err)
-		m, err = responderChannel.ConfirmOpen(m)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(m)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := initiatorChannel.OpenTx()
@@ -688,16 +696,18 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
-			IterationNumber:            1,
-			Balance:                    -60, // Remote (responder) owes local (initiator) 60.
-			ObservationPeriodTime:      10,
-			ObservationPeriodLedgerGap: 10,
-			ConfirmingSigner:           localSigner.FromAddress(),
+		Envelope: CloseEnvelope{
+			Details: CloseDetails{
+				IterationNumber:            1,
+				Balance:                    -60, // Remote (responder) owes local (initiator) 60.
+				ObservationPeriodTime:      10,
+				ObservationPeriodLedgerGap: 10,
+				ConfirmingSigner:           localSigner.FromAddress(),
+			},
 		},
 	}
 
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    -110, // Remote (responder) owes local (initiator) 110, which responder ❌ cannot pay.
 		PaymentAmount:              50,
@@ -706,7 +716,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
 	}
-	txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Details, ca)
+	txs, err := initiatorChannel.closeTxs(initiatorChannel.openAgreement.Envelope.Details, ca)
 	txDecl := txs.Declaration
 	txClose := txs.Close
 	require.NoError(t, err)
@@ -714,7 +724,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 	require.NoError(t, err)
 	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
-	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
+	_, err = initiatorChannel.ConfirmPayment(CloseEnvelope{
 		Details: ca,
 		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
@@ -726,7 +736,7 @@ func TestChannel_ConfirmPayment_initiatorRejectsPaymentThatIsUnderfunded(t *test
 
 	// The same close payment should pass if the balance has been updated.
 	initiatorChannel.UpdateRemoteEscrowAccountBalance(200)
-	_, err = initiatorChannel.ConfirmPayment(CloseAgreement{
+	_, err = initiatorChannel.ConfirmPayment(CloseEnvelope{
 		Details: ca,
 		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
@@ -770,9 +780,9 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 			StartingSequence: 101,
 		})
 		require.NoError(t, err)
-		m, err = responderChannel.ConfirmOpen(m)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(m)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := initiatorChannel.OpenTx()
@@ -803,16 +813,18 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
-			IterationNumber:            1,
-			Balance:                    60, // Remote (initiator) owes local (responder) 60.
-			ObservationPeriodTime:      10,
-			ObservationPeriodLedgerGap: 10,
-			ConfirmingSigner:           localSigner.FromAddress(),
+		Envelope: CloseEnvelope{
+			Details: CloseDetails{
+				IterationNumber:            1,
+				Balance:                    60, // Remote (initiator) owes local (responder) 60.
+				ObservationPeriodTime:      10,
+				ObservationPeriodLedgerGap: 10,
+				ConfirmingSigner:           localSigner.FromAddress(),
+			},
 		},
 	}
 
-	ca := CloseAgreementDetails{
+	ca := CloseDetails{
 		IterationNumber:            2,
 		Balance:                    110, // Remote (initiator) owes local (responder) 110, which initiator ❌ cannot pay.
 		PaymentAmount:              50,
@@ -821,7 +833,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 		ObservationPeriodTime:      10,
 		ObservationPeriodLedgerGap: 10,
 	}
-	txs, err := responderChannel.closeTxs(responderChannel.openAgreement.Details, ca)
+	txs, err := responderChannel.closeTxs(responderChannel.openAgreement.Envelope.Details, ca)
 	txDecl := txs.Declaration
 	txClose := txs.Close
 	require.NoError(t, err)
@@ -829,7 +841,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 	require.NoError(t, err)
 	txClose, err = txClose.Sign(network.TestNetworkPassphrase, remoteSigner)
 	require.NoError(t, err)
-	_, err = responderChannel.ConfirmPayment(CloseAgreement{
+	_, err = responderChannel.ConfirmPayment(CloseEnvelope{
 		Details: ca,
 		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
@@ -841,7 +853,7 @@ func TestChannel_ConfirmPayment_responderRejectsPaymentThatIsUnderfunded(t *test
 
 	// The same close payment should pass if the balance has been updated.
 	responderChannel.UpdateRemoteEscrowAccountBalance(200)
-	_, err = responderChannel.ConfirmPayment(CloseAgreement{
+	_, err = responderChannel.ConfirmPayment(CloseEnvelope{
 		Details: ca,
 		ProposerSignatures: CloseSignatures{
 			Declaration: txDecl.Signatures()[0].Signature,
@@ -885,9 +897,9 @@ func TestChannel_ConfirmPayment_initiatorCannotProposePaymentThatIsUnderfunded(t
 			StartingSequence: 101,
 		})
 		require.NoError(t, err)
-		m, err = responderChannel.ConfirmOpen(m)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(m)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := initiatorChannel.OpenTx()
@@ -918,12 +930,14 @@ func TestChannel_ConfirmPayment_initiatorCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	initiatorChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
-			IterationNumber:            1,
-			Balance:                    60, // Local (initiator) owes remote (responder) 60.
-			ObservationPeriodTime:      10,
-			ObservationPeriodLedgerGap: 10,
-			ConfirmingSigner:           localSigner.FromAddress(),
+		Envelope: CloseEnvelope{
+			Details: CloseDetails{
+				IterationNumber:            1,
+				Balance:                    60, // Local (initiator) owes remote (responder) 60.
+				ObservationPeriodTime:      10,
+				ObservationPeriodLedgerGap: 10,
+				ConfirmingSigner:           localSigner.FromAddress(),
+			},
 		},
 	}
 
@@ -971,9 +985,9 @@ func TestChannel_ConfirmPayment_responderCannotProposePaymentThatIsUnderfunded(t
 			StartingSequence: 101,
 		})
 		require.NoError(t, err)
-		m, err = responderChannel.ConfirmOpen(m)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(m)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := initiatorChannel.OpenTx()
@@ -1004,14 +1018,16 @@ func TestChannel_ConfirmPayment_responderCannotProposePaymentThatIsUnderfunded(t
 	// A close agreement from the remote participant should be rejected if the
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
-		Details: CloseAgreementDetails{
+		Envelope: CloseEnvelope{
+		Details: CloseDetails{
 			IterationNumber:            1,
 			Balance:                    -60, // Local (responder) owes remote (initiator) 60.
 			ObservationPeriodTime:      10,
 			ObservationPeriodLedgerGap: 10,
 			ConfirmingSigner:           localSigner.FromAddress(),
 		},
-	}
+	},
+}
 
 	_, err := responderChannel.ProposePayment(110)
 	assert.EqualError(t, err, "amount over commits: account is underfunded to make payment")
@@ -1057,9 +1073,9 @@ func TestLastConfirmedPayment(t *testing.T) {
 			StartingSequence:           101,
 		})
 		require.NoError(t, err)
-		m, err = receiverChannel.ConfirmOpen(m)
+		m, err = receiverChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = sendingChannel.ConfirmOpen(m)
+		_, err = sendingChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := sendingChannel.OpenTx()
@@ -1103,27 +1119,27 @@ func TestLastConfirmedPayment(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ca, sendingChannel.latestUnauthorizedCloseAgreement)
 
-	caResponse, err := receiverChannel.ConfirmPayment(ca)
+	caResponse, err := receiverChannel.ConfirmPayment(ca.Envelope)
 	require.NoError(t, err)
 	assert.Equal(t, caResponse, receiverChannel.latestAuthorizedCloseAgreement)
 
 	// Confirming a close agreement with same sequence number but different Amount should error
-	caDifferent := CloseAgreement{
-		Details: CloseAgreementDetails{
+	caDifferent := CloseEnvelope{
+		Details: CloseDetails{
 			IterationNumber:            2,
 			Balance:                    400,
 			ObservationPeriodTime:      10,
 			ObservationPeriodLedgerGap: 10,
 		},
-		ProposerSignatures:  ca.ProposerSignatures,
-		ConfirmerSignatures: ca.ConfirmerSignatures,
+		ProposerSignatures:  ca.Envelope.ProposerSignatures,
+		ConfirmerSignatures: ca.Envelope.ConfirmerSignatures,
 	}
 	_, err = sendingChannel.ConfirmPayment(caDifferent)
 	require.EqualError(t, err, "validating payment: close agreement does not match the close agreement already in progress")
 	assert.Equal(t, ca, sendingChannel.latestUnauthorizedCloseAgreement)
 
 	// Confirming a payment with same sequence number and same amount should pass
-	caFinal, err := sendingChannel.ConfirmPayment(caResponse)
+	caFinal, err := sendingChannel.ConfirmPayment(caResponse.Envelope)
 	require.NoError(t, err)
 	assert.Equal(t, CloseAgreement{}, sendingChannel.latestUnauthorizedCloseAgreement)
 	assert.Equal(t, caFinal, sendingChannel.latestAuthorizedCloseAgreement)
@@ -1160,7 +1176,7 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 	require.EqualError(t, err, "cannot propose a payment before channel is opened")
 
 	// Before open, confirming a payment should error.
-	_, err = senderChannel.ConfirmPayment(CloseAgreement{})
+	_, err = senderChannel.ConfirmPayment(CloseEnvelope{})
 	require.EqualError(t, err, "validating payment: cannot confirm a payment before channel is opened")
 
 	// Open channel.
@@ -1172,17 +1188,17 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 		StartingSequence:           101,
 	})
 	require.NoError(t, err)
-	m, err = receiverChannel.ConfirmOpen(m)
+	m, err = receiverChannel.ConfirmOpen(m.Envelope)
 	require.NoError(t, err)
-	_, err = senderChannel.ConfirmOpen(m)
+	_, err = senderChannel.ConfirmOpen(m.Envelope)
 	require.NoError(t, err)
 
 	// Before an open is executed and validated, proposing and confirming a payment should error.
-	assert.False(t, senderChannel.latestAuthorizedCloseAgreement.isEmpty())
+	assert.False(t, senderChannel.latestAuthorizedCloseAgreement.Envelope.isEmpty())
 	_, err = senderChannel.ProposePayment(10)
 	require.EqualError(t, err, "cannot propose a payment before channel is opened")
 
-	_, err = senderChannel.ConfirmPayment(CloseAgreement{})
+	_, err = senderChannel.ConfirmPayment(CloseEnvelope{})
 	require.EqualError(t, err, "validating payment: cannot confirm a payment before channel is opened")
 
 	// Put channel into the Open state.
@@ -1227,8 +1243,8 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 	require.EqualError(t, err, "cannot propose payment after proposing a coordinated close")
 
 	// After proposing a coordinated close, confirming a payment should error.
-	p := CloseAgreement{
-		Details: CloseAgreementDetails{
+	p := CloseEnvelope{
+		Details: CloseDetails{
 			ObservationPeriodTime:      10,
 			ObservationPeriodLedgerGap: 10,
 			IterationNumber:            1,
@@ -1240,9 +1256,9 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 	require.EqualError(t, err, "validating payment: cannot confirm payment after proposing a coordinated close")
 
 	// Finish close.
-	ca, err = receiverChannel.ConfirmClose(ca)
+	ca, err = receiverChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
-	_, err = senderChannel.ConfirmClose(ca)
+	_, err = senderChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
 
 	// After a confirmed coordinated close, proposing a payment should error.
@@ -1253,8 +1269,8 @@ func TestChannel_ProposeAndConfirmPayment_rejectIfChannelNotOpen(t *testing.T) {
 	require.EqualError(t, err, "cannot propose payment after an accepted coordinated close")
 
 	// After a confirmed coordinated close, confirming a payment should error.
-	p = CloseAgreement{
-		Details: CloseAgreementDetails{
+	p = CloseEnvelope{
+		Details: CloseDetails{
 			ObservationPeriodTime:      0,
 			ObservationPeriodLedgerGap: 0,
 			IterationNumber:            2,
@@ -1303,9 +1319,9 @@ func TestChannel_enforceOnlyOneCloseAgreementAllowed(t *testing.T) {
 		StartingSequence:           101,
 	})
 	require.NoError(t, err)
-	m, err = receiverChannel.ConfirmOpen(m)
+	m, err = receiverChannel.ConfirmOpen(m.Envelope)
 	require.NoError(t, err)
-	_, err = senderChannel.ConfirmOpen(m)
+	_, err = senderChannel.ConfirmOpen(m.Envelope)
 	require.NoError(t, err)
 
 	// Put channel into the Open state.
@@ -1403,9 +1419,9 @@ func TestChannel_ConfirmPayment_validatePaymentAmount(t *testing.T) {
 			ObservationPeriodLedgerGap: 10,
 		})
 		require.NoError(t, err)
-		m, err = responderChannel.ConfirmOpen(m)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
-		_, err = initiatorChannel.ConfirmOpen(m)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
 		require.NoError(t, err)
 
 		ftx, err := initiatorChannel.OpenTx()
@@ -1447,34 +1463,34 @@ func TestChannel_ConfirmPayment_validatePaymentAmount(t *testing.T) {
 	// Initiator proposes payment to Responder.
 	ca, err := initiatorChannel.ProposePayment(50)
 	require.NoError(t, err)
-	assert.Equal(t, int64(50), ca.Details.Balance)
-	assert.Equal(t, int64(50), ca.Details.PaymentAmount)
+	assert.Equal(t, int64(50), ca.Envelope.Details.Balance)
+	assert.Equal(t, int64(50), ca.Envelope.Details.PaymentAmount)
 
 	// An incorrect PaymentAmount should error.
-	ca.Details.PaymentAmount = 49
-	_, err = responderChannel.ConfirmPayment(ca)
+	ca.Envelope.Details.PaymentAmount = 49
+	_, err = responderChannel.ConfirmPayment(ca.Envelope)
 	require.EqualError(t, err, "validating payment: close agreement payment amount is unexpected: "+
 		"current balance: 0 proposed balance: 50 payment amount: 49 initiator proposed: true")
 
-	ca.Details.PaymentAmount = 50
-	ca, err = responderChannel.ConfirmPayment(ca)
+	ca.Envelope.Details.PaymentAmount = 50
+	ca, err = responderChannel.ConfirmPayment(ca.Envelope)
 	require.NoError(t, err)
-	ca, err = initiatorChannel.ConfirmPayment(ca)
+	ca, err = initiatorChannel.ConfirmPayment(ca.Envelope)
 	require.NoError(t, err)
 
 	// Responder proposes payment to Initiator.
 	ca, err = responderChannel.ProposePayment(100)
 	require.NoError(t, err)
-	assert.Equal(t, int64(-50), ca.Details.Balance)
-	assert.Equal(t, int64(100), ca.Details.PaymentAmount)
+	assert.Equal(t, int64(-50), ca.Envelope.Details.Balance)
+	assert.Equal(t, int64(100), ca.Envelope.Details.PaymentAmount)
 
 	// An incorrect Balance should error.
-	ca.Details.Balance = -49
-	_, err = initiatorChannel.ConfirmPayment(ca)
+	ca.Envelope.Details.Balance = -49
+	_, err = initiatorChannel.ConfirmPayment(ca.Envelope)
 	require.EqualError(t, err, "validating payment: close agreement payment amount is unexpected: "+
 		"current balance: 50 proposed balance: -49 payment amount: 100 initiator proposed: false")
 
-	ca.Details.Balance = -50
-	ca, err = initiatorChannel.ConfirmPayment(ca)
+	ca.Envelope.Details.Balance = -50
+	ca, err = initiatorChannel.ConfirmPayment(ca.Envelope)
 	require.NoError(t, err)
 }

--- a/sdk/state/payment_test.go
+++ b/sdk/state/payment_test.go
@@ -1019,15 +1019,15 @@ func TestChannel_ConfirmPayment_responderCannotProposePaymentThatIsUnderfunded(t
 	// payment changes the balance in the favor of the remote.
 	responderChannel.latestAuthorizedCloseAgreement = CloseAgreement{
 		Envelope: CloseEnvelope{
-		Details: CloseDetails{
-			IterationNumber:            1,
-			Balance:                    -60, // Local (responder) owes remote (initiator) 60.
-			ObservationPeriodTime:      10,
-			ObservationPeriodLedgerGap: 10,
-			ConfirmingSigner:           localSigner.FromAddress(),
+			Details: CloseDetails{
+				IterationNumber:            1,
+				Balance:                    -60, // Local (responder) owes remote (initiator) 60.
+				ObservationPeriodTime:      10,
+				ObservationPeriodLedgerGap: 10,
+				ConfirmingSigner:           localSigner.FromAddress(),
+			},
 		},
-	},
-}
+	}
 
 	_, err := responderChannel.ProposePayment(110)
 	assert.EqualError(t, err, "amount over commits: account is underfunded to make payment")

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -69,7 +69,7 @@ func NewChannelFromSnapshot(c Config, s Snapshot) *Channel {
 	channel.remoteEscrowAccount.Balance = s.RemoteEscrowAccountBalance
 
 	channel.openAgreement = s.OpenAgreement
-	channel.openAgreementTransactions = s.OpenAgreementTransactions
+	channel.openTransactions = s.OpenAgreementTransactions
 	channel.openExecutedAndValidated = s.OpenExecutedAndValidated
 	if s.OpenExecutedWithError {
 		channel.openExecutedWithError = fmt.Errorf("open executed with error")
@@ -100,10 +100,10 @@ type Channel struct {
 	localSigner  *keypair.Full
 	remoteSigner *keypair.FromAddress
 
-	openAgreement             OpenAgreement
-	openAgreementTransactions OpenTransactions
-	openExecutedAndValidated  bool
-	openExecutedWithError     error
+	openAgreement            OpenAgreement
+	openTransactions         OpenTransactions
+	openExecutedAndValidated bool
+	openExecutedWithError    error
 
 	latestAuthorizedCloseAgreement      CloseAgreement
 	latestAuthorizedCloseTransactions   CloseTransactions
@@ -122,7 +122,7 @@ func (c *Channel) Snapshot() Snapshot {
 		RemoteEscrowAccountBalance: c.remoteEscrowAccount.Balance,
 
 		OpenAgreement:             c.openAgreement,
-		OpenAgreementTransactions: c.openAgreementTransactions,
+		OpenAgreementTransactions: c.openTransactions,
 		OpenExecutedAndValidated:  c.openExecutedAndValidated,
 		OpenExecutedWithError:     c.openExecutedWithError != nil,
 

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -46,14 +46,11 @@ type Snapshot struct {
 	RemoteEscrowAccountBalance int64
 
 	OpenAgreement             OpenAgreement
-	OpenAgreementTransactions OpenTransactions
 	OpenExecutedAndValidated  bool
 	OpenExecutedWithError     bool
 
 	LatestAuthorizedCloseAgreement      CloseAgreement
-	LatestAuthorizedCloseTransactions   CloseTransactions
 	LatestUnauthorizedCloseAgreement    CloseAgreement
-	LatestUnauthorizedCloseTransactions CloseTransactions
 }
 
 // NewChannelFromSnapshot creates the channel with the given config, and
@@ -69,16 +66,13 @@ func NewChannelFromSnapshot(c Config, s Snapshot) *Channel {
 	channel.remoteEscrowAccount.Balance = s.RemoteEscrowAccountBalance
 
 	channel.openAgreement = s.OpenAgreement
-	channel.openTransactions = s.OpenAgreementTransactions
 	channel.openExecutedAndValidated = s.OpenExecutedAndValidated
 	if s.OpenExecutedWithError {
 		channel.openExecutedWithError = fmt.Errorf("open executed with error")
 	}
 
 	channel.latestAuthorizedCloseAgreement = s.LatestAuthorizedCloseAgreement
-	channel.latestAuthorizedCloseTransactions = s.LatestAuthorizedCloseTransactions
 	channel.latestUnauthorizedCloseAgreement = s.LatestUnauthorizedCloseAgreement
-	channel.latestUnauthorizedCloseTransactions = s.LatestUnauthorizedCloseTransactions
 
 	return channel
 }
@@ -101,14 +95,11 @@ type Channel struct {
 	remoteSigner *keypair.FromAddress
 
 	openAgreement            OpenAgreement
-	openTransactions         OpenTransactions
 	openExecutedAndValidated bool
 	openExecutedWithError    error
 
 	latestAuthorizedCloseAgreement      CloseAgreement
-	latestAuthorizedCloseTransactions   CloseTransactions
 	latestUnauthorizedCloseAgreement    CloseAgreement
-	latestUnauthorizedCloseTransactions CloseTransactions
 }
 
 // Snapshot returns a snapshot of the channel's internal state that if combined
@@ -122,14 +113,11 @@ func (c *Channel) Snapshot() Snapshot {
 		RemoteEscrowAccountBalance: c.remoteEscrowAccount.Balance,
 
 		OpenAgreement:             c.openAgreement,
-		OpenAgreementTransactions: c.openTransactions,
 		OpenExecutedAndValidated:  c.openExecutedAndValidated,
 		OpenExecutedWithError:     c.openExecutedWithError != nil,
 
 		LatestAuthorizedCloseAgreement:      c.latestAuthorizedCloseAgreement,
-		LatestAuthorizedCloseTransactions:   c.latestAuthorizedCloseTransactions,
 		LatestUnauthorizedCloseAgreement:    c.latestUnauthorizedCloseAgreement,
-		LatestUnauthorizedCloseTransactions: c.latestUnauthorizedCloseTransactions,
 	}
 }
 
@@ -158,7 +146,7 @@ func (c *Channel) State() (State, error) {
 	}
 
 	// Get the sequence numbers for the latest close agreement transactions.
-	txs, err := c.closeTxs(c.openAgreement.Details, c.latestAuthorizedCloseAgreement.Details)
+	txs, err := c.closeTxs(c.openAgreement.Envelope.Details, c.latestAuthorizedCloseAgreement.Envelope.Details)
 	if err != nil {
 		return -1, fmt.Errorf("building declaration and close txs for latest authorized close agreement: %w", err)
 	}
@@ -167,7 +155,7 @@ func (c *Channel) State() (State, error) {
 
 	initiatorEscrowSeqNum := c.initiatorEscrowAccount().SequenceNumber
 
-	if initiatorEscrowSeqNum == c.openAgreement.Details.StartingSequence {
+	if initiatorEscrowSeqNum == c.openAgreement.Envelope.Details.StartingSequence {
 		return StateOpen, nil
 	} else if initiatorEscrowSeqNum < latestDeclSequence {
 		return StateClosingWithOutdatedState, nil
@@ -189,24 +177,24 @@ func (c *Channel) IsInitiator() bool {
 }
 
 func (c *Channel) NextIterationNumber() int64 {
-	if !c.latestUnauthorizedCloseAgreement.isEmpty() {
-		return c.latestUnauthorizedCloseAgreement.Details.IterationNumber
+	if !c.latestUnauthorizedCloseAgreement.Envelope.isEmpty() {
+		return c.latestUnauthorizedCloseAgreement.Envelope.Details.IterationNumber
 	}
-	return c.latestAuthorizedCloseAgreement.Details.IterationNumber + 1
+	return c.latestAuthorizedCloseAgreement.Envelope.Details.IterationNumber + 1
 }
 
 // Balance returns the amount owing from the initiator to the responder, if positive, or
 // the amount owing from the responder to the initiator, if negative.
 func (c *Channel) Balance() int64 {
-	return c.latestAuthorizedCloseAgreement.Details.Balance
+	return c.latestAuthorizedCloseAgreement.Envelope.Details.Balance
 }
 
-func (c *Channel) OpenAgreement() OpenAgreement {
-	return c.openAgreement
+func (c *Channel) OpenAgreement() OpenEnvelope {
+	return c.openAgreement.Envelope
 }
 
-func (c *Channel) LatestCloseAgreement() CloseAgreement {
-	return c.latestAuthorizedCloseAgreement
+func (c *Channel) LatestCloseAgreement() CloseEnvelope {
+	return c.latestAuthorizedCloseAgreement.Envelope
 }
 
 func (c *Channel) UpdateLocalEscrowAccountBalance(balance int64) {

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -45,12 +45,12 @@ type Snapshot struct {
 	RemoteEscrowSequence       int64
 	RemoteEscrowAccountBalance int64
 
-	OpenAgreement             OpenAgreement
-	OpenExecutedAndValidated  bool
-	OpenExecutedWithError     bool
+	OpenAgreement            OpenAgreement
+	OpenExecutedAndValidated bool
+	OpenExecutedWithError    bool
 
-	LatestAuthorizedCloseAgreement      CloseAgreement
-	LatestUnauthorizedCloseAgreement    CloseAgreement
+	LatestAuthorizedCloseAgreement   CloseAgreement
+	LatestUnauthorizedCloseAgreement CloseAgreement
 }
 
 // NewChannelFromSnapshot creates the channel with the given config, and
@@ -98,8 +98,8 @@ type Channel struct {
 	openExecutedAndValidated bool
 	openExecutedWithError    error
 
-	latestAuthorizedCloseAgreement      CloseAgreement
-	latestUnauthorizedCloseAgreement    CloseAgreement
+	latestAuthorizedCloseAgreement   CloseAgreement
+	latestUnauthorizedCloseAgreement CloseAgreement
 }
 
 // Snapshot returns a snapshot of the channel's internal state that if combined
@@ -112,12 +112,12 @@ func (c *Channel) Snapshot() Snapshot {
 		RemoteEscrowSequence:       c.remoteEscrowAccount.SequenceNumber,
 		RemoteEscrowAccountBalance: c.remoteEscrowAccount.Balance,
 
-		OpenAgreement:             c.openAgreement,
-		OpenExecutedAndValidated:  c.openExecutedAndValidated,
-		OpenExecutedWithError:     c.openExecutedWithError != nil,
+		OpenAgreement:            c.openAgreement,
+		OpenExecutedAndValidated: c.openExecutedAndValidated,
+		OpenExecutedWithError:    c.openExecutedWithError != nil,
 
-		LatestAuthorizedCloseAgreement:      c.latestAuthorizedCloseAgreement,
-		LatestUnauthorizedCloseAgreement:    c.latestUnauthorizedCloseAgreement,
+		LatestAuthorizedCloseAgreement:   c.latestAuthorizedCloseAgreement,
+		LatestUnauthorizedCloseAgreement: c.latestUnauthorizedCloseAgreement,
 	}
 }
 

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -46,14 +46,14 @@ type Snapshot struct {
 	RemoteEscrowAccountBalance int64
 
 	OpenAgreement             OpenAgreement
-	OpenAgreementTransactions OpenAgreementTransactions
+	OpenAgreementTransactions OpenTransactions
 	OpenExecutedAndValidated  bool
 	OpenExecutedWithError     bool
 
-	LatestAuthorizedCloseAgreement               CloseAgreement
-	LatestAuthorizedCloseAgreementTransactions   CloseAgreementTransactions
-	LatestUnauthorizedCloseAgreement             CloseAgreement
-	LatestUnauthorizedCloseAgreementTransactions CloseAgreementTransactions
+	LatestAuthorizedCloseAgreement      CloseAgreement
+	LatestAuthorizedCloseTransactions   CloseTransactions
+	LatestUnauthorizedCloseAgreement    CloseAgreement
+	LatestUnauthorizedCloseTransactions CloseTransactions
 }
 
 // NewChannelFromSnapshot creates the channel with the given config, and
@@ -76,9 +76,9 @@ func NewChannelFromSnapshot(c Config, s Snapshot) *Channel {
 	}
 
 	channel.latestAuthorizedCloseAgreement = s.LatestAuthorizedCloseAgreement
-	channel.latestAuthorizedCloseAgreementTransactions = s.LatestAuthorizedCloseAgreementTransactions
+	channel.latestAuthorizedCloseTransactions = s.LatestAuthorizedCloseTransactions
 	channel.latestUnauthorizedCloseAgreement = s.LatestUnauthorizedCloseAgreement
-	channel.latestUnauthorizedCloseAgreementTransactions = s.LatestUnauthorizedCloseAgreementTransactions
+	channel.latestUnauthorizedCloseTransactions = s.LatestUnauthorizedCloseTransactions
 
 	return channel
 }
@@ -101,14 +101,14 @@ type Channel struct {
 	remoteSigner *keypair.FromAddress
 
 	openAgreement             OpenAgreement
-	openAgreementTransactions OpenAgreementTransactions
+	openAgreementTransactions OpenTransactions
 	openExecutedAndValidated  bool
 	openExecutedWithError     error
 
-	latestAuthorizedCloseAgreement               CloseAgreement
-	latestAuthorizedCloseAgreementTransactions   CloseAgreementTransactions
-	latestUnauthorizedCloseAgreement             CloseAgreement
-	latestUnauthorizedCloseAgreementTransactions CloseAgreementTransactions
+	latestAuthorizedCloseAgreement      CloseAgreement
+	latestAuthorizedCloseTransactions   CloseTransactions
+	latestUnauthorizedCloseAgreement    CloseAgreement
+	latestUnauthorizedCloseTransactions CloseTransactions
 }
 
 // Snapshot returns a snapshot of the channel's internal state that if combined
@@ -126,10 +126,10 @@ func (c *Channel) Snapshot() Snapshot {
 		OpenExecutedAndValidated:  c.openExecutedAndValidated,
 		OpenExecutedWithError:     c.openExecutedWithError != nil,
 
-		LatestAuthorizedCloseAgreement:               c.latestAuthorizedCloseAgreement,
-		LatestAuthorizedCloseAgreementTransactions:   c.latestAuthorizedCloseAgreementTransactions,
-		LatestUnauthorizedCloseAgreement:             c.latestUnauthorizedCloseAgreement,
-		LatestUnauthorizedCloseAgreementTransactions: c.latestUnauthorizedCloseAgreementTransactions,
+		LatestAuthorizedCloseAgreement:      c.latestAuthorizedCloseAgreement,
+		LatestAuthorizedCloseTransactions:   c.latestAuthorizedCloseTransactions,
+		LatestUnauthorizedCloseAgreement:    c.latestUnauthorizedCloseAgreement,
+		LatestUnauthorizedCloseTransactions: c.latestUnauthorizedCloseTransactions,
 	}
 }
 

--- a/sdk/state/state_test.go
+++ b/sdk/state/state_test.go
@@ -69,9 +69,9 @@ func TestNewChannelWithSnapshot(t *testing.T) {
 			StartingSequence:           101,
 		})
 		require.NoError(t, err)
-		open2, err := remoteChannel.ConfirmOpen(open1)
+		open2, err := remoteChannel.ConfirmOpen(open1.Envelope)
 		require.NoError(t, err)
-		_, err = localChannel.ConfirmOpen(open2)
+		_, err = localChannel.ConfirmOpen(open2.Envelope)
 		require.NoError(t, err)
 	}
 
@@ -136,9 +136,9 @@ func TestNewChannelWithSnapshot(t *testing.T) {
 	assertChannelSnapshotsAndRestores(t, remoteConfig, remoteChannel)
 
 	// Confirm the payment.
-	ca, err = remoteChannel.ConfirmPayment(ca)
+	ca, err = remoteChannel.ConfirmPayment(ca.Envelope)
 	require.NoError(t, err)
-	_, err = localChannel.ConfirmPayment(ca)
+	_, err = localChannel.ConfirmPayment(ca.Envelope)
 	require.NoError(t, err)
 
 	// Check snapshot rehydrates the channel identically when payment confirmed.
@@ -210,9 +210,9 @@ func TestNewChannelWithSnapshot(t *testing.T) {
 	assertChannelSnapshotsAndRestores(t, remoteConfig, remoteChannel)
 
 	// Confirm the close.
-	ca, err = remoteChannel.ConfirmClose(ca)
+	ca, err = remoteChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
-	_, err = localChannel.ConfirmClose(ca)
+	_, err = localChannel.ConfirmClose(ca.Envelope)
 	require.NoError(t, err)
 
 	// Check snapshot rehydrates the channel identically when payment confirmed.


### PR DESCRIPTION
### What
Encapsulate stored transactions `CloseTransactions` inside `CloseAgreement`, and move most of what is already inside `CloseAgreement` inside `CloseEnvelope` which lives inside `CloseAgreement`.

#### Before
![Untitled-2021-08-20-2126-4](https://user-images.githubusercontent.com/351529/132628266-b0aea654-1e98-4b78-867b-10dcd62234b5.png)

#### After
![Untitled-2021-08-20-2126-3](https://user-images.githubusercontent.com/351529/132628286-c47f4638-7959-43f9-8bca-b10bd23fc7b3.png)

#### Example of Channel State

An example of an agreement in the `state.Channel` `Snapshot` rendered as JSON with this change:

```json
"LatestAuthorizedCloseAgreement": {
  "Envelope": {
    "Details": {
      "ObservationPeriodTime": 0,
      "ObservationPeriodLedgerGap": 0,
      "IterationNumber": 4,
      "Balance": 490000000,
      "PaymentAmount": 30000000,
      "ProposingSigner": "GBFUR3LXINTVW74QKRL7T5WSPABUJORLFOOH22PXGQCCWCAV3SHCHCQN",
      "ConfirmingSigner": "GB5NCO6I2ROUAF2V7CRIKXQPQ5B4RIOUACTXEARXJE3PNJTXYYTONEX3"
    },
    "ProposerSignatures": {
      "Close": "XGTZ/GzUEZf0vofMXun/R0fqBwrENGGJGev/dW3ZGHYE9q1r2eMAuGAUNdkFtM1QiNd9Hvu58imk3+i3x1f+AA==",
      "Declaration": "E45br2sVGPAkbNnyXJRzQVd3KrJh3713ScUyn0PX3Wu1dJ85DRRzopiuQiMKzVkB/4KQtLNQBEEv26vd0lo+BA=="
    },
    "ConfirmerSignatures": {
      "Close": "Eqa1tn2sM2HjFNhPxnqrp37aip67DfHsBEbpJBowj/CvWEsz6Aj+7XRIhbeHn2J6HQcD9oegN/QEdx+4UAtHCQ==",
      "Declaration": "Jysy/n8r2JGF8FFXIPrVG0SVgAe7+r0eqd5bzQfW+UEEkz0R+GlQtFu/bskHVEMRaeVomGwJT3tRdU1nHZ1nBg=="
    }
  },
  "Transactions": {
    "CloseHash": "7cf7360284b3695721bf1cd1fc3e775a00c85af46a21dab8fe9e88f13b2d2277",
    "Close": "AAAAAgAAAADsxhDF9xufXYYykz8gRn0i8jBEsO4BA5ItofiGd3/3uwAAAAAAAH3lAAAACgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAABAAAAAOzGEMX3G59dhjKTPyBGfSLyMESw7gEDki2h+IZ3f/e7AAAABQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAetE7yNRdQBdV+KKFXg+HQ8ih1ACncgI3STb2pnfGJuYAAAAAAAAAAQAAAAAD9R1A3o4QPCVHjsHdA8QZZOir5JzkYCs5+ENKX37YTwAAAAUAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAAAAAABAAAAAEtI7XdDZ1t/kFRX+fbSeANEuisrnH1p9zQEKwgV3I4jAAAAAAAAAAEAAAAA7MYQxfcbn12GMpM/IEZ9IvIwRLDuAQOSLaH4hnd/97sAAAABAAAAAAP1HUDejhA8JUeOwd0DxBlk6KvknORgKzn4Q0pffthPAAAAAAAAAAAdNM6AAAAAAAAAAAA=",
    "DeclarationHash": "cadbf9c6db7ce7f60c5dccacbd3f631064c891d8bd6cd5f1569e3df099e00f58",
    "Declaration": "AAAAAgAAAADsxhDF9xufXYYykz8gRn0i8jBEsO4BA5ItofiGd3/3uwAAAAAAAH3lAAAACQAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAB95QAAAAEAAAAAAAAAAAAAAAAAAAABAAAAA3rRO8jUXUAXVfiihV4Ph0PIodQAp3ICN0k29qZ3xibmAAAAIHz3NgKEs2lXIb8c0fw+d1oAyFr0aiHauP6eiPE7LSJ3AAAAAAAAAAEAAAAAAAAACwAAAAAAAAAAAAAAAAAAAAA="
  }
},
```

### Why
At the moment we store transactions alongside the close agreements. Everywhere we set the close agreements we must also remember to store the transactions. @acharb raised the point in https://github.com/stellar/experimental-payment-channels/pull/294#discussion_r704825595 that it could be easy to make mistakes setting one and not the other, and so it could be safer to have them inside the same object.

We get other benefits of wrapping them in a single object because we can return the transactions whenever we return the agreement from functions like `ProposePayment`/`ConfirmPayment`, or in events that transmit the agreement.

This change does not simply move `CloseTransactions` inside the existing `CloseAgreement` because that would have the side-effect of the transactions being an input to `ConfirmPayment` and `ConfirmClose`. That's a problem because we'd be saying that the transactions are part of the data blob that the two participants agree on, which is unnecessary. That would be inconvenient because any input data should be validated, so we'd have to validate the transactions passed matches also. All this is unnecessary logic we don't need in the confirm functions.

I chose the name `CloseEnvelope` for the new name for the type that holds the `CloseDetails` and the `CloseSignatures` because it is generic enough to represent an envelope of data that is passed around, and it is also the term we use in the Stellar protocol for the outer most part of a transaction that gets passed around. It's not a perfect name, and it is easy for me to change with Go refactoring tools so if anyone has a better idea now I can rename it, or if we find a better name later I can rename it later easily.

For #302