### PR TITLE
sdk/agent/bufferedagent: add memos for buffered payments

### DIFF
--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -133,9 +133,9 @@ func run() error {
 				stats.AddPaymentsSent(1)
 
 			case bufferedagent.BufferedPaymentsReceivedEvent:
-				stats.AddBufferedPaymentsReceived(len(e.Amounts))
+				stats.AddBufferedPaymentsReceived(len(e.Payments))
 			case bufferedagent.BufferedPaymentsSentEvent:
-				stats.AddBufferedPaymentsSent(len(e.Amounts))
+				stats.AddBufferedPaymentsSent(len(e.Payments))
 
 			case agentpkg.ClosingEvent:
 				fmt.Fprintf(os.Stderr, "channel closing\n")
@@ -370,8 +370,9 @@ func prompt(agent *bufferedagent.Agent, stats *stats, submitter agentpkg.Submitt
 		agent.SetMaxBufferSize(bufferSize)
 		stats.MarkStart()
 		for i := 0; i < x; i++ {
+			memo := "tx-" + strconv.Itoa(i)
 			for {
-				_, err = agent.Payment(amt)
+				_, err = agent.PaymentWithMemo(amt, memo)
 				if err != nil {
 					continue
 				}

--- a/examples/dashboard.html
+++ b/examples/dashboard.html
@@ -291,7 +291,7 @@
       const count = r['Snapshot']['State']['Snapshot']['LatestAuthorizedCloseAgreement']['Envelope']['Details']['IterationNumber'] - 1;
       e.innerText = `Agreements Signed: ${count}`;
     };
-    setInterval(chartUpdate, 1000);
+    setInterval(chartUpdate, 100);
   }
 
   function stats(bindto, agentUrl) {

--- a/sdk/agent/bufferedagent/buffered_memo.go
+++ b/sdk/agent/bufferedagent/buffered_memo.go
@@ -9,8 +9,8 @@ import (
 )
 
 type bufferedPaymentsMemo struct {
-	ID      string
-	Amounts []int64
+	ID       string
+	Payments []BufferedPayment
 }
 
 func (m bufferedPaymentsMemo) String() string {

--- a/sdk/agent/bufferedagent/buffered_payment.go
+++ b/sdk/agent/bufferedagent/buffered_payment.go
@@ -1,0 +1,6 @@
+package bufferedagent
+
+type BufferedPayment struct {
+	Amount int64  `json:",empty"`
+	Memo   string `json:",empty"`
+}

--- a/sdk/agent/bufferedagent/events.go
+++ b/sdk/agent/bufferedagent/events.go
@@ -7,12 +7,12 @@ import "github.com/stellar/experimental-payment-channels/sdk/agent"
 type BufferedPaymentsReceivedEvent struct {
 	agent.PaymentReceivedEvent
 	BufferID string
-	Amounts  []int64
+	Payments  []BufferedPayment
 }
 
 // BufferedPaymentSentEvent occurs when a payment is sent that was buffered.
 type BufferedPaymentsSentEvent struct {
 	agent.PaymentSentEvent
 	BufferID string
-	Amounts  []int64
+	Payments  []BufferedPayment
 }


### PR DESCRIPTION
### What
Add memos to buffered payments.

### Why
So that buffered payments are identifiable.