### PR TITLE
examples/benchmark: add ci that makes sure the example still compiles

### DIFF
--- a/.github/workflows/examples-benchmark.yml
+++ b/.github/workflows/examples-benchmark.yml
@@ -1,0 +1,41 @@
+name: 'Examples: Benchmark'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.41.1
+          working-directory: examples/benchmark
+          skip-go-installation: true
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1
+    - name: Build
+      working-directory: examples/benchmark
+      run: go build ./...
+    - name: Build Tests
+      working-directory: examples/benchmark
+      run: go test -exec=echo ./...


### PR DESCRIPTION
### What
Add a ci job that makes sure the examples/benchmark code still compiles.

### Why
It isn't covered by the existing jobs.