### PR TITLE
all: pin golangci-lint action version

### DIFF
--- a/.github/workflows/examples-benchmark.yml
+++ b/.github/workflows/examples-benchmark.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
           version: v1.41.1
           working-directory: examples/benchmark

--- a/.github/workflows/examples-console.yml
+++ b/.github/workflows/examples-console.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
           version: v1.41.1
           working-directory: examples/console

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
           version: v1.41.1
           working-directory: sdk


### PR DESCRIPTION
### What
Pin the version of the golangci-lint action to a specific commit.

### Why
So that we don't introduce new action code into our builds without us knowing about it and choosing to explicitly do that.

It is a good practice noted here: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions