### PR TITLE
all: update stellar/go dependency to use updated with protocol 18 branch

### DIFF
--- a/examples/benchmark/go.mod
+++ b/examples/benchmark/go.mod
@@ -2,13 +2,11 @@ module github.com/stellar/experimental-paymentment-channels/examples/benchmark
 
 go 1.17
 
-replace github.com/stellar/go => github.com/stellar/go v0.0.0-20210924221542-a72304844558
-
 replace github.com/stellar/experimental-payment-channels/sdk => ../../sdk
 
 require (
 	github.com/stellar/experimental-payment-channels/sdk v0.0.0-00010101000000-000000000000
-	github.com/stellar/go v0.0.0-00010101000000-000000000000
+	github.com/stellar/go v0.0.0-20211019190220-c47964999c2a
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 

--- a/examples/benchmark/go.sum
+++ b/examples/benchmark/go.sum
@@ -50,7 +50,7 @@ github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f h1:zvClvFQwU++UpIUBGC8YmD
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/asaskevich/govalidator v0.0.0-20180319081651-7d2e70ef918f/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.39.5/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -64,7 +64,6 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -92,6 +91,7 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/packr v1.12.1/go.mod h1:H2dZhQFqHeZwr/5A/uGQkBp7xYuMGuzXFeKhYdcz5No=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -186,7 +186,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v0.0.0-20161106143436-e3b7981a12dd h1:vQ0EEfHpdFUtNRj1ri25MUq5jb3Vma+kKhLyjeUTVow=
 github.com/klauspost/compress v0.0.0-20161106143436-e3b7981a12dd/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -259,8 +258,8 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20210924221542-a72304844558 h1:al6mVZRenC2zz0s7yKWUTqtuOyYaXWzahRhPugirj1U=
-github.com/stellar/go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
+github.com/stellar/go v0.0.0-20211019190220-c47964999c2a h1:QvfR68atkI9uoXgbizunHUHqWvwrq5Uo5kRpPP5H//Y=
+github.com/stellar/go v0.0.0-20211019190220-c47964999c2a/go.mod h1:H+AG8jyBM3bHICvpYayk0YZyRWax36FYFJJSrrO4cI4=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
@@ -280,8 +279,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v0.0.0-20170109085056-0a7f0a797cd6 h1:s0IDmR1jFyWvOK7jVIuAsmHQaGkXUuTas8NXFUOwuAI=
 github.com/valyala/fasthttp v0.0.0-20170109085056-0a7f0a797cd6/go.mod h1:+g/po7GqyG5E+1CNgquiIxJnsXEi5vwFn5weFujbO78=
-github.com/xdrpp/goxdr v0.1.0 h1:464WVKpe16VazriMaPxuGZtU/oE0Bxr5q5hLGs2I0rs=
-github.com/xdrpp/goxdr v0.1.0/go.mod h1:sIkGTrelHHneJXYd+dJGuziv4dWDofbdMl+onW+E3x8=
+github.com/xdrpp/goxdr v0.1.1 h1:E1B2c6E8eYhOVyd7yEpOyopzTPirUeF6mVOfXfGyJyc=
+github.com/xdrpp/goxdr v0.1.1/go.mod h1:dXo1scL/l6s7iME1gxHWo2XCppbHEKZS7m/KyYWkNzA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076 h1:KM4T3G70MiR+JtqplcYkNVoNz7pDwYaBxWBXQK804So=
 github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c h1:XZWnr3bsDQWAZg4Ne+cPoXRPILrNlPNQfxBuwLl43is=

--- a/examples/bufferedbenchmark/go.mod
+++ b/examples/bufferedbenchmark/go.mod
@@ -2,13 +2,11 @@ module github.com/stellar/experimental-paymentment-channels/examples/bufferedben
 
 go 1.17
 
-replace github.com/stellar/go => github.com/stellar/go v0.0.0-20210924221542-a72304844558
-
 replace github.com/stellar/experimental-payment-channels/sdk => ../../sdk
 
 require (
 	github.com/stellar/experimental-payment-channels/sdk v0.0.0-00010101000000-000000000000
-	github.com/stellar/go v0.0.0-00010101000000-000000000000
+	github.com/stellar/go v0.0.0-20211019190220-c47964999c2a
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 

--- a/examples/bufferedbenchmark/go.sum
+++ b/examples/bufferedbenchmark/go.sum
@@ -50,7 +50,7 @@ github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f h1:zvClvFQwU++UpIUBGC8YmD
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/asaskevich/govalidator v0.0.0-20180319081651-7d2e70ef918f/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.39.5/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -64,7 +64,6 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -92,6 +91,7 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/packr v1.12.1/go.mod h1:H2dZhQFqHeZwr/5A/uGQkBp7xYuMGuzXFeKhYdcz5No=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -187,7 +187,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v0.0.0-20161106143436-e3b7981a12dd h1:vQ0EEfHpdFUtNRj1ri25MUq5jb3Vma+kKhLyjeUTVow=
 github.com/klauspost/compress v0.0.0-20161106143436-e3b7981a12dd/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -262,8 +261,8 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20210924221542-a72304844558 h1:al6mVZRenC2zz0s7yKWUTqtuOyYaXWzahRhPugirj1U=
-github.com/stellar/go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
+github.com/stellar/go v0.0.0-20211019190220-c47964999c2a h1:QvfR68atkI9uoXgbizunHUHqWvwrq5Uo5kRpPP5H//Y=
+github.com/stellar/go v0.0.0-20211019190220-c47964999c2a/go.mod h1:H+AG8jyBM3bHICvpYayk0YZyRWax36FYFJJSrrO4cI4=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
@@ -283,8 +282,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v0.0.0-20170109085056-0a7f0a797cd6 h1:s0IDmR1jFyWvOK7jVIuAsmHQaGkXUuTas8NXFUOwuAI=
 github.com/valyala/fasthttp v0.0.0-20170109085056-0a7f0a797cd6/go.mod h1:+g/po7GqyG5E+1CNgquiIxJnsXEi5vwFn5weFujbO78=
-github.com/xdrpp/goxdr v0.1.0 h1:464WVKpe16VazriMaPxuGZtU/oE0Bxr5q5hLGs2I0rs=
-github.com/xdrpp/goxdr v0.1.0/go.mod h1:sIkGTrelHHneJXYd+dJGuziv4dWDofbdMl+onW+E3x8=
+github.com/xdrpp/goxdr v0.1.1 h1:E1B2c6E8eYhOVyd7yEpOyopzTPirUeF6mVOfXfGyJyc=
+github.com/xdrpp/goxdr v0.1.1/go.mod h1:dXo1scL/l6s7iME1gxHWo2XCppbHEKZS7m/KyYWkNzA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076 h1:KM4T3G70MiR+JtqplcYkNVoNz7pDwYaBxWBXQK804So=
 github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c h1:XZWnr3bsDQWAZg4Ne+cPoXRPILrNlPNQfxBuwLl43is=

--- a/examples/console/go.mod
+++ b/examples/console/go.mod
@@ -2,14 +2,12 @@ module github.com/stellar/experimental-paymentment-channels/examples/console
 
 go 1.17
 
-replace github.com/stellar/go => github.com/stellar/go v0.0.0-20210924221542-a72304844558
-
 replace github.com/stellar/experimental-payment-channels/sdk => ../../sdk
 
 require (
 	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
 	github.com/stellar/experimental-payment-channels/sdk v0.0.0-00010101000000-000000000000
-	github.com/stellar/go v0.0.0-00010101000000-000000000000
+	github.com/stellar/go v0.0.0-20211019190220-c47964999c2a
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 

--- a/examples/console/go.sum
+++ b/examples/console/go.sum
@@ -50,7 +50,7 @@ github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f h1:zvClvFQwU++UpIUBGC8YmD
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/asaskevich/govalidator v0.0.0-20180319081651-7d2e70ef918f/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.39.5/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -64,7 +64,6 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -92,6 +91,7 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/packr v1.12.1/go.mod h1:H2dZhQFqHeZwr/5A/uGQkBp7xYuMGuzXFeKhYdcz5No=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -187,7 +187,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v0.0.0-20161106143436-e3b7981a12dd h1:vQ0EEfHpdFUtNRj1ri25MUq5jb3Vma+kKhLyjeUTVow=
 github.com/klauspost/compress v0.0.0-20161106143436-e3b7981a12dd/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -262,8 +261,8 @@ github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20210924221542-a72304844558 h1:al6mVZRenC2zz0s7yKWUTqtuOyYaXWzahRhPugirj1U=
-github.com/stellar/go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
+github.com/stellar/go v0.0.0-20211019190220-c47964999c2a h1:QvfR68atkI9uoXgbizunHUHqWvwrq5Uo5kRpPP5H//Y=
+github.com/stellar/go v0.0.0-20211019190220-c47964999c2a/go.mod h1:H+AG8jyBM3bHICvpYayk0YZyRWax36FYFJJSrrO4cI4=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
@@ -283,8 +282,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v0.0.0-20170109085056-0a7f0a797cd6 h1:s0IDmR1jFyWvOK7jVIuAsmHQaGkXUuTas8NXFUOwuAI=
 github.com/valyala/fasthttp v0.0.0-20170109085056-0a7f0a797cd6/go.mod h1:+g/po7GqyG5E+1CNgquiIxJnsXEi5vwFn5weFujbO78=
-github.com/xdrpp/goxdr v0.1.0 h1:464WVKpe16VazriMaPxuGZtU/oE0Bxr5q5hLGs2I0rs=
-github.com/xdrpp/goxdr v0.1.0/go.mod h1:sIkGTrelHHneJXYd+dJGuziv4dWDofbdMl+onW+E3x8=
+github.com/xdrpp/goxdr v0.1.1 h1:E1B2c6E8eYhOVyd7yEpOyopzTPirUeF6mVOfXfGyJyc=
+github.com/xdrpp/goxdr v0.1.1/go.mod h1:dXo1scL/l6s7iME1gxHWo2XCppbHEKZS7m/KyYWkNzA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076 h1:KM4T3G70MiR+JtqplcYkNVoNz7pDwYaBxWBXQK804So=
 github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c h1:XZWnr3bsDQWAZg4Ne+cPoXRPILrNlPNQfxBuwLl43is=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,13 +2,11 @@ module github.com/stellar/experimental-payment-channels/sdk
 
 go 1.17
 
-replace github.com/stellar/go => github.com/stellar/go v0.0.0-20210924221542-a72304844558
-
 require (
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.2.0
 	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
-	github.com/stellar/go v0.0.0-00010101000000-000000000000
+	github.com/stellar/go v0.0.0-20211019190220-c47964999c2a
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -266,6 +266,7 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/stellar/go v0.0.0-20210924221542-a72304844558 h1:al6mVZRenC2zz0s7yKWUTqtuOyYaXWzahRhPugirj1U=
 github.com/stellar/go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
+github.com/stellar/go v0.0.0-20211019190220-c47964999c2a h1:QvfR68atkI9uoXgbizunHUHqWvwrq5Uo5kRpPP5H//Y=
 github.com/stellar/go v0.0.0-20211019190220-c47964999c2a/go.mod h1:H+AG8jyBM3bHICvpYayk0YZyRWax36FYFJJSrrO4cI4=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -51,6 +51,7 @@ github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvB
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/asaskevich/govalidator v0.0.0-20180319081651-7d2e70ef918f/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.39.5/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -92,6 +93,7 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/packr v1.12.1/go.mod h1:H2dZhQFqHeZwr/5A/uGQkBp7xYuMGuzXFeKhYdcz5No=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -264,6 +266,7 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/stellar/go v0.0.0-20210924221542-a72304844558 h1:al6mVZRenC2zz0s7yKWUTqtuOyYaXWzahRhPugirj1U=
 github.com/stellar/go v0.0.0-20210924221542-a72304844558/go.mod h1:GUYGng5T2YXpniTJwCU8VcHMpRmSejibArP1Ow9wdLY=
+github.com/stellar/go v0.0.0-20211019190220-c47964999c2a/go.mod h1:H+AG8jyBM3bHICvpYayk0YZyRWax36FYFJJSrrO4cI4=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
@@ -285,6 +288,7 @@ github.com/valyala/fasthttp v0.0.0-20170109085056-0a7f0a797cd6 h1:s0IDmR1jFyWvOK
 github.com/valyala/fasthttp v0.0.0-20170109085056-0a7f0a797cd6/go.mod h1:+g/po7GqyG5E+1CNgquiIxJnsXEi5vwFn5weFujbO78=
 github.com/xdrpp/goxdr v0.1.0 h1:464WVKpe16VazriMaPxuGZtU/oE0Bxr5q5hLGs2I0rs=
 github.com/xdrpp/goxdr v0.1.0/go.mod h1:sIkGTrelHHneJXYd+dJGuziv4dWDofbdMl+onW+E3x8=
+github.com/xdrpp/goxdr v0.1.1/go.mod h1:dXo1scL/l6s7iME1gxHWo2XCppbHEKZS7m/KyYWkNzA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076 h1:KM4T3G70MiR+JtqplcYkNVoNz7pDwYaBxWBXQK804So=
 github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c h1:XZWnr3bsDQWAZg4Ne+cPoXRPILrNlPNQfxBuwLl43is=

--- a/sdk/state/asset.go
+++ b/sdk/state/asset.go
@@ -42,7 +42,7 @@ func (a Asset) StringCanonical() string {
 	return fmt.Sprintf("%s:%s", a.Code(), a.Issuer())
 }
 
-func (a Asset) EqualsTrustLineAsset(ta xdr.TrustLineAsset) bool {
+func (a Asset) EqualTrustLineAsset(ta xdr.TrustLineAsset) bool {
 	if ta.Type == xdr.AssetTypeAssetTypePoolShare {
 		return false
 	}

--- a/sdk/state/asset.go
+++ b/sdk/state/asset.go
@@ -41,3 +41,10 @@ func (a Asset) StringCanonical() string {
 	}
 	return fmt.Sprintf("%s:%s", a.Code(), a.Issuer())
 }
+
+func (a Asset) EqualsTrustLineAsset(ta xdr.TrustLineAsset) bool {
+	if ta.Type == xdr.AssetTypeAssetTypePoolShare {
+		return false
+	}
+	return ta.ToAsset().StringCanonical() == a.StringCanonical()
+}

--- a/sdk/state/asset.go
+++ b/sdk/state/asset.go
@@ -43,8 +43,9 @@ func (a Asset) StringCanonical() string {
 }
 
 func (a Asset) EqualTrustLineAsset(ta xdr.TrustLineAsset) bool {
-	if ta.Type == xdr.AssetTypeAssetTypePoolShare {
-		return false
+	switch ta.Type {
+	case xdr.AssetTypeAssetTypeNative, xdr.AssetTypeAssetTypeCreditAlphanum4, xdr.AssetTypeAssetTypeCreditAlphanum12:
+		return ta.ToAsset().StringCanonical() == a.StringCanonical()
 	}
-	return ta.ToAsset().StringCanonical() == a.StringCanonical()
+	return false
 }

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -189,7 +189,7 @@ func (c *Channel) ingestTxMetaToUpdateBalances(txOrderID int64, resultMetaXDR st
 				if !ok {
 					continue
 				}
-				if channelAsset.StringCanonical() != tl.Asset.ToAsset().StringCanonical() {
+				if !channelAsset.EqualsTrustLineAsset(tl.Asset) {
 					continue
 				}
 				ledgerEntryAddress = tl.AccountId.Address()
@@ -277,7 +277,7 @@ func (c *Channel) ingestFormationTx(tx *txnbuild.Transaction, resultXDR string, 
 
 			switch updated.Data.Type {
 			case xdr.LedgerEntryTypeTrustline:
-				if updated.Data.TrustLine.Asset.ToAsset().StringCanonical() != c.openAgreement.Envelope.Details.Asset.StringCanonical() {
+				if !c.openAgreement.Envelope.Details.Asset.EqualsTrustLineAsset(updated.Data.TrustLine.Asset) {
 					continue
 				}
 				if updated.Data.TrustLine.AccountId.Address() == c.initiatorEscrowAccount().Address.Address() {

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -189,7 +189,7 @@ func (c *Channel) ingestTxMetaToUpdateBalances(txOrderID int64, resultMetaXDR st
 				if !ok {
 					continue
 				}
-				if !channelAsset.EqualsTrustLineAsset(tl.Asset) {
+				if !channelAsset.EqualTrustLineAsset(tl.Asset) {
 					continue
 				}
 				ledgerEntryAddress = tl.AccountId.Address()
@@ -277,7 +277,7 @@ func (c *Channel) ingestFormationTx(tx *txnbuild.Transaction, resultXDR string, 
 
 			switch updated.Data.Type {
 			case xdr.LedgerEntryTypeTrustline:
-				if !c.openAgreement.Envelope.Details.Asset.EqualsTrustLineAsset(updated.Data.TrustLine.Asset) {
+				if !c.openAgreement.Envelope.Details.Asset.EqualTrustLineAsset(updated.Data.TrustLine.Asset) {
 					continue
 				}
 				if updated.Data.TrustLine.AccountId.Address() == c.initiatorEscrowAccount().Address.Address() {

--- a/sdk/state/ingest.go
+++ b/sdk/state/ingest.go
@@ -189,7 +189,7 @@ func (c *Channel) ingestTxMetaToUpdateBalances(txOrderID int64, resultMetaXDR st
 				if !ok {
 					continue
 				}
-				if channelAsset.StringCanonical() != tl.Asset.StringCanonical() {
+				if channelAsset.StringCanonical() != tl.Asset.ToAsset().StringCanonical() {
 					continue
 				}
 				ledgerEntryAddress = tl.AccountId.Address()
@@ -277,7 +277,7 @@ func (c *Channel) ingestFormationTx(tx *txnbuild.Transaction, resultXDR string, 
 
 			switch updated.Data.Type {
 			case xdr.LedgerEntryTypeTrustline:
-				if updated.Data.TrustLine.Asset.StringCanonical() != c.openAgreement.Envelope.Details.Asset.StringCanonical() {
+				if updated.Data.TrustLine.Asset.ToAsset().StringCanonical() != c.openAgreement.Envelope.Details.Asset.StringCanonical() {
 					continue
 				}
 				if updated.Data.TrustLine.AccountId.Address() == c.initiatorEscrowAccount().Address.Address() {

--- a/sdk/state/ingest_test.go
+++ b/sdk/state/ingest_test.go
@@ -644,7 +644,7 @@ func TestChannel_IngestTx_updateBalancesNonNative_withLiabilities(t *testing.T) 
 				Type: xdr.LedgerEntryTypeTrustline,
 				TrustLine: &xdr.TrustLineEntry{
 					AccountId: xdr.MustAddress(tc.escrowAccount.Address()),
-					Asset:     xdr.MustNewCreditAsset(asset.Code(), asset.Issuer()),
+					Asset:     xdr.MustNewCreditAsset(asset.Code(), asset.Issuer()).ToTrustLineAsset(),
 					Balance:   tc.trustLineBalance,
 					Ext:       tle,
 				},

--- a/sdk/state/integrationtests/helpers_test.go
+++ b/sdk/state/integrationtests/helpers_test.go
@@ -176,7 +176,7 @@ func initAsset(t *testing.T, client horizonclient.ClientInterface, code string) 
 			Timebounds:           txnbuild.NewInfiniteTimeout(),
 			Operations: []txnbuild.Operation{
 				&txnbuild.ChangeTrust{
-					Line:  asset,
+					Line:  asset.MustToChangeTrustAsset(),
 					Limit: "5000",
 				},
 				&txnbuild.Payment{
@@ -239,7 +239,7 @@ func fundAsset(asset state.Asset, amount int64, accountKP *keypair.Full, distrib
 	if !asset.IsNative() {
 		ops = append(ops, &txnbuild.ChangeTrust{
 			SourceAccount: accountKP.Address(),
-			Line:          asset.Asset(),
+			Line:          asset.Asset().MustToChangeTrustAsset(),
 			Limit:         "5000",
 		})
 	}

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -36,13 +36,12 @@ func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
 		},
 	}
 	if !p.Asset.IsNative() {
-		// Alec TODO - diff between changetrust asset and trustline asset?
-		asset, err := p.Asset.ToChangeTrustAsset()
+		cta, err := p.Asset.ToChangeTrustAsset()
 		if err != nil {
 			return nil, fmt.Errorf("getting change trust asset from nonnative asset: %w", err)
 		}
 		ops = append(ops, &txnbuild.ChangeTrust{
-			Line:          asset,
+			Line:          cta,
 			Limit:         amount.StringFromInt64(math.MaxInt64),
 			SourceAccount: p.Escrow.Address(),
 		})

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -38,7 +38,7 @@ func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
 	if !p.Asset.IsNative() {
 		cta, err := p.Asset.ToChangeTrustAsset()
 		if err != nil {
-			return nil, fmt.Errorf("getting change trust asset from nonnative asset: %w", err)
+			return nil, fmt.Errorf("getting change trust asset from non-native asset: %w", err)
 		}
 		ops = append(ops, &txnbuild.ChangeTrust{
 			Line:          cta,

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -1,7 +1,6 @@
 package txbuild
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/stellar/go/amount"
@@ -36,12 +35,8 @@ func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
 		},
 	}
 	if !p.Asset.IsNative() {
-		cta, err := p.Asset.ToChangeTrustAsset()
-		if err != nil {
-			return nil, fmt.Errorf("getting change trust asset from non-native asset: %w", err)
-		}
 		ops = append(ops, &txnbuild.ChangeTrust{
-			Line:          cta,
+			Line:          p.Asset.MustToChangeTrustAsset(),
 			Limit:         amount.StringFromInt64(math.MaxInt64),
 			SourceAccount: p.Escrow.Address(),
 		})

--- a/sdk/txbuild/create_escrow.go
+++ b/sdk/txbuild/create_escrow.go
@@ -1,6 +1,7 @@
 package txbuild
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/stellar/go/amount"
@@ -12,7 +13,7 @@ type CreateEscrowParams struct {
 	Creator        *keypair.FromAddress
 	Escrow         *keypair.FromAddress
 	SequenceNumber int64
-	Asset          txnbuild.Asset
+	Asset          txnbuild.BasicAsset
 }
 
 func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
@@ -35,8 +36,13 @@ func CreateEscrow(p CreateEscrowParams) (*txnbuild.Transaction, error) {
 		},
 	}
 	if !p.Asset.IsNative() {
+		// Alec TODO - diff between changetrust asset and trustline asset?
+		asset, err := p.Asset.ToChangeTrustAsset()
+		if err != nil {
+			return nil, fmt.Errorf("getting change trust asset from nonnative asset: %w", err)
+		}
 		ops = append(ops, &txnbuild.ChangeTrust{
-			Line:          p.Asset,
+			Line:          asset,
 			Limit:         amount.StringFromInt64(math.MaxInt64),
 			SourceAccount: p.Escrow.Address(),
 		})

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -1,6 +1,7 @@
 package txbuild
 
 import (
+	"fmt"
 	"math"
 	"time"
 
@@ -71,8 +72,12 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		Signer:          &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
 	})
 	if !p.Asset.IsNative() {
+		cta, err := p.Asset.ToChangeTrustAsset()
+		if err != nil {
+			return nil, fmt.Errorf("getting change trust asset from nonnative asset: %w", err)
+		}
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
-			Line:          p.Asset,
+			Line:          cta,
 			Limit:         amount.StringFromInt64(math.MaxInt64),
 			SourceAccount: p.InitiatorEscrow.Address(),
 		})
@@ -98,8 +103,12 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		Signer:          &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
 	})
 	if !p.Asset.IsNative() {
+		cta, err := p.Asset.ToChangeTrustAsset()
+		if err != nil {
+			return nil, fmt.Errorf("getting change trust asset from nonnative asset: %w", err)
+		}
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
-			Line:          p.Asset,
+			Line:          cta,
 			Limit:         amount.StringFromInt64(math.MaxInt64),
 			SourceAccount: p.ResponderEscrow.Address(),
 		})

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -1,7 +1,6 @@
 package txbuild
 
 import (
-	"fmt"
 	"math"
 	"time"
 
@@ -72,12 +71,8 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		Signer:          &txnbuild.Signer{Address: p.InitiatorSigner.Address(), Weight: 1},
 	})
 	if !p.Asset.IsNative() {
-		cta, err := p.Asset.ToChangeTrustAsset()
-		if err != nil {
-			return nil, fmt.Errorf("getting change trust asset from non-native asset: %w", err)
-		}
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
-			Line:          cta,
+			Line:          p.Asset.MustToChangeTrustAsset(),
 			Limit:         amount.StringFromInt64(math.MaxInt64),
 			SourceAccount: p.InitiatorEscrow.Address(),
 		})
@@ -103,12 +98,8 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 		Signer:          &txnbuild.Signer{Address: p.ResponderSigner.Address(), Weight: 1},
 	})
 	if !p.Asset.IsNative() {
-		cta, err := p.Asset.ToChangeTrustAsset()
-		if err != nil {
-			return nil, fmt.Errorf("getting change trust asset from non-native asset: %w", err)
-		}
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
-			Line:          cta,
+			Line:          p.Asset.MustToChangeTrustAsset(),
 			Limit:         amount.StringFromInt64(math.MaxInt64),
 			SourceAccount: p.ResponderEscrow.Address(),
 		})

--- a/sdk/txbuild/formation.go
+++ b/sdk/txbuild/formation.go
@@ -74,7 +74,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 	if !p.Asset.IsNative() {
 		cta, err := p.Asset.ToChangeTrustAsset()
 		if err != nil {
-			return nil, fmt.Errorf("getting change trust asset from nonnative asset: %w", err)
+			return nil, fmt.Errorf("getting change trust asset from non-native asset: %w", err)
 		}
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
 			Line:          cta,
@@ -105,7 +105,7 @@ func Formation(p FormationParams) (*txnbuild.Transaction, error) {
 	if !p.Asset.IsNative() {
 		cta, err := p.Asset.ToChangeTrustAsset()
 		if err != nil {
-			return nil, fmt.Errorf("getting change trust asset from nonnative asset: %w", err)
+			return nil, fmt.Errorf("getting change trust asset from non-native asset: %w", err)
 		}
 		tp.Operations = append(tp.Operations, &txnbuild.ChangeTrust{
 			Line:          cta,

--- a/sdk/txbuildtest/txbuildtest.go
+++ b/sdk/txbuildtest/txbuildtest.go
@@ -115,7 +115,7 @@ func BuildFormationResultMetaXDR(params FormationResultMetaParams) (string, erro
 				TrustLine: &xdr.TrustLineEntry{
 					AccountId: xdr.MustAddress(params.InitiatorEscrow),
 					Balance:   0,
-					Asset:     xdr.MustNewCreditAsset(params.Asset.GetCode(), params.Asset.GetIssuer()),
+					Asset:     xdr.MustNewCreditAsset(params.Asset.GetCode(), params.Asset.GetIssuer()).ToTrustLineAsset(),
 					Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 				},
 			},
@@ -124,7 +124,7 @@ func BuildFormationResultMetaXDR(params FormationResultMetaParams) (string, erro
 				TrustLine: &xdr.TrustLineEntry{
 					AccountId: xdr.MustAddress(params.ResponderEscrow),
 					Balance:   0,
-					Asset:     xdr.MustNewCreditAsset(params.Asset.GetCode(), params.Asset.GetIssuer()),
+					Asset:     xdr.MustNewCreditAsset(params.Asset.GetCode(), params.Asset.GetIssuer()).ToTrustLineAsset(),
 					Flags:     xdr.Uint32(xdr.TrustLineFlagsAuthorizedFlag),
 				},
 			},


### PR DESCRIPTION
**WHAT**
updates the go-sdk dependency to the[ updated branch](https://github.com/stellar/go/tree/cap21and40) we have on the stellar/go repo now

**WHY**
updating the go-sdk with the protocol 18 changes, and updating our sdk since it depends on it