### PR TITLE
examples/console: add a delay during account creation

### DIFF
--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -195,6 +195,8 @@ func run() error {
 
 		escrowAccountKeyFull := keypair.MustRandom()
 		escrowAccountKey = escrowAccountKeyFull.FromAddress()
+		fmt.Fprintln(os.Stdout, "waiting before creating escrow")
+		time.Sleep(5 * time.Second)
 		fmt.Fprintln(os.Stdout, "escrow account:", escrowAccountKey.Address())
 
 		config := agentpkg.Config{
@@ -241,6 +243,7 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("submitting tx to create escrow account: %w", err)
 		}
+		fmt.Fprintln(os.Stdout, "escrow created")
 	} else {
 		escrowAccountKey = file.EscrowAccountKey
 		config := agentpkg.Config{


### PR DESCRIPTION
### What
Introduce a delay when creating accounts during the console setup.

### Why
There's a bug somewhere in our fork relating to sequence number checks, and when the account is executed too quickly after the account is created the transaction response isn't being captured properly. I've spent a while digging into it and have ideas, but we need a hold over until we can fix this properly. 