### PR TITLE
examples/bufferedbenchmark: variety of improvements

### DIFF
--- a/sdk/agent/bufferedagent/agent.go
+++ b/sdk/agent/bufferedagent/agent.go
@@ -8,6 +8,7 @@
 package bufferedagent
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -16,9 +17,13 @@ import (
 	"github.com/stellar/experimental-payment-channels/sdk/agent"
 )
 
+var ErrQueueFull = errors.New("queue full")
+
 type Config struct {
 	Agent       *agent.Agent
 	AgentEvents <-chan agent.Event
+
+	MaxQueueSize int
 
 	LogWriter io.Writer
 
@@ -30,12 +35,19 @@ func NewAgent(c Config) *Agent {
 		agent:       c.Agent,
 		agentEvents: c.AgentEvents,
 
+		maxQueueSize: c.MaxQueueSize,
+
 		logWriter: c.LogWriter,
 
-		events: c.Events,
+		queueReady:   make(chan struct{}, 1),
+		sendingReady: make(chan struct{}, 1),
+		idle:         make(chan struct{}),
 
-		settlementID: uuid.NewString(),
+		events: c.Events,
 	}
+	agent.resetQueue()
+	agent.sendingReady <- struct{}{}
+	go agent.flushLoop()
 	return agent
 }
 
@@ -43,6 +55,8 @@ func NewAgent(c Config) *Agent {
 // buffers payments by collapsing them down into single payments while it waits
 // for a change to make a payment itself.
 type Agent struct {
+	maxQueueSize int
+
 	logWriter io.Writer
 
 	agentEvents <-chan agent.Event
@@ -54,20 +68,14 @@ type Agent struct {
 	// lock.
 	mu sync.Mutex
 
-	waitingConfirmation bool
-	settlementID        string
-	queue               []int64
-	agent               *agent.Agent
-}
+	agent *agent.Agent
 
-func (a *Agent) QueueLen() int {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	queueLen := len(a.queue)
-	if queueLen == 0 && a.waitingConfirmation {
-		return 1
-	}
-	return queueLen
+	queueID          string
+	queue            []int64
+	queueTotalAmount int64
+	queueReady       chan struct{}
+	sendingReady     chan struct{}
+	idle             chan struct{}
 }
 
 func (a *Agent) Open() error {
@@ -78,66 +86,52 @@ func (a *Agent) Open() error {
 
 // Payment queues a payment which will be paid in the next settlement. The
 // identifier for the settlement is returned.
-func (a *Agent) Payment(paymentAmount int64) (settlementID string) {
+func (a *Agent) Payment(paymentAmount int64) (queueID string, err error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.maxQueueSize != 0 && len(a.queue) == a.maxQueueSize {
+		return "", ErrQueueFull
+	}
 	a.queue = append(a.queue, paymentAmount)
-	settlementID = a.settlementID
-	if !a.waitingConfirmation {
-		a.flushQueue()
+	a.queueTotalAmount += paymentAmount // TODO: Return queue full error on overflow.
+	queueID = a.queueID
+	select {
+	case a.queueReady <- struct{}{}:
+	default:
 	}
 	return
 }
 
-func (a *Agent) flushQueue() {
-	if a.waitingConfirmation {
-		return
-	}
-
-	if len(a.queue) == 0 {
-		return
-	}
-
-	memo := settlementMemo{
-		ID: a.settlementID,
-	}
-	a.settlementID = uuid.NewString()
-
-	sum := int64(0)
-	for _, paymentAmount := range a.queue {
-		// TODO: Handle overflow.
-		sum += paymentAmount
-		memo.Amounts = append(memo.Amounts, paymentAmount)
-	}
-
-	err := a.agent.PaymentWithMemo(sum, memo.String())
-	if err != nil {
-		a.events <- agent.ErrorEvent{Err: err}
-		return
-	}
-	a.waitingConfirmation = true
-	a.queue = a.queue[:0]
+// Wait waits for sending to complete and the queue to be empty.
+func (a *Agent) Wait() {
+	<-a.idle
 }
 
 func (a *Agent) DeclareClose() error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	// TODO: Handle channel closing but payments still in queue.
+	close(a.queueReady)
 	return a.agent.DeclareClose()
 }
 
 func (a *Agent) Close() error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	// TODO: Handle channel closing but payments still in queue.
+	close(a.queueReady)
 	return a.agent.Close()
 }
 
 func (a *Agent) eventLoop() {
 	defer close(a.events)
+	defer close(a.sendingReady)
+	defer fmt.Fprintf(a.logWriter, "event loop stopped\n")
 	fmt.Fprintf(a.logWriter, "event loop started\n")
 	for {
-		switch e := (<-a.agentEvents).(type) {
+		ae, open := <-a.agentEvents
+		if !open {
+			break
+		}
+		switch e := ae.(type) {
 		case agent.PaymentReceivedEvent:
 			memo, err := parseSettlementMemo(e.CloseAgreement.Envelope.Details.Memo)
 			if err != nil {
@@ -150,7 +144,7 @@ func (a *Agent) eventLoop() {
 				Amounts:        memo.Amounts,
 			}
 		case agent.PaymentSentEvent:
-			a.handlePaymentSent()
+			a.sendingReady <- struct{}{}
 			memo, err := parseSettlementMemo(e.CloseAgreement.Envelope.Details.Memo)
 			if err != nil {
 				a.events <- agent.ErrorEvent{Err: err}
@@ -162,16 +156,73 @@ func (a *Agent) eventLoop() {
 				Amounts:        memo.Amounts,
 			}
 		default:
-			// TODO: Handle channel closing but payments still in queue.
 			a.events <- e
 		}
-		// TODO: Handle exiting.
 	}
 }
 
-func (a *Agent) handlePaymentSent() {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.waitingConfirmation = false
-	a.flushQueue()
+func (a *Agent) flushLoop() {
+	defer fmt.Fprintf(a.logWriter, "flush loop stopped\n")
+	fmt.Fprintf(a.logWriter, "flush loop started\n")
+	for {
+		_, open := <-a.sendingReady
+		if !open {
+			return
+		}
+		select {
+		case _, open = <-a.queueReady:
+			if !open {
+				return
+			}
+			a.flush()
+		default:
+			select {
+			case _, open = <-a.queueReady:
+				if !open {
+					return
+				}
+				a.flush()
+			case a.idle <- struct{}{}:
+				a.sendingReady <- struct{}{}
+			}
+		}
+	}
+}
+
+func (a *Agent) flush() {
+	var queueID string
+	var queue []int64
+	var queueTotalAmount int64
+
+	func() {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+
+		queueID = a.queueID
+		queue = a.queue
+		queueTotalAmount = a.queueTotalAmount
+		a.resetQueue()
+	}()
+
+	if len(queue) == 0 {
+		a.sendingReady <- struct{}{}
+		return
+	}
+
+	memo := settlementMemo{
+		ID:      queueID,
+		Amounts: queue,
+	}
+
+	err := a.agent.PaymentWithMemo(queueTotalAmount, memo.String())
+	if err != nil {
+		a.events <- agent.ErrorEvent{Err: err}
+		return
+	}
+}
+
+func (a *Agent) resetQueue() {
+	a.queueID = uuid.NewString()
+	a.queue = nil
+	a.queueTotalAmount = 0
 }


### PR DESCRIPTION
### What
A variety of changes to the bufferedbenchmark:
- Added a max queue size that limits how big the queue can get.
- Added a wait function that allows the calling code to wait until the queue is empty and idle.
- Added cli parameters for controlling the max queue size and the test size.
- Changed the internal to use the same patterns employed in stellar/go#3980

### Why
Adding a max queue size lets us run benchmarks with a variety of queue sizes to see how that impacts performance. Large queues use more memory, which affects application performance, so testing this is valuable.

Having a state where the queue is full requires that we have a way to find out when it is available again. Adding the wait functionality required restructuring the internals of how the signaling worked, and I used the same pattern that was used in stellar/go#3980 because I think it was easier to extend.
