### PR TITLE
sdk/state, sdk/agent: add memos to payments

### DIFF
--- a/sdk/agent/agent.go
+++ b/sdk/agent/agent.go
@@ -276,6 +276,15 @@ func (a *Agent) Open() error {
 // The payment is not authorized until the remote participant signs the payment
 // and returns the payment.
 func (a *Agent) Payment(paymentAmount int64) error {
+	return a.PaymentWithMemo(paymentAmount, "")
+}
+
+// Payment makes a payment of the payment amount to the remote participant using
+// the open channel. The process is asynchronous and the function returns
+// immediately after the payment is signed and sent to the remote participant.
+// The payment is not authorized until the remote participant signs the payment
+// and returns the payment. The memo is attached to the payment.
+func (a *Agent) PaymentWithMemo(paymentAmount int64, memo string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -288,7 +297,7 @@ func (a *Agent) Payment(paymentAmount int64) error {
 
 	defer a.snapshot()
 
-	ca, err := a.channel.ProposePayment(paymentAmount)
+	ca, err := a.channel.ProposePaymentWithMemo(paymentAmount, memo)
 	if errors.Is(err, state.ErrUnderfunded) {
 		fmt.Fprintf(a.logWriter, "local is underfunded for this payment based on cached account balances, checking escrow account...\n")
 		var balance int64


### PR DESCRIPTION
### What

Add a memo field to close agreements that is optional. The memo is a string with unspecified bounds. The memo is not included in the final transaction so its contents does not leak to the public ledger when the channel is closed. Subsequently the signatures for close agreements to do not cover the memo.

### Why

Payments should have memos so they can be identifiable on the terms of the participants. Participants may communicate about a payment ahead of sending a payment and the memo will provide a way to annotate or identify the payment in whatever way they require.

Note that this is similar but different to #339. #339 is concerned with uniquely identifying payments with an identifier that the state machine attaches to close agreements. That would not be useful in the situation described above where an identifier must be assigned prior to the payment being made.

This is useful for things like buffered channels, something I'm experimenting with right now for #340.

Close #347