### PR TITLE
all: update urls to gosdk and quickstart forks

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Stellar Quickstart w/ CAP-21: Build"
-      run: docker build -t stellar/quickstart:cap21and40 https://github.com/leighmcculloch/stellar--docker-stellar-core-horizon.git#cap21and40
+      run: docker build -t stellar/quickstart:cap21and40 https://github.com/stellar/docker-stellar-core-horizon.git#cap21and40
     - name: "Stellar Quickstart w/ CAP-21: Run"
       run: docker run -d -p 8000:8000 --name stellar stellar/quickstart:cap21and40 --standalone --enable-core-artificially-accelerate-time-for-testing
     - name: "Stellar Quickstart w/ CAP-21: Wait for Ready"

--- a/Getting Started.md
+++ b/Getting Started.md
@@ -4,7 +4,7 @@
 To run a standalone network and Horizon instance use the fork of the quickstart docker image:
 
 ```
-docker build -t stellar/quickstart:cap21and40 https://github.com/leighmcculloch/stellar--docker-stellar-core-horizon.git#cap21and40
+docker build -t stellar/quickstart:cap21and40 https://github.com/stellar/docker-stellar-core-horizon.git#cap21and40
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The code in this repository uses forks of some software with partial implementat
 
 - xdr: https://github.com/leighmcculloch/stellar--stellar-core/tree/cap21/src/xdr
 - stellar-core: https://github.com/leighmcculloch/stellar--stellar-core/pull/1
-- horizon & Go SDK: https://github.com/stellar/go/pull/3546
-- quickstart: https://github.com/leighmcculloch/stellar--docker-stellar-core-horizon/pull/2
+- horizon & Go SDK: https://github.com/stellar/go/pull/4013
+- quickstart: https://github.com/stellar/docker-stellar-core-horizon/pull/294
 - stc: https://github.com/leighmcculloch/xdrpp--stc/pull/1
 
 ### CAP-21

--- a/examples/benchmark/go.mod
+++ b/examples/benchmark/go.mod
@@ -2,7 +2,7 @@ module github.com/stellar/experimental-paymentment-channels/examples/benchmark
 
 go 1.17
 
-replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558
+replace github.com/stellar/go => github.com/stellar/go v0.0.0-20210924221542-a72304844558
 
 replace github.com/stellar/experimental-payment-channels/sdk => ../../sdk
 

--- a/examples/benchmark/go.sum
+++ b/examples/benchmark/go.sum
@@ -204,8 +204,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
-github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558 h1:CXK0ZPLdyCde60WeTCSasyKmgW89jBWl9f6CIvo25y0=
-github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.5.4/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -261,6 +259,8 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
+github.com/stellar/go v0.0.0-20210924221542-a72304844558 h1:al6mVZRenC2zz0s7yKWUTqtuOyYaXWzahRhPugirj1U=
+github.com/stellar/go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/examples/bufferedbenchmark/go.mod
+++ b/examples/bufferedbenchmark/go.mod
@@ -2,7 +2,7 @@ module github.com/stellar/experimental-paymentment-channels/examples/bufferedben
 
 go 1.17
 
-replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558
+replace github.com/stellar/go => github.com/stellar/go v0.0.0-20210924221542-a72304844558
 
 replace github.com/stellar/experimental-payment-channels/sdk => ../../sdk
 

--- a/examples/bufferedbenchmark/go.sum
+++ b/examples/bufferedbenchmark/go.sum
@@ -205,8 +205,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
-github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558 h1:CXK0ZPLdyCde60WeTCSasyKmgW89jBWl9f6CIvo25y0=
-github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.5.4/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -264,6 +262,8 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
+github.com/stellar/go v0.0.0-20210924221542-a72304844558 h1:al6mVZRenC2zz0s7yKWUTqtuOyYaXWzahRhPugirj1U=
+github.com/stellar/go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/examples/console/go.mod
+++ b/examples/console/go.mod
@@ -2,7 +2,7 @@ module github.com/stellar/experimental-paymentment-channels/examples/console
 
 go 1.17
 
-replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558
+replace github.com/stellar/go => github.com/stellar/go v0.0.0-20210924221542-a72304844558
 
 replace github.com/stellar/experimental-payment-channels/sdk => ../../sdk
 

--- a/examples/console/go.sum
+++ b/examples/console/go.sum
@@ -205,8 +205,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
-github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558 h1:CXK0ZPLdyCde60WeTCSasyKmgW89jBWl9f6CIvo25y0=
-github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.5.4/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -264,6 +262,8 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
+github.com/stellar/go v0.0.0-20210924221542-a72304844558 h1:al6mVZRenC2zz0s7yKWUTqtuOyYaXWzahRhPugirj1U=
+github.com/stellar/go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,7 +2,7 @@ module github.com/stellar/experimental-payment-channels/sdk
 
 go 1.17
 
-replace github.com/stellar/go => github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558
+replace github.com/stellar/go => github.com/stellar/go v0.0.0-20210924221542-a72304844558
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -205,8 +205,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
-github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558 h1:CXK0ZPLdyCde60WeTCSasyKmgW89jBWl9f6CIvo25y0=
-github.com/leighmcculloch/stellar--go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.5.4/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -264,6 +262,8 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
+github.com/stellar/go v0.0.0-20210924221542-a72304844558 h1:al6mVZRenC2zz0s7yKWUTqtuOyYaXWzahRhPugirj1U=
+github.com/stellar/go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=


### PR DESCRIPTION
### What
Update the URLs and imports for the Go SDK and the Quickstart forks.

### Why
I'm moving all the forks, that live on branches of my forks of the respective repos, to branches on the source repos to facilitate smoother collaboration. This should be no functional change.