### PR TITLE
sdk/state: have the exported funcs return agreements not envelopes

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -291,7 +291,7 @@ func (a *Agent) Payment(paymentAmount string) error {
 	if errors.Is(err, state.ErrUnderfunded) {
 		fmt.Fprintf(a.logWriter, "local is underfunded for this payment based on cached account balances, checking escrow account...\n")
 		var balance int64
-		balance, err = a.balanceCollector.GetBalance(a.channel.LocalEscrowAccount().Address, a.channel.OpenAgreement().Details.Asset)
+		balance, err = a.balanceCollector.GetBalance(a.channel.LocalEscrowAccount().Address, a.channel.OpenAgreement().Envelope.Details.Asset)
 		if err != nil {
 			return err
 		}
@@ -552,7 +552,7 @@ func (a *Agent) handlePaymentRequest(m msg.Message, send *msg.Encoder) error {
 	if errors.Is(err, state.ErrUnderfunded) {
 		fmt.Fprintf(a.logWriter, "remote is underfunded for this payment based on cached account balances, checking their escrow account...\n")
 		var balance int64
-		balance, err = a.balanceCollector.GetBalance(a.channel.RemoteEscrowAccount().Address, a.channel.OpenAgreement().Details.Asset)
+		balance, err = a.balanceCollector.GetBalance(a.channel.RemoteEscrowAccount().Address, a.channel.OpenAgreement().Envelope.Details.Asset)
 		if err != nil {
 			return err
 		}

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -12,7 +12,7 @@ import (
 // channel if the transaction relates to the channel.
 func (c *Channel) IngestTx(txXDR, resultXDR, resultMetaXDR string) error {
 	// If channel has not been opened or has been closed, return.
-	if c.OpenAgreement().isEmpty() {
+	if c.OpenAgreement().Envelope.isEmpty() {
 		return fmt.Errorf("channel has not been opened")
 	}
 	cs, err := c.State()

--- a/sdk/state/integrationtests/state_test.go
+++ b/sdk/state/integrationtests/state_test.go
@@ -1073,8 +1073,8 @@ func TestOpenUpdatesUncoordinatedClose_recieverNotReturningSigs(t *testing.T) {
 		// owing as 10. The initiator has a last authorized agreement with total
 		// balance owing as 8, and an unauthorized agreement with total balance
 		// as 10.
-		assert.Equal(t, initiatorChannel.LatestCloseAgreement().Details.Balance, int64(8))
-		assert.Equal(t, responderChannel.LatestCloseAgreement().Details.Balance, int64(10))
+		assert.Equal(t, initiatorChannel.LatestCloseAgreement().Envelope.Details.Balance, int64(8))
+		assert.Equal(t, responderChannel.LatestCloseAgreement().Envelope.Details.Balance, int64(10))
 	}
 
 	// Responder starts but doesn't finish closing the channel.
@@ -1155,7 +1155,7 @@ func TestOpenUpdatesUncoordinatedClose_recieverNotReturningSigs(t *testing.T) {
 		err = initiatorChannel.IngestTx(broadcastedTxXDR, validResultXDR, placeholderXDR)
 		require.NoError(t, err)
 
-		t.Log("Initiator found signature:", base64.StdEncoding.EncodeToString(initiatorChannel.LatestCloseAgreement().ConfirmerSignatures.Close))
+		t.Log("Initiator found signature:", base64.StdEncoding.EncodeToString(initiatorChannel.LatestCloseAgreement().Envelope.ConfirmerSignatures.Close))
 
 		t.Log("Initiator waits the observation period...")
 		time.Sleep(observationPeriodTime)

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -189,12 +189,12 @@ func (c *Channel) Balance() int64 {
 	return c.latestAuthorizedCloseAgreement.Envelope.Details.Balance
 }
 
-func (c *Channel) OpenAgreement() OpenEnvelope {
-	return c.openAgreement.Envelope
+func (c *Channel) OpenAgreement() OpenAgreement {
+	return c.openAgreement
 }
 
-func (c *Channel) LatestCloseAgreement() CloseEnvelope {
-	return c.latestAuthorizedCloseAgreement.Envelope
+func (c *Channel) LatestCloseAgreement() CloseAgreement {
+	return c.latestAuthorizedCloseAgreement
 }
 
 func (c *Channel) UpdateLocalEscrowAccountBalance(balance int64) {


### PR DESCRIPTION
**WHAT**
OpenAgreement() to return OpenAgreement
LatestCloseAgreement() to return CloseAgreement

**WHY**
currently they're returning envelopes, which work but is confusing with the function name since there are also agreement types for those envelopes