### PR TITLE
sdk/state: in IngestTx end early if channel is closed or hasn't been opened

### DIFF
--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -127,8 +127,8 @@ const (
 	StateError State = iota - 1
 	StateNone
 	StateOpen
-	StateClosing
 	StateClosingWithOutdatedState
+	StateClosing
 	StateClosed
 )
 


### PR DESCRIPTION
**WHAT**
end the IngestTx process early and return error if the channel hasnt been opened or has been closed

**WHY**
if the channel doesn't exist it shouldnt be updating its state

closes https://github.com/stellar/experimental-payment-channels/issues/282