### PR TITLE
sdk/state: dont let escrow account sequence number go backwards

### DIFF
--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -1,14 +1,11 @@
 package state
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 )
-
-var errOldSeqNum = errors.New("old sequence number")
 
 // IngestTx accepts any transaction that has been seen as successful or
 // unsuccessful on the network. The function updates the internal state of the
@@ -64,7 +61,6 @@ func (c *Channel) ingestTxToUpdateInitiatorEscrowAccountSequence(tx *txnbuild.Tr
 	}
 
 	c.setInitiatorEscrowAccountSequence(tx.SourceAccount().Sequence)
-	return
 }
 
 // ingestTxToUpdateUnauthorizedCloseAgreement uses the signatures in the transaction to

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -55,6 +55,11 @@ func (c *Channel) ingestTxToUpdateInitiatorEscrowAccountSequence(tx *txnbuild.Tr
 		return
 	}
 
+	// If the transaction is from an earlier sequence number, return.
+	if tx.SourceAccount().Sequence < c.initiatorEscrowAccount().SequenceNumber {
+		return
+	}
+
 	c.setInitiatorEscrowAccountSequence(tx.SourceAccount().Sequence)
 }
 

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -32,10 +32,10 @@ func (c *Channel) IngestTx(txXDR, resultXDR, resultMetaXDR string) error {
 	}
 
 	err = c.ingestTxToUpdateInitiatorEscrowAccountSequence(tx)
+	if errors.Is(err, errOldSeqNum) {
+		return nil
+	}
 	if err != nil {
-		if errors.Is(err, errOldSeqNum) {
-			return nil
-		}
 		return err
 	}
 

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -1,14 +1,11 @@
 package state
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 )
-
-var errOldSeqNum = errors.New("old sequence number")
 
 // IngestTx accepts any transaction that has been seen as successful or
 // unsuccessful on the network. The function updates the internal state of the
@@ -31,13 +28,12 @@ func (c *Channel) IngestTx(txXDR, resultXDR, resultMetaXDR string) error {
 		return fmt.Errorf("transaction unrecognized")
 	}
 
-	err = c.ingestTxToUpdateInitiatorEscrowAccountSequence(tx)
-	if err != nil {
-		if errors.Is(err, errOldSeqNum) {
-			return nil
-		}
-		return err
+	// If the transaction is from an earlier sequence number, return.
+	if tx.SequenceNumber() < c.initiatorEscrowAccount().SequenceNumber {
+		return nil
 	}
+
+	c.ingestTxToUpdateInitiatorEscrowAccountSequence(tx)
 
 	err = c.ingestTxToUpdateUnauthorizedCloseAgreement(tx)
 	if err != nil {
@@ -57,20 +53,14 @@ func (c *Channel) IngestTx(txXDR, resultXDR, resultMetaXDR string) error {
 	return nil
 }
 
-func (c *Channel) ingestTxToUpdateInitiatorEscrowAccountSequence(tx *txnbuild.Transaction) error {
+func (c *Channel) ingestTxToUpdateInitiatorEscrowAccountSequence(tx *txnbuild.Transaction) {
 	// If the transaction's source account is not the initiator's escrow
 	// account, return.
 	if tx.SourceAccount().AccountID != c.initiatorEscrowAccount().Address.Address() {
-		return nil
-	}
-
-	// If the transaction is from an earlier sequence number, return.
-	if tx.SourceAccount().Sequence < c.initiatorEscrowAccount().SequenceNumber {
-		return errOldSeqNum
+		return
 	}
 
 	c.setInitiatorEscrowAccountSequence(tx.SourceAccount().Sequence)
-	return nil
 }
 
 // ingestTxToUpdateUnauthorizedCloseAgreement uses the signatures in the transaction to

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -31,13 +31,7 @@ func (c *Channel) IngestTx(txXDR, resultXDR, resultMetaXDR string) error {
 		return fmt.Errorf("transaction unrecognized")
 	}
 
-	err = c.ingestTxToUpdateInitiatorEscrowAccountSequence(tx)
-	if errors.Is(err, errOldSeqNum) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
+	c.ingestTxToUpdateInitiatorEscrowAccountSequence(tx)
 
 	err = c.ingestTxToUpdateUnauthorizedCloseAgreement(tx)
 	if err != nil {
@@ -57,20 +51,20 @@ func (c *Channel) IngestTx(txXDR, resultXDR, resultMetaXDR string) error {
 	return nil
 }
 
-func (c *Channel) ingestTxToUpdateInitiatorEscrowAccountSequence(tx *txnbuild.Transaction) error {
+func (c *Channel) ingestTxToUpdateInitiatorEscrowAccountSequence(tx *txnbuild.Transaction) {
 	// If the transaction's source account is not the initiator's escrow
 	// account, return.
 	if tx.SourceAccount().AccountID != c.initiatorEscrowAccount().Address.Address() {
-		return nil
+		return
 	}
 
 	// If the transaction is from an earlier sequence number, return.
 	if tx.SourceAccount().Sequence < c.initiatorEscrowAccount().SequenceNumber {
-		return errOldSeqNum
+		return
 	}
 
 	c.setInitiatorEscrowAccountSequence(tx.SourceAccount().Sequence)
-	return nil
+	return
 }
 
 // ingestTxToUpdateUnauthorizedCloseAgreement uses the signatures in the transaction to

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -56,7 +56,7 @@ func (c *Channel) ingestTxToUpdateInitiatorEscrowAccountSequence(tx *txnbuild.Tr
 	}
 
 	// If the transaction is from an earlier sequence number, return.
-	if tx.SourceAccount().Sequence < c.initiatorEscrowAccount().SequenceNumber {
+	if tx.SourceAccount().Sequence <= c.initiatorEscrowAccount().SequenceNumber {
 		return
 	}
 

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -1,11 +1,14 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 )
+
+var errOldSeqNum = errors.New("old sequence number")
 
 // IngestTx accepts any transaction that has been seen as successful or
 // unsuccessful on the network. The function updates the internal state of the
@@ -28,12 +31,13 @@ func (c *Channel) IngestTx(txXDR, resultXDR, resultMetaXDR string) error {
 		return fmt.Errorf("transaction unrecognized")
 	}
 
-	// If the transaction is from an earlier sequence number, return.
-	if tx.SequenceNumber() < c.initiatorEscrowAccount().SequenceNumber {
-		return nil
+	err = c.ingestTxToUpdateInitiatorEscrowAccountSequence(tx)
+	if err != nil {
+		if errors.Is(err, errOldSeqNum) {
+			return nil
+		}
+		return err
 	}
-
-	c.ingestTxToUpdateInitiatorEscrowAccountSequence(tx)
 
 	err = c.ingestTxToUpdateUnauthorizedCloseAgreement(tx)
 	if err != nil {
@@ -53,14 +57,20 @@ func (c *Channel) IngestTx(txXDR, resultXDR, resultMetaXDR string) error {
 	return nil
 }
 
-func (c *Channel) ingestTxToUpdateInitiatorEscrowAccountSequence(tx *txnbuild.Transaction) {
+func (c *Channel) ingestTxToUpdateInitiatorEscrowAccountSequence(tx *txnbuild.Transaction) error {
 	// If the transaction's source account is not the initiator's escrow
 	// account, return.
 	if tx.SourceAccount().AccountID != c.initiatorEscrowAccount().Address.Address() {
-		return
+		return nil
+	}
+
+	// If the transaction is from an earlier sequence number, return.
+	if tx.SourceAccount().Sequence < c.initiatorEscrowAccount().SequenceNumber {
+		return errOldSeqNum
 	}
 
 	c.setInitiatorEscrowAccountSequence(tx.SourceAccount().Sequence)
+	return nil
 }
 
 // ingestTxToUpdateUnauthorizedCloseAgreement uses the signatures in the transaction to

--- a/sdk/state/ingest_test.go
+++ b/sdk/state/ingest_test.go
@@ -962,3 +962,121 @@ func TestChannel_IngestTx_updateState_invalid_initiatorEscrowHasExtraSigner(t *t
 	require.NoError(t, err)
 	assert.EqualError(t, initiatorChannel.openExecutedWithError, "unexpected signer found on escrow account")
 }
+
+func TestChannel_IngestTx_seqNumCantGoBackwards(t *testing.T) {
+	initiatorSigner := keypair.MustRandom()
+	responderSigner := keypair.MustRandom()
+	initiatorEscrow := keypair.MustRandom().FromAddress()
+	responderEscrow := keypair.MustRandom().FromAddress()
+
+	// Given a channel with observation periods set to 1.
+	initiatorChannel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           true,
+		LocalSigner:         initiatorSigner,
+		RemoteSigner:        responderSigner.FromAddress(),
+		LocalEscrowAccount:  initiatorEscrow,
+		RemoteEscrowAccount: responderEscrow,
+		MaxOpenExpiry:       2 * time.Hour,
+	})
+	responderChannel := NewChannel(Config{
+		NetworkPassphrase:   network.TestNetworkPassphrase,
+		Initiator:           false,
+		LocalSigner:         responderSigner,
+		RemoteSigner:        initiatorSigner.FromAddress(),
+		LocalEscrowAccount:  responderEscrow,
+		RemoteEscrowAccount: initiatorEscrow,
+		MaxOpenExpiry:       2 * time.Hour,
+	})
+
+	// Put channel into the Open state.
+	{
+		m, err := initiatorChannel.ProposeOpen(OpenParams{
+			Asset:                      NativeAsset,
+			ExpiresAt:                  time.Now().Add(5 * time.Minute),
+			StartingSequence:           101,
+			ObservationPeriodTime:      10,
+			ObservationPeriodLedgerGap: 10,
+		})
+		require.NoError(t, err)
+		m, err = responderChannel.ConfirmOpen(m.Envelope)
+		require.NoError(t, err)
+		_, err = initiatorChannel.ConfirmOpen(m.Envelope)
+		require.NoError(t, err)
+
+		ftx, err := initiatorChannel.OpenTx()
+		require.NoError(t, err)
+		ftxXDR, err := ftx.Base64()
+		require.NoError(t, err)
+
+		successResultXDR, err := txbuildtest.BuildResultXDR(true)
+		require.NoError(t, err)
+		resultMetaXDR, err := txbuildtest.BuildFormationResultMetaXDR(txbuildtest.FormationResultMetaParams{
+			InitiatorSigner: initiatorSigner.Address(),
+			ResponderSigner: responderSigner.Address(),
+			InitiatorEscrow: initiatorEscrow.Address(),
+			ResponderEscrow: responderEscrow.Address(),
+			StartSequence:   101,
+			Asset:           txnbuild.NativeAsset{},
+		})
+		require.NoError(t, err)
+
+		err = initiatorChannel.IngestTx(ftxXDR, successResultXDR, resultMetaXDR)
+		require.NoError(t, err)
+		err = responderChannel.IngestTx(ftxXDR, successResultXDR, resultMetaXDR)
+		require.NoError(t, err)
+
+		cs, err := initiatorChannel.State()
+		require.NoError(t, err)
+		assert.Equal(t, StateOpen, cs)
+		cs, err = responderChannel.State()
+		require.NoError(t, err)
+		assert.Equal(t, StateOpen, cs)
+	}
+
+	declTx, closeTx, err := responderChannel.CloseTxs()
+	require.NoError(t, err)
+
+	declTxXDR, err := declTx.Base64()
+	require.NoError(t, err)
+
+	closeTxXDR, err := closeTx.Base64()
+	require.NoError(t, err)
+
+	placeholderXDR := "AAAAAgAAAAIAAAADABArWwAAAAAAAAAAWPnYf+6kQN3t44vgesQdWh4JOOPj7aer852I7RJhtzAAAAAWg8TZOwANrPwAAAAKAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABABArWwAAAAAAAAAAWPnYf+6kQN3t44vgesQdWh4JOOPj7aer852I7RJhtzAAAAAWg8TZOwANrPwAAAALAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMAD/39AAAAAAAAAAD49aUpVx7fhJPK6wDdlPJgkA1HkAi85qUL1tii8YSZzQAAABdjSVwcAA/8sgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAECtbAAAAAAAAAAD49aUpVx7fhJPK6wDdlPJgkA1HkAi85qUL1tii8YSZzQAAABee5CYcAA/8sgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAECtbAAAAAAAAAABY+dh/7qRA3e3ji+B6xB1aHgk44+Ptp6vznYjtEmG3MAAAABaDxNk7AA2s/AAAAAsAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAECtbAAAAAAAAAABY+dh/7qRA3e3ji+B6xB1aHgk44+Ptp6vznYjtEmG3MAAAABZIKg87AA2s/AAAAAsAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA="
+	validResultXDR, err := txbuildtest.BuildResultXDR(true)
+	require.NoError(t, err)
+
+	// Ingest the close Tx first to go into StateClosed.
+	err = initiatorChannel.IngestTx(closeTxXDR, validResultXDR, placeholderXDR)
+	require.NoError(t, err)
+	cs, err := initiatorChannel.State()
+	require.NoError(t, err)
+	assert.Equal(t, StateClosed, cs)
+	assert.Equal(t, int64(104), initiatorChannel.initiatorEscrowAccount().SequenceNumber)
+
+	// Ingesting a transaction with a previous seqNum should not move state backwards.
+	err = initiatorChannel.IngestTx(declTxXDR, validResultXDR, placeholderXDR)
+	require.NoError(t, err)
+	cs, err = initiatorChannel.State()
+	require.NoError(t, err)
+	assert.Equal(t, StateClosed, cs)
+	assert.Equal(t, int64(104), initiatorChannel.initiatorEscrowAccount().SequenceNumber)
+
+	// Imposter formation tx can not be ingested and move state back.
+	formationTx, err := initiatorChannel.OpenTx()
+	require.NoError(t, err)
+	imposterTx := formationTx.ToXDR()
+	imposterTxMemo, err := xdr.NewMemo(xdr.MemoTypeMemoText, "imposter")
+	require.NoError(t, err)
+	imposterTx.V1.Tx.Memo = imposterTxMemo
+	imposterTxBytes, err := imposterTx.MarshalBinary()
+	require.NoError(t, err)
+	imposterTxXDR := base64.StdEncoding.EncodeToString(imposterTxBytes)
+	err = initiatorChannel.IngestTx(imposterTxXDR, validResultXDR, placeholderXDR)
+	require.NoError(t, err)
+
+	cs, err = initiatorChannel.State()
+	require.NoError(t, err)
+	assert.Equal(t, StateClosed, cs)
+}


### PR DESCRIPTION
**WHAT**
if the channel ingests a transaction that would set the initiator escrow account seq num backwards, then return the ingestion process early and don't update state.

**WHY**
it can't be certain that transaction will be ingested in order in case two are submitted at the same time. So always just update the state from the transaction with the latest sequence number

closes https://github.com/stellar/experimental-payment-channels/issues/267

