### PR TITLE
sdk/state: allow proposing payments with zero amounts

### DIFF
--- a/sdk/state/payment.go
+++ b/sdk/state/payment.go
@@ -147,8 +147,8 @@ func (ca CloseAgreement) SignedTransactions() CloseTransactions {
 }
 
 func (c *Channel) ProposePayment(amount int64) (CloseAgreement, error) {
-	if amount <= 0 {
-		return CloseAgreement{}, fmt.Errorf("payment amount must be greater than 0")
+	if amount < 0 {
+		return CloseAgreement{}, fmt.Errorf("payment amount must not be less than 0")
 	}
 
 	// If the channel is not open yet, error.


### PR DESCRIPTION
### What
Allow proposing payments with zero amounts.

### Why
The SDK prevents proposing payments that are zero amounts, but from best I can tell allows the receiver to accept a zero amount. It's not really necessary that we prevent zero payments and they can be a useful primitive for generating a new iteration for the current agreement.

This would make merging channels easier, and implementing turn taking buffered channels easier also.

Close #341