### PR TITLE
sdk/state: avoid rehashing txs and remove cmp usage

### DIFF
--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -169,7 +169,7 @@ func (c *Channel) ConfirmClose(ce CloseEnvelope) (closeAgreement CloseAgreement,
 	if localSigs == nil {
 		return CloseAgreement{}, fmt.Errorf("local is not a signer")
 	}
-	err = localSigs.Verify(txs,  c.localSigner.FromAddress())
+	err = localSigs.Verify(txs, c.localSigner.FromAddress())
 	if err != nil {
 		// If the local is not the confirmer, do not sign, because being the
 		// proposer they should have signed earlier.

--- a/sdk/state/close.go
+++ b/sdk/state/close.go
@@ -100,7 +100,7 @@ func (c *Channel) ProposeClose() (CloseAgreement, error) {
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("making declaration and close transactions: %w", err)
 	}
-	sigs, err := signCloseAgreementTxs(txs, c.networkPassphrase, c.localSigner)
+	sigs, err := signCloseAgreementTxs(txs, c.localSigner)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("signing open agreement with local: %w", err)
 	}
@@ -159,7 +159,7 @@ func (c *Channel) ConfirmClose(ce CloseEnvelope) (closeAgreement CloseAgreement,
 	if remoteSigs == nil {
 		return CloseAgreement{}, fmt.Errorf("remote is not a signer")
 	}
-	err = remoteSigs.Verify(txs, c.networkPassphrase, c.remoteSigner)
+	err = remoteSigs.Verify(txs, c.remoteSigner)
 	if err != nil {
 		return CloseAgreement{}, fmt.Errorf("not signed by remote: %w", err)
 	}
@@ -169,14 +169,14 @@ func (c *Channel) ConfirmClose(ce CloseEnvelope) (closeAgreement CloseAgreement,
 	if localSigs == nil {
 		return CloseAgreement{}, fmt.Errorf("local is not a signer")
 	}
-	err = localSigs.Verify(txs, c.networkPassphrase, c.localSigner.FromAddress())
+	err = localSigs.Verify(txs,  c.localSigner.FromAddress())
 	if err != nil {
 		// If the local is not the confirmer, do not sign, because being the
 		// proposer they should have signed earlier.
 		if !ce.Details.ConfirmingSigner.Equal(c.localSigner.FromAddress()) {
 			return CloseAgreement{}, fmt.Errorf("not signed by local: %w", err)
 		}
-		ce.ConfirmerSignatures, err = signCloseAgreementTxs(txs, c.networkPassphrase, c.localSigner)
+		ce.ConfirmerSignatures, err = signCloseAgreementTxs(txs, c.localSigner)
 		if err != nil {
 			return CloseAgreement{}, fmt.Errorf("local signing: %w", err)
 		}

--- a/sdk/state/open.go
+++ b/sdk/state/open.go
@@ -1,10 +1,10 @@
 package state
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
@@ -39,12 +39,6 @@ type OpenSignatures struct {
 
 func (oas OpenSignatures) isFull() bool {
 	return len(oas.Close) > 0 && len(oas.Declaration) > 0 && len(oas.Formation) > 0
-}
-
-func (oas OpenSignatures) Equal(oas2 OpenSignatures) bool {
-	return bytes.Equal(oas.Formation, oas2.Formation) &&
-		bytes.Equal(oas.Declaration, oas2.Declaration) &&
-		bytes.Equal(oas.Close, oas2.Close)
 }
 
 func signOpenAgreementTxs(txs OpenTransactions, closeTxs CloseTransactions, signer *keypair.Full) (s OpenSignatures, err error) {
@@ -103,9 +97,9 @@ func (oa OpenEnvelope) isFull() bool {
 }
 
 func (oa OpenEnvelope) Equal(oa2 OpenEnvelope) bool {
-	return oa.Details.Equal(oa2.Details) &&
-		oa.ProposerSignatures.Equal(oa2.ProposerSignatures) &&
-		oa.ConfirmerSignatures.Equal(oa2.ConfirmerSignatures)
+	// TODO: Replace cmp.Equal with a hand written equals.
+	type OA OpenEnvelope
+	return cmp.Equal(OA(oa), OA(oa2))
 }
 
 func (oa OpenEnvelope) SignaturesFor(signer *keypair.FromAddress) *OpenSignatures {

--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -1,10 +1,10 @@
 package state
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
@@ -29,23 +29,14 @@ type CloseDetails struct {
 }
 
 func (d CloseDetails) Equal(d2 CloseDetails) bool {
-	return d.ObservationPeriodTime == d2.ObservationPeriodTime &&
-		d.ObservationPeriodLedgerGap == d2.ObservationPeriodLedgerGap &&
-		d.IterationNumber == d2.IterationNumber &&
-		d.Balance == d2.Balance &&
-		d.PaymentAmount == d2.PaymentAmount &&
-		d.ProposingSigner.Equal(d2.ProposingSigner) &&
-		d.ConfirmingSigner.Equal(d2.ConfirmingSigner)
+	// TODO: Replace cmp.Equal with a hand written equals.
+	type CAD CloseDetails
+	return cmp.Equal(CAD(d), CAD(d2))
 }
 
 type CloseSignatures struct {
 	Close       xdr.Signature
 	Declaration xdr.Signature
-}
-
-func (cas CloseSignatures) Equal(cas2 CloseSignatures) bool {
-	return bytes.Equal(cas.Declaration, cas2.Declaration) &&
-		bytes.Equal(cas.Close, cas2.Close)
 }
 
 func signCloseAgreementTxs(txs CloseTransactions, signer *keypair.Full) (s CloseSignatures, err error) {
@@ -94,9 +85,9 @@ func (ca CloseEnvelope) isEmpty() bool {
 }
 
 func (ca CloseEnvelope) Equal(ca2 CloseEnvelope) bool {
-	return ca.Details.Equal(ca2.Details) &&
-		ca.ProposerSignatures.Equal(ca2.ProposerSignatures) &&
-		ca.ConfirmerSignatures.Equal(ca2.ConfirmerSignatures)
+	// TODO: Replace cmp.Equal with a hand written equals.
+	type CA CloseEnvelope
+	return cmp.Equal(CA(ca), CA(ca2))
 }
 
 func (ca CloseEnvelope) SignaturesFor(signer *keypair.FromAddress) *CloseSignatures {

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
 	"github.com/stellar/go/keypair"
-	"github.com/stellar/go/network"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 )
@@ -285,18 +284,6 @@ func amountToResponder(balance int64) int64 {
 		return balance
 	}
 	return 0
-}
-
-func signTx(tx *txnbuild.Transaction, networkPassphrase string, kp *keypair.Full) (xdr.Signature, error) {
-	h, err := network.HashTransactionInEnvelope(tx.ToXDR(), networkPassphrase)
-	if err != nil {
-		return nil, fmt.Errorf("failed to hash transaction: %w", err)
-	}
-	sig, err := kp.Sign(h[:])
-	if err != nil {
-		return nil, fmt.Errorf("failed to sign transaction hash: %w", err)
-	}
-	return xdr.Signature(sig), nil
 }
 
 func verifySigned(tx *txnbuild.Transaction, networkPassphrase string, signer keypair.KP, sig xdr.Signature) error {

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stellar/experimental-payment-channels/sdk/txbuild"
 	"github.com/stellar/go/keypair"
-	"github.com/stellar/go/txnbuild"
-	"github.com/stellar/go/xdr"
 )
 
 type Config struct {
@@ -284,16 +282,4 @@ func amountToResponder(balance int64) int64 {
 		return balance
 	}
 	return 0
-}
-
-func verifySigned(tx *txnbuild.Transaction, networkPassphrase string, signer keypair.KP, sig xdr.Signature) error {
-	hash, err := tx.Hash(networkPassphrase)
-	if err != nil {
-		return err
-	}
-	err = signer.Verify(hash[:], []byte(sig))
-	if err != nil {
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
### What
Avoid rehashing transactions.

### Why
We rehash transactions during signing and verification. It's pretty expensive because full transaction has to be serialized. We hold hashes of the transactions next to the transactions and so there's little value in rehashing.

I didn't add any benchmark tests because even without benchmarks this is a pretty clear win that we wouldn't recalculate the hash when it is literally sitting next to the transaction in the same struct.

Close #327 